### PR TITLE
Add support for SwiftUI's new Label initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
-- None
+- Add two SwiftUI `Label` initializers (By [Seb Jachec](https://github.com/sebj))
 
 ### Changed
 
-- None
+- Add macOS support for SwiftUI `Image` initializer (By [Seb Jachec](https://github.com/sebj))
 
 ### Fixed
 

--- a/Sources/SFSafeSymbols/Initializers/SwiftUIImageExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUIImageExtension.swift
@@ -2,13 +2,12 @@
 
 import SwiftUI
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13.0, macOS 10.16, tvOS 13.0, watchOS 6.0, *)
 public extension SwiftUI.Image {
     
     /// Creates a instance of `Image` with a system symbol image of the given type.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
-    @available(macOS, unavailable)
     init(systemSymbol: SFSymbol) {
         self.init(systemName: systemSymbol.rawValue)
     }

--- a/Sources/SFSafeSymbols/Initializers/SwiftUILabelExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUILabelExtension.swift
@@ -1,0 +1,25 @@
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+@available(iOS 14.0, OSX 10.16, tvOS 14.0, watchOS 7.0, *)
+public extension Label where Title == Text, Icon == Image {
+    
+    /// Creates a label with a system symbol image and a title generated from a
+    /// localized string.
+    ///
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol) {
+        self.init(titleKey, systemImage: systemSymbol.rawValue)
+    }
+    
+    /// Creates a label with a system symbol image and a title generated from a
+    /// string.
+    ///
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    init<S>(_ title: S, systemSymbol: SFSymbol) where S : StringProtocol {
+        self.init(title, systemImage: systemSymbol.rawValue)
+    }
+}
+
+#endif

--- a/Tests/SFSafeSymbolsTests/LabelExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/LabelExtensionTests.swift
@@ -8,16 +8,16 @@ import XCTest
 
 import SwiftUI
 
-class ImageExtensionTests: XCTestCase {
+class LabelExtensionTests: XCTestCase {
     func testInit() {
-        if #available(iOS 13.0, macOS 10.16, tvOS 13.0, watchOS 6.0, *) {
+        if #available(iOS 14.0, OSX 10.16, tvOS 14.0, watchOS 7.0, *) {
             SFSymbol.allCases.forEach { symbol in
                 // If this doesn't crash, everything works fine
                 print("Testing existence of \(symbol.rawValue) via Image init")
-                _ = Image(systemSymbol: symbol)
+                _ = Label("Title", systemSymbol: symbol)
             }
         } else {
-            XCTFail("iOS 13, macOS 10.16, or tvOS 13 is required to test SFSafeSymbols.")
+            XCTFail("iOS 14, macOS 10.16 or tvOS 14 is required to test SFSafeSymbols.")
         }
     }
 }


### PR DESCRIPTION
Added support for two new `Label` initializers that can take a system symbol image, supported on iOS 14 / watchOS 7 / macOS 10.16 (11) & tvOS 14.

Also tweaked the previous SwiftUI `Image` extension, as that initializer is now available on the upcoming macOS.

— Seb