### PR TITLE
Improve package specs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,12 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
     name: "SFSafeSymbols",
-    platforms: [.iOS(.v11), .tvOS(.v11), .watchOS(.v6), .macOS(.v10_13)],
+    platforms: [.iOS(.v10), .tvOS(.v10), .watchOS(.v3), .macOS(.v10_12)],
     products: [
-        .library(name: "SFSafeSymbols", type: .static, targets: ["SFSafeSymbols"]),
-        .library(name: "SFSafeSymbols-Dynamic", type: .dynamic, targets: ["SFSafeSymbols"])
+        .library(name: "SFSafeSymbols", targets: ["SFSafeSymbols"]),
     ],
     dependencies: [],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SFSafeSymbols",
-    platforms: [.iOS(.v10), .tvOS(.v10), .watchOS(.v3), .macOS(.v10_12)],
+    platforms: [.iOS(.v11), .tvOS(.v11), .watchOS(.v4), .macOS(.v10_13)],
     products: [
         .library(name: "SFSafeSymbols", targets: ["SFSafeSymbols"]),
     ],

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following SF Symbols versions are currently supported:
 
 `SFSafeSymbols` can be installed via the **Swift Package Manager (recommended)**, Carthage or CocoaPods.
 
-Supported platforms are `iOS (10.0+)`, `macOS (10.12+)`, `tvOS (10.0+)` and `watchOS (3.0+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `macOS 11.0`, `tvOS 13.0` and `watchOS 6.0`.
+Supported platforms are `iOS (11.0+)`, `macOS (10.13+)`, `tvOS (11.0+)` and `watchOS (4.0+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `macOS 11.0`, `tvOS 13.0` and `watchOS 6.0`.
 
 ### Swift Package Manager (Xcode-integrated)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following SF Symbols versions are currently supported:
 
 `SFSafeSymbols` can be installed via the **Swift Package Manager (recommended)**, Carthage or CocoaPods.
 
-Supported platforms are `iOS (11.0+)`, `macOS (10.13+)`, `tvOS (11.0+)` and `watchOS (6.0+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `macOS 11.0`, `tvOS 13.0` and `watchOS 6.0`.
+Supported platforms are `iOS (10.0+)`, `macOS (10.12+)`, `tvOS (10.0+)` and `watchOS (3.0+)`, although the actual functionality is of course only accessible starting with `iOS 13.0`, `macOS 11.0`, `tvOS 13.0` and `watchOS 6.0`.
 
 ### Swift Package Manager (Xcode-integrated)
 

--- a/SFSafeSymbols.podspec
+++ b/SFSafeSymbols.podspec
@@ -8,15 +8,13 @@ Pod::Spec.new do |spec|
 
   spec.author = { 'Frederick Pietschmann' => 'cocoapods@fredpi.de' }
   spec.social_media_url = 'https://twitter.com/piknotech'
-
-  spec.static_framework = true
   
-  spec.ios.deployment_target = '11.0'
-  spec.tvos.deployment_target = '11.0'
-  spec.watchos.deployment_target = '6.0'
-  spec.macos.deployment_target = '10.13'
+  spec.ios.deployment_target = '10.0'
+  spec.tvos.deployment_target = '10.0'
+  spec.watchos.deployment_target = '3.0'
+  spec.macos.deployment_target = '10.12'
 
-  spec.swift_version = '5.3'
+  spec.swift_versions = ['5.3', '5.4', '5.5']
 
   spec.source = { :git => "https://github.com/SFSafeSymbols/SFSafeSymbols.git", :tag => "#{spec.version}" }
   spec.source_files = 'Sources/**/*'

--- a/SFSafeSymbols.podspec
+++ b/SFSafeSymbols.podspec
@@ -9,10 +9,10 @@ Pod::Spec.new do |spec|
   spec.author = { 'Frederick Pietschmann' => 'cocoapods@fredpi.de' }
   spec.social_media_url = 'https://twitter.com/piknotech'
   
-  spec.ios.deployment_target = '10.0'
-  spec.tvos.deployment_target = '10.0'
-  spec.watchos.deployment_target = '3.0'
-  spec.macos.deployment_target = '10.12'
+  spec.ios.deployment_target = '11.0'
+  spec.tvos.deployment_target = '11.0'
+  spec.watchos.deployment_target = '4.0'
+  spec.macos.deployment_target = '10.13'
 
   spec.swift_versions = ['5.3', '5.4', '5.5']
 


### PR DESCRIPTION
This PR improves the package specs (`Package.swift` and `SFSafeSymbols.podspec`):

* General: Lower the library requirements to 2016 platforms (iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0).
* `Package.swift`: Raise the minimum Swift version to `5.3` to match `SFSafeSymbols.podspec`.
* `Package.swift`: Remove the library type (static/dynamic) which lets SPM picks it automatically ([recommended by Apple](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#product)). Tested successfully on the repo provided in #61.
* `SFSafeSymbols.podspec`: Add support for swift `5.4` and `5.5`.
* `SFSafeSymbols.podspec`: Remove `static_framework = true`. Fixes #78.