### PR TITLE
Allow optional symbol for SwiftUI's `Label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
-- None
+- Changed SwiftUI's `Label` initializer to take an optional `SFSymbol` (By [Steven Sorial](https://github.com/StevenSorial))
 
 ### Fixed
 

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUILabelExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUILabelExtension.swift
@@ -9,8 +9,8 @@ public extension Label where Title == Text, Icon == Image {
     /// localized string.
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
-    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol) {
-        self.init(titleKey, systemImage: systemSymbol.rawValue)
+    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?) {
+        self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "")
     }
     
     /// Creates a label with a system symbol image and a title generated from a
@@ -18,8 +18,8 @@ public extension Label where Title == Text, Icon == Image {
     ///
     /// - Parameter systemSymbol: The `SFSymbol` describing this image.
     @_disfavoredOverload
-    init<S>(_ title: S, systemSymbol: SFSymbol) where S : StringProtocol {
-        self.init(title, systemImage: systemSymbol.rawValue)
+    init<S>(_ title: S, systemSymbol: SFSymbol?) where S : StringProtocol {
+        self.init(title, systemImage: systemSymbol?.rawValue ?? "")
     }
 }
 

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUILabelExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUILabelExtension.swift
@@ -8,7 +8,7 @@ public extension Label where Title == Text, Icon == Image {
     /// Creates a label with a system symbol image and a title generated from a
     /// localized string.
     ///
-    /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
     init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?) {
         self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "")
     }
@@ -16,7 +16,7 @@ public extension Label where Title == Text, Icon == Image {
     /// Creates a label with a system symbol image and a title generated from a
     /// string.
     ///
-    /// - Parameter systemSymbol: The `SFSymbol` describing this image.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
     @_disfavoredOverload
     init<S>(_ title: S, systemSymbol: SFSymbol?) where S : StringProtocol {
         self.init(title, systemImage: systemSymbol?.rawValue ?? "")


### PR DESCRIPTION
When using SwiftUI, i find myself writing `Label("My Label", systemImage: showImage ? "plus" : "")`, which doesn't translate well when using `SFSafeSymbols`.
Option 1:
```
If showImage {
	Label("My Label", systemSymbol: .plus)
} else {
	Text("My Label")
}
```

Options 2:
```
Label("My Label", systemSymbol: showImage ? .plus : .init(rawValue: ""))
```

Option 3:
```
Label("My Label", systemSymbol: .plus)
	.labelStyle(showImage ? .titleAndIcon : .titleOnly)
```
I think option 1 is too verbose, option 2 requires the user to understand how the SFSymbol initializers work, option 3 I think Is the most acceptable but I think it's a little weird to always assign an image.

This PR makes the symbol optional to be:

```
Label("My Label", systemSymbol: showImage ? .plus : nil)
```
