### PR TITLE
Mark UIImage extension initializers as available for watchOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
-- None
+- Mark UIImage extension initializers as available for watchOS (By [Tomas Franzén](https://github.com/tomasf))
 
 ## [2.1.1] - 2020-12-13
 

--- a/Sources/SFSafeSymbols/Initializers/UIKit/UIImageExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/UIKit/UIImageExtension.swift
@@ -8,8 +8,7 @@ public extension UIImage {
     /// Retrieve a system symbol image of the given type.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
-    @available(iOS 13.0, tvOS 13.0, *)
-    @available(watchOS, unavailable)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     convenience init(systemSymbol: SFSymbol) {
         self.init(systemName: systemSymbol.rawValue)!
     }
@@ -18,8 +17,7 @@ public extension UIImage {
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
     /// - Parameter configuration: The `UIImage.Configuration` applied to this system image.
-    @available(iOS 13.0, tvOS 13.0, *)
-    @available(watchOS, unavailable)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     convenience init(systemSymbol: SFSymbol, withConfiguration configuration: UIImage.Configuration?) {
         self.init(systemName: systemSymbol.rawValue, withConfiguration: configuration)!
     }


### PR DESCRIPTION
The UIImage initializers in UIImageExtension.swift were marked as unavailable for watchOS, but the underlying `UIImage(systemName:[...])` initializers do exist and work on watchOS.