### PR TITLE
fix: Make eyedropper.halffull use correct symbol

### DIFF
--- a/Sources/SFSafeSymbols/Enum/SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Enum/SFSymbol.swift
@@ -2373,7 +2373,7 @@ public enum SFSymbol: String, CaseIterable {
     /// 􀎙
     case eyedropperFull = "eyedropper.full"
 
-    /// 􀎙
+    /// 􀎘
     case eyedropperHalffull = "eyedropper.halffull"
 
     /// 􀖆


### PR DESCRIPTION
`eyedropper.halffull` was using `eyedropper.full` symbol for its documentation

(GitHub does not render it, but if you copy from the SFSymbols app and use safari search it detects the symbol)