### PR TITLE
Fix macOS compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
-- None
+- macOS compilation—I know, but still (By [Chris Zielinski](https://github.com/chriszielinski))
 
 
 
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
-- Update to symbols that are actually available in the final iOS 13, tVOS 13 and watchOS 6 releases (By [Frederick Pietschmann](github.com/fredpi))
+- Update to symbols that are actually available in the final iOS 13, tvOS 13 and watchOS 6 releases (By [Frederick Pietschmann](github.com/fredpi))
 
 ### Fixed
 

--- a/Sources/SFSafeSymbols/Enum/SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Enum/SFSymbol.swift
@@ -2,7 +2,7 @@
 // Note: Cases that are commented out are symbols defined in the SFSymbols app
 // that nonetheless aren't available on-device (Apple bug)
 
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum SFSymbol: String, CaseIterable {
     case _00Circle = "00.circle"
     case _00CircleFill = "00.circle.fill"

--- a/Sources/SFSafeSymbols/Initializers/SwiftUIImageExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUIImageExtension.swift
@@ -2,12 +2,13 @@
 
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension SwiftUI.Image {
     
     /// Creates a instance of `Image` with a system symbol image of the given type.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    @available(macOS, unavailable)
     init(systemSymbol: SFSymbol) {
         self.init(systemName: systemSymbol.rawValue)
     }

--- a/Tests/SFSafeSymbolsTests/ImageExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/ImageExtensionTests.swift
@@ -1,6 +1,6 @@
 @testable import SFSafeSymbols
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 
 import XCTest
 

--- a/Tests/SFSafeSymbolsTests/UIImageExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/UIImageExtensionTests.swift
@@ -1,6 +1,6 @@
 @testable import SFSafeSymbols
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 
 import XCTest
 


### PR DESCRIPTION
At the moment, Carthage fails when it attempts to build for the macOS platform. Since macOS is explicitly a supported platform (build settings), I added the appropriate attributes where necessary.