### PR TITLE
Add support for UIApplicationShortcutIcon

### DIFF
--- a/Sources/SFSafeSymbols/Initializers/UIApplicationShortcutIconExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/UIApplicationShortcutIconExtension.swift
@@ -1,0 +1,16 @@
+#if canImport(UIKit) && (os(iOS) || targetEnvironment(macCatalyst))
+
+import UIKit
+
+@available(iOS 13.0, *)
+public extension UIApplicationShortcutIcon {
+
+    /// Create an icon using a system symbol image of the given type.
+    ///
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    convenience init(systemSymbol: SFSymbol) {
+        self.init(systemImageName: systemSymbol.rawValue)
+    }
+}
+
+#endif

--- a/Tests/SFSafeSymbolsTests/UIApplicationShortcutIconExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/UIApplicationShortcutIconExtensionTests.swift
@@ -1,0 +1,21 @@
+@testable import SFSafeSymbols
+
+#if os(iOS) || targetEnvironment(macCatalyst)
+
+import XCTest
+
+final class UIApplicationShortcutIconExtensionTests: XCTestCase {
+    func testSimpleInit() {
+        if #available(iOS 13.0, *) {
+            SFSymbol.allCases.forEach { symbol in
+                // If this doesn't crash, everything works fine
+                print("Testing existence of \(symbol.rawValue) via UIApplicationShortcutIcon init")
+                _ = UIApplicationShortcutIcon(systemSymbol: symbol)
+            }
+        } else {
+            XCTFail("iOS 13 is required to test SFSafeSymbols.")
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Hi, thanks for SFSafeSymbols!

I've noticed that it's possible to use SF Symbols for dynamic home screen quick action icons (passing them as Strings to `UIApplicationShortcutIcon`, similar to `UIImage` etc), so thought it'd be useful for SFSafeSymbols to have an initialiser extension for `UIApplicationShortcutIcon`.

Cloned the project with Xcode 11.3 and added the initialiser & a unit test.

For some reason, Xcode silently reformatted `project.pbxproj` with different formatting when I opened the project. This doesn’t seem to have caused any issues, but I'm open to any suggestions if this is undesired.

— Seb