### PR TITLE
Fix availability for Image extension

### DIFF
--- a/Sources/SFSafeSymbols/ImageExtension.swift
+++ b/Sources/SFSafeSymbols/ImageExtension.swift
@@ -2,12 +2,11 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Image {
     /// Creates a instance of `Image` with a system symbol image of the given type.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
-    @available(iOS 13.0, *)
     init(systemSymbol: SFSymbol) {
         self.init(systemName: systemSymbol.rawValue)
     }


### PR DESCRIPTION
This also include OSX, tvOS, watchOS in available targets for the SwiftUI Image extension. Closer matches how Apple themselves gate SwiftUI.