### PR TITLE
Swiftlint regex fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ custom_rules:
   sf_safe_symbol:
     name: "Safe SFSymbol"
     message: "Use `SFSafeSymbols` via `systemSymbol` parameters for type safety."
-    regex: "(Image\\(systemName:)|(NSImage\\(symbolName:)|(Label.*?systemImage:)|(UIApplicationShortcutIcon\\(systemImageName:)"
+    regex: "(Image\\(systemName:)|(NSImage\\(symbolName:)|(Label[^,]+?,\\s*systemImage:)|(UIApplicationShortcutIcon\\(systemImageName:)"
     severity: warning
 ```
 


### PR DESCRIPTION
We noticed at work that the regex for SwiftLint's custom rule from #113 had problems with newlines.
This PR corrects it.