### PR TITLE
Add UIButton initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
-- None.
+- Add an UIButton extension with `systemButton(with:, target:, action:)`  initializer and `setImage(with:, for:)`   (By [Antonino Musolino](https://github.com/posix88))
 
 ### Changed
 

--- a/SFSafeSymbols.xcodeproj/project.pbxproj
+++ b/SFSafeSymbols.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		4C86407F242925E40061EEAD /* UIButtonExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C86407E242925E40061EEAD /* UIButtonExtension.swift */; };
+		4C864081242928CF0061EEAD /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C864080242928CF0061EEAD /* UIButtonExtensionTests.swift */; };
 		OBJ_39 /* SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* SFSymbol.swift */; };
 		OBJ_40 /* SwiftUIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* SwiftUIImageExtension.swift */; };
 		OBJ_41 /* UIApplicationShortcutIconExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* UIApplicationShortcutIconExtension.swift */; };
@@ -50,6 +52,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4C86407E242925E40061EEAD /* UIButtonExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtension.swift; sourceTree = "<group>"; };
+		4C864080242928CF0061EEAD /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		OBJ_12 /* SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbol.swift; sourceTree = "<group>"; };
 		OBJ_14 /* SwiftUIImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIImageExtension.swift; sourceTree = "<group>"; };
 		OBJ_15 /* UIApplicationShortcutIconExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationShortcutIconExtension.swift; sourceTree = "<group>"; };
@@ -115,6 +119,7 @@
 				OBJ_14 /* SwiftUIImageExtension.swift */,
 				OBJ_15 /* UIApplicationShortcutIconExtension.swift */,
 				OBJ_16 /* UIImageExtension.swift */,
+				4C86407E242925E40061EEAD /* UIButtonExtension.swift */,
 			);
 			path = Initializers;
 			sourceTree = "<group>";
@@ -133,6 +138,7 @@
 				OBJ_19 /* ImageExtensionTests.swift */,
 				OBJ_20 /* UIApplicationShortcutIconExtensionTests.swift */,
 				OBJ_21 /* UIImageExtensionTests.swift */,
+				4C864080242928CF0061EEAD /* UIButtonExtensionTests.swift */,
 			);
 			name = SFSafeSymbolsTests;
 			path = Tests/SFSafeSymbolsTests;
@@ -147,7 +153,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -165,7 +171,6 @@
 				OBJ_32 /* CONTRIBUTING.md */,
 				OBJ_33 /* SFSafeSymbols.podspec */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Configs */ = {
@@ -250,7 +255,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_22 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -272,6 +277,7 @@
 				OBJ_40 /* SwiftUIImageExtension.swift in Sources */,
 				OBJ_41 /* UIApplicationShortcutIconExtension.swift in Sources */,
 				OBJ_42 /* UIImageExtension.swift in Sources */,
+				4C86407F242925E40061EEAD /* UIButtonExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -288,6 +294,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_60 /* ImageExtensionTests.swift in Sources */,
+				4C864081242928CF0061EEAD /* UIButtonExtensionTests.swift in Sources */,
 				OBJ_61 /* UIApplicationShortcutIconExtensionTests.swift in Sources */,
 				OBJ_62 /* UIImageExtensionTests.swift in Sources */,
 			);

--- a/Sources/SFSafeSymbols/Initializers/UIButtonExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/UIButtonExtension.swift
@@ -1,8 +1,8 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && (os(iOS) || targetEnvironment(macCatalyst))
 
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13.0, *)
 public extension UIButton {
     
     class func systemButton(with symbol: SFSymbol, target: Any?, action: Selector?) -> Self {

--- a/Sources/SFSafeSymbols/Initializers/UIButtonExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/UIButtonExtension.swift
@@ -1,0 +1,19 @@
+#if canImport(UIKit)
+
+import UIKit
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension UIButton {
+    
+    class func systemButton(with symbol: SFSymbol, target: Any?, action: Selector?) -> Self {
+        let symbol = UIImage(systemSymbol: symbol)
+        return self.systemButton(with: symbol, target: target, action: action)
+    }
+    
+    func setImage(with symbol: SFSymbol, for state: UIControl.State) {
+        let symbol = UIImage(systemSymbol: symbol)
+        self.setImage(symbol, for: state)
+    }
+    
+}
+#endif

--- a/Tests/SFSafeSymbolsTests/UIButtonExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/UIButtonExtensionTests.swift
@@ -1,12 +1,13 @@
 @testable import SFSafeSymbols
 
-#if !os(watchOS) && !os(macOS)
+#if os(iOS) || targetEnvironment(macCatalyst)
+
 import XCTest
 
 class UIButtonExtensionTests: XCTestCase {
 
     func testButtonInit() {
-        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+        if #available(iOS 13.0, *) {
             SFSymbol.allCases.forEach { symbol in
                 print("Testing UIButton init with \(symbol.rawValue)")
                 let button = UIButton.systemButton(with: symbol, target: nil, action: nil)
@@ -18,7 +19,7 @@ class UIButtonExtensionTests: XCTestCase {
     }
     
     func testSetImage() {
-        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+        if #available(iOS 13.0, *) {
             SFSymbol.allCases.forEach { symbol in
                 print("Testing UIButton setImage with \(symbol.rawValue)")
                 let button = UIButton()

--- a/Tests/SFSafeSymbolsTests/UIButtonExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/UIButtonExtensionTests.swift
@@ -1,0 +1,35 @@
+@testable import SFSafeSymbols
+
+#if !os(watchOS) && !os(macOS)
+import XCTest
+
+class UIButtonExtensionTests: XCTestCase {
+
+    func testButtonInit() {
+        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            SFSymbol.allCases.forEach { symbol in
+                print("Testing UIButton init with \(symbol.rawValue)")
+                let button = UIButton.systemButton(with: symbol, target: nil, action: nil)
+                XCTAssertEqual(button.currentImage, UIImage(systemSymbol: symbol))
+            }
+        } else {
+            XCTFail("iOS 13 or tvOS 13 is required to test  SFSafeSymbols.")
+        }
+    }
+    
+    func testSetImage() {
+        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            SFSymbol.allCases.forEach { symbol in
+                print("Testing UIButton setImage with \(symbol.rawValue)")
+                let button = UIButton()
+                let symbolImage = UIImage(systemSymbol: symbol)
+                button.setImage(symbolImage, for: .normal)
+                XCTAssertEqual(button.image(for: .normal), symbolImage)
+            }
+        } else {
+            XCTFail("iOS 13 or tvOS 13 is required to test  SFSafeSymbols.")
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Hello and thanks for this project.
I've found the open issue #14  about adding some missing convenience methods for `UIButton`.

I've added the following two methods :
`func systemButton(with symbol: SFSymbol, target: Any?, action: Selector?) -> Self`
`func setImage(with symbol: SFSymbol, for state: UIControl.State)`

that leverage on the `UIImage` extension and `UIButton` native methods.

I've also inserted some tests for the new behaviors.

Greetings