### PR TITLE
Remove support for macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SFSafeSymbols",
-    platforms: [.iOS(.v9), .macOS(.v10_10), .tvOS(.v9), .watchOS(.v2)],
+    platforms: [.iOS(.v9), .tvOS(.v9), .watchOS(.v2)],
     products: [
         .library(name: "SFSafeSymbols", type: .static, targets: ["SFSafeSymbols"])
     ],

--- a/Sources/SFSafeSymbols/ImageExtension.swift
+++ b/Sources/SFSafeSymbols/ImageExtension.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+@available(OSX, unavailable)
 public extension Image {
+    
     /// Creates a instance of `Image` with a system symbol image of the given type.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    
+    #if os(watchOS) || os(iOS) || os(tvOS)
     init(systemSymbol: SFSymbol) {
         self.init(systemName: systemSymbol.rawValue)
     }
+    #endif
 }

--- a/Sources/SFSafeSymbols/SFSymbolExtension.swift
+++ b/Sources/SFSafeSymbols/SFSymbolExtension.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import UIKit
 
 @available(iOS 13.0, *)
@@ -25,3 +26,4 @@ public extension SFSymbol {
         UIImage(systemSymbol: self, compatibleWith: traitCollection)
     }
 }
+#endif

--- a/Sources/SFSafeSymbols/UIImageExtension.swift
+++ b/Sources/SFSafeSymbols/UIImageExtension.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import UIKit
 
 @available(iOS 13.0, *)
@@ -25,3 +26,4 @@ public extension UIImage {
         self.init(systemName: systemSymbol.rawValue, compatibleWith: traitCollection)!
     }
 }
+#endif


### PR DESCRIPTION
As soon the initializer `Image(systemName:)` doesn't have support to macOS yet, in my point of view, doesn't make sense to support the platform yet.

Checking SwiftUI headers, specifically for the init method mentioned above, macOS/OSX is currently unavailable, for this reason I'm creating this pull request.

Here the snippet of code extracted from SwiftUI headers:
```swift
@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
@available(OSX, unavailable)
extension Image {

    @available(OSX, unavailable)
    public init(systemName: String)
}
```