### PR TITLE
Cleanup after repo transfer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
-Bug reports and suggestions for improvements are welcome! For this, please [raise an issue on GitHub](https://github.com/piknotech/SFSafeSymbols/issues). [Pull requests](https://github.com/piknotech/SFSafeSymbols/pulls) are also very much welcome. However, for non-trivial changes, please make sure to raise an issue before opening up a PR that addresses the issue.
+Bug reports and suggestions for improvements are welcome! For this, please [raise an issue on GitHub](https://github.com/SFSafeSymbols/SFSafeSymbols/issues). [Pull requests](https://github.com/SFSafeSymbols/SFSafeSymbols/pulls) are also very much welcome. However, for non-trivial changes, please make sure to raise an issue before opening up a PR that addresses the issue.
 
 ## Core Contributors
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Piknotech
+Copyright (c) 2021 SFSafeSymbols
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-    <a href="#idea-&-features">Idea & Features</a>
+    <a href="#idea--features">Idea & Features</a>
   • <a href="#supported-versions">Supported Versions</a>
   • <a href="#installation">Installation</a>
   • <a href="#usage">Usage</a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/piknotech/SFSafeSymbols/stable/Logo.png" width=600>
+    <img src="https://raw.githubusercontent.com/SFSafeSymbols/SFSafeSymbols/stable/Logo.png" width=600>
 </p>
 
 <p align="center">
@@ -9,7 +9,7 @@
     <a href="#">
         <img src="https://img.shields.io/badge/swift-5-FFAC45.svg" alt="Swift: 5">
     </a>
-    <a href="https://github.com/piknotech/SFSafeSymbols/releases">
+    <a href="https://github.com/SFSafeSymbols/SFSafeSymbols/releases">
     <img src="https://img.shields.io/badge/version-2.1.3-blue.svg"
     alt="Version: 2.1.3">
     </a>
@@ -17,7 +17,7 @@
     <img src="https://img.shields.io/badge/Platforms-iOS%20|%20tvOS%20|%20watchOS%20|%20macOS-FF69B4.svg"
         alt="Platforms: iOS – tvOS – watchOS – macOS">
     </a>
-    <a href="https://github.com/piknotech/SFSafeSymbols/blob/stable/LICENSE.md">
+    <a href="https://github.com/SFSafeSymbols/SFSafeSymbols/blob/stable/LICENSE.md">
         <img src="https://img.shields.io/badge/license-MIT-lightgrey.svg" alt="License: MIT">
     </a>
     <br />
@@ -33,55 +33,62 @@
 </p>
 
 <p align="center">
-    <a href="#supported-versions">Supported Versions</a>
-  • <a href="#motivation">Motivation</a>
+    <a href="#idea-&-features">Idea & Features</a>
+  • <a href="#supported-versions">Supported Versions</a>
   • <a href="#installation">Installation</a>
   • <a href="#usage">Usage</a>
   • <a href="#contributing">Contributing</a>
   • <a href="#license">License</a>
-  • <a href="https://github.com/piknotech/SFSafeSymbols/issues">Issues</a>
-  • <a href="https://github.com/piknotech/SFSafeSymbols/pulls">Pull Requests</a>
+  • <a href="https://github.com/SFSafeSymbols/SFSafeSymbols/issues">Issues</a>
+  • <a href="https://github.com/SFSafeSymbols/SFSafeSymbols/pulls">Pull Requests</a>
 </p>
 
-## Supported Versions
+## Idea & Features
 
-`SFSafeSymbols` supports multiple SF Symbols versions at the same time by utilizing the `@availability` flag. The following versions are currently supported:
-
-- SF Symbols 1.0 (iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0)
-- SF Symbols 2.0 (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-- SF Symbols 2.1 (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
-- SF Symbols 2.2 (iOS 14.5, macOS 11.3, tvOS 14.5, watchOS 7.4)
-- SF Symbols 3.0 (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-- SF Symbols 3.1 (iOS 15.1, macOS 12.0, tvOS 15.1, watchOS 8.1)
-
-## Motivation
-
-At WWDC 2019, Apple announced a new library of icons that came included with that year's new operating system versions. To browse them, there's a [dedicated Mac app](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/) called SF Symbols. However, developers still have to copy the name of an icon and reference it unsafely, resulting in code like this:
+At WWDC 2019, Apple announced a new library of icons that came included with that year's new operating system versions. To browse them, there's a [dedicated Mac app](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/) called SF Symbols. However, developers still have to copy the name of a symbol and reference it unsafely, resulting in code like this:
 
 ```swift
 UIImage(systemName: "circle.fill")
 ```
 
-It didn't take long until [first ideas came up](https://twitter.com/simjp/status/1135642837322588161?s=12) to make these icons accessible in a safe way using a framework. And this is just what `SFSafeSymbols` does!
+It didn't take long until [first ideas came up](https://twitter.com/simjp/status/1135642837322588161?s=12) to make these icons **accessible in a safe way** using a framework. And this is just the basic idea behind `SFSafeSymbols`!
 
-Additionally, every symbol is documented in code so that lookups in the SF Symbols app (e. g. about available layersets, available localizations & the look of the symbol) are no longer needed.
+Furthermore, with `SFSafeSymbols`...
+
+- ... you can be sure your symbol code won't crash due to typos or symbol availability issues. This is because **all symbols are tested via a CI** (on the latest iOS & tvOS versions and also some earlier OS versions).
+- ... lookups in the SF Symbols app (e. g. about available **layersets**, available **localizations** & the **look of the symbol**) are no longer needed because every symbol is **documented in code**.
+- ... **multiple SF Symbols versions** are supported at the same time (via utilization of the `@availability` flag). Each symbol is only made available on those platform versions where Apple says it's available.
+- ... **renamed symbols can be detected easily** (via a deprecation notice which suggests the use of the new name at the same time).
+
+## Supported Versions
+
+The following SF Symbols versions are currently supported:
+
+| SF Symbols Version | iOS Version | macOS Version | tvOS Version | watchOS Version |
+| ------------------ | ----------- | ------------- | ------------ | --------------- |
+| 1.0 | 13.0 | 10.15 | 13.0 | 6.0 |
+| 2.0 | 14.0 | 11.0 | 14.0 | 7.0 |
+| 2.1 | 14.2 | 11.0 | 14.2 | 7.1 |
+| 2.2 | 14.5 | 11.3 | 14.5 | 7.4 |
+| 3.0 | 15.0 | 12.0 | 15.0 | 8.0 |
+| 3.1 | 15.1 | 12.0 | 15.1 | 8.1 |
 
 ## Installation
 
 `SFSafeSymbols` can be installed via the **Swift Package Manager (recommended)**, Carthage or CocoaPods.
 
-Supported platforms are `iOS (11.0+)`, `tvOS (11.0+)`,  `watchOS (6.0+)` and `macOS (10.13+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `tvOS 13.0`, `watchOS 6.0` and `macOS 11.0`.
+Supported platforms are `iOS (11.0+)`, `macOS (10.13+)`, `tvOS (11.0+)` and `watchOS (6.0+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `macOS 11.0`, `tvOS 13.0` and `watchOS 6.0`.
 
 ### Swift Package Manager (Xcode-integrated)
 
-To integrate SFSafeSymbols using the Xcode-built-in SPM, choose `File` → `Swift Packages` → `Add Package Dependency`. Enter the following url: `https://github.com/piknotech/SFSafeSymbols` and click `Next`. When asked about the version, leave the preselection and click `Next`. In the following step, select `SFSafeSymbols` as the package product and click `Finish` unless you really want to use `SFSafeSymbols-Dynamic` and know what you are doing.
+To integrate SFSafeSymbols using the Xcode-built-in SPM, choose `File` → `Swift Packages` → `Add Package Dependency`. Enter the following url: `https://github.com/SFSafeSymbols/SFSafeSymbols` and click `Next`. When asked about the version, leave the preselection and click `Next`. In the following step, select `SFSafeSymbols` as the package product and click `Finish` unless you really want to use `SFSafeSymbols-Dynamic` and know what you are doing.
 
 ### Swift Package Manager (standalone)
 
 To integrate using the standalone version of Apple's Swift Package Manager, add the following as a dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/piknotech/SFSafeSymbols.git", .upToNextMajor(from: "2.1.3"))
+.package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "2.1.3"))
 ```
 
 After specifying `"SFSafeSymbols"` as a dependency of the target in which you want to use it, run `swift package update`.
@@ -91,7 +98,7 @@ After specifying `"SFSafeSymbols"` as a dependency of the target in which you wa
 Add the following entry to your Cartfile:
 
 ```
-github "piknotech/SFSafeSymbols" ~> 2.1.3
+github "SFSafeSymbols/SFSafeSymbols" ~> 2.1.3
 ```
 
 Then run `carthage update`.
@@ -108,7 +115,7 @@ Then run `pod install`.
 
 ## Usage
 
-All the system icons are accessible via the `SFSymbol` type. They are named similar to Apple's names, but use a lower camel case style and prefix names with leading numbers with a `_` character:
+All the system symbols are accessible via the `SFSymbol` type. They are named similar to Apple's names, but use a lower camel case style and prefix names with leading numbers with a `_` character:
 
 ```
 c.circle        ~> SFSymbol.cCircle
@@ -159,14 +166,10 @@ NSImage(systemSymbol: .cCircle)
 NSImage(systemSymbol: SFSymbol.eCircleFill, accessibilityDescription: "some.description")
 ```
 
-## Testing
-
-**All symbols are tested via a CI** (on the latest iOS & tvOS versions), so you can be sure your code won't crash because an image couldn't be found!
-
 ## Contributing
 
-Contributions are very much welcome! See [CONTRIBUTING.md](https://github.com/piknotech/SFSafeSymbols/blob/stable/CONTRIBUTING.md) for more information.
+Contributions are very much welcome! See [CONTRIBUTING.md](https://github.com/SFSafeSymbols/SFSafeSymbols/blob/stable/CONTRIBUTING.md) for more information.
 
 ## License
 
-This library is released under the [MIT License](http://opensource.org/licenses/MIT). See [LICENSE](https://github.com/piknotech/SFSafeSymbols/blob/stable/LICENSE) for details.
+This library is released under the [MIT License](http://opensource.org/licenses/MIT). See [LICENSE](https://github.com/SFSafeSymbols/SFSafeSymbols/blob/stable/LICENSE) for details.

--- a/SFSafeSymbols.podspec
+++ b/SFSafeSymbols.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
   spec.version = '2.1.3'
   spec.summary = "Safely access Apple's SF Symbols using static typing"
 
-  spec.homepage = 'https://github.com/piknotech/SFSafeSymbols'
+  spec.homepage = 'https://github.com/SFSafeSymbols/SFSafeSymbols'
   spec.license = { :type => 'MIT', :file => 'LICENSE' }
 
   spec.author = { 'Frederick Pietschmann' => 'cocoapods@fredpi.de' }
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = '5.3'
 
-  spec.source = { :git => "https://github.com/piknotech/SFSafeSymbols.git", :tag => "#{spec.version}" }
+  spec.source = { :git => "https://github.com/SFSafeSymbols/SFSafeSymbols.git", :tag => "#{spec.version}" }
   spec.source_files = 'Sources/**/*'
 
   spec.weak_framework = 'SwiftUI'

--- a/SFSafeSymbols.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/SFSafeSymbols.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol.swift
@@ -1,9 +1,3 @@
-//
-//  SFSymbol.swift
-//  SFSafeSymbols
-//
-//  Created by Steven on 4/23/21.
-//
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct SFSymbol: RawRepresentable, Equatable, Hashable {

--- a/Tests/SFSafeSymbolsTests/Core/CodableTests.swift
+++ b/Tests/SFSafeSymbolsTests/Core/CodableTests.swift
@@ -1,9 +1,3 @@
-//
-//  CodableTests.swift
-//  SFSafeSymbols
-//
-//  Created by Steven on 4/27/21.
-//
 
 @testable import SFSafeSymbols
 import XCTest
@@ -33,4 +27,4 @@ class CodableTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-extension SFSymbol: Codable {}
+extension SFSymbol: Codable { }


### PR DESCRIPTION
In this (again: hopefully v3-final) PR, the README is cleaned up and restructured a bit and old links pointing to the previous hosting organization (piknotech/SFSafeSymbols) are replaced with the new ones (SFSafeSymbols/SFSafeSymbols). Also, a shared file header format is enforced.