### PR TITLE
Add missing initializers for SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - Add support for SF Symbols 6 (By [Rod Brown](https://github.com/RodBrown1988))
 - Added initializers for SwiftUI Button.
+- Add new `MenuBarExtra.init(titleKey:systemSymbol:content:)`, `MenuBarExtra.init(titleKey:systemSymbol:isInserted:content:)`, `MenuBarExtra.init(title:systemSymbol:content:)` and `MenuBarExtra.init(title:systemSymbol:isInserted:content:)` interfaces. (By [david-swift](https://github.com/david-swift))
+- Add new `ContentUnavailableView.init(titleKey:systemSymbol:description:)` and `ContentUnavailableView.init(title:systemSymbol:description:)` interfaces. (By [david-swift](https://github.com/david-swift))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - Add support for SF Symbols 6 (By [Rod Brown](https://github.com/RodBrown1988))
 - Added initializers for SwiftUI Button.
-- Add new `MenuBarExtra.init(titleKey:systemSymbol:content:)`, `MenuBarExtra.init(titleKey:systemSymbol:isInserted:content:)`, `MenuBarExtra.init(title:systemSymbol:content:)` and `MenuBarExtra.init(title:systemSymbol:isInserted:content:)` interfaces. (By [david-swift](https://github.com/david-swift))
-- Add new `ContentUnavailableView.init(titleKey:systemSymbol:description:)` and `ContentUnavailableView.init(title:systemSymbol:description:)` interfaces. (By [david-swift](https://github.com/david-swift))
+- Add new `MenuBarExtra` initializers. (By [david-swift](https://github.com/david-swift))
+- Add new `ContentUnavailableView` initializers. (By [david-swift](https://github.com/david-swift))
 
 ### Changed
 

--- a/SFSafeSymbols.xcodeproj/project.pbxproj
+++ b/SFSafeSymbols.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		B01C18742B55D9B300AC4288 /* SFSymbol+AllSymbols+5.0.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01C186C2B55D9B300AC4288 /* SFSymbol+AllSymbols+5.0.swift */; };
 		B01CF32629258987000FBB12 /* SFSymbol+4.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01CF32429258987000FBB12 /* SFSymbol+4.1.swift */; };
 		B01CF32729258987000FBB12 /* SFSymbol+AllSymbols+4.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01CF32529258987000FBB12 /* SFSymbol+AllSymbols+4.1.swift */; };
+		B092AAA52CDFCA3E007828D9 /* SwiftUIMenuBarExtraExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B092AAA42CDFCA3E007828D9 /* SwiftUIMenuBarExtraExtension.swift */; };
+		B092AAA62CDFCA3E007828D9 /* SwiftUIContentUnavailableViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B092AAA32CDFCA3E007828D9 /* SwiftUIContentUnavailableViewExtension.swift */; };
+		B092AAA92CDFEAF7007828D9 /* SwiftUIContentUnavailableViewExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B092AAA72CDFEAF7007828D9 /* SwiftUIContentUnavailableViewExtensionTests.swift */; };
+		B092AAAA2CDFEAF7007828D9 /* SwiftUIMenuBarExtraExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B092AAA82CDFEAF7007828D9 /* SwiftUIMenuBarExtraExtensionTests.swift */; };
 		B0AEA82B2801A8E000A02015 /* SFSymbol+1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AEA8282801A8E000A02015 /* SFSymbol+1.1.swift */; };
 		B0AEA82C2801A8E000A02015 /* SFSymbol+3.3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AEA8292801A8E000A02015 /* SFSymbol+3.3.swift */; };
 		B0AEA82D2801A8E000A02015 /* SFSymbol+AllSymbols+3.3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AEA82A2801A8E000A02015 /* SFSymbol+AllSymbols+3.3.swift */; };
@@ -106,6 +110,10 @@
 		B01C186C2B55D9B300AC4288 /* SFSymbol+AllSymbols+5.0.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+AllSymbols+5.0.swift"; sourceTree = "<group>"; };
 		B01CF32429258987000FBB12 /* SFSymbol+4.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+4.1.swift"; sourceTree = "<group>"; };
 		B01CF32529258987000FBB12 /* SFSymbol+AllSymbols+4.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+AllSymbols+4.1.swift"; sourceTree = "<group>"; };
+		B092AAA32CDFCA3E007828D9 /* SwiftUIContentUnavailableViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIContentUnavailableViewExtension.swift; sourceTree = "<group>"; };
+		B092AAA42CDFCA3E007828D9 /* SwiftUIMenuBarExtraExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIMenuBarExtraExtension.swift; sourceTree = "<group>"; };
+		B092AAA72CDFEAF7007828D9 /* SwiftUIContentUnavailableViewExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIContentUnavailableViewExtensionTests.swift; sourceTree = "<group>"; };
+		B092AAA82CDFEAF7007828D9 /* SwiftUIMenuBarExtraExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIMenuBarExtraExtensionTests.swift; sourceTree = "<group>"; };
 		B0AEA8282801A8E000A02015 /* SFSymbol+1.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+1.1.swift"; sourceTree = "<group>"; };
 		B0AEA8292801A8E000A02015 /* SFSymbol+3.3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+3.3.swift"; sourceTree = "<group>"; };
 		B0AEA82A2801A8E000A02015 /* SFSymbol+AllSymbols+3.3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SFSymbol+AllSymbols+3.3.swift"; sourceTree = "<group>"; };
@@ -268,6 +276,8 @@
 		CCCCCFFE252F620400C7CE9F /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				B092AAA32CDFCA3E007828D9 /* SwiftUIContentUnavailableViewExtension.swift */,
+				B092AAA42CDFCA3E007828D9 /* SwiftUIMenuBarExtraExtension.swift */,
 				CCCCCFE8252F61E700C7CE9F /* SwiftUIImageExtension.swift */,
 				CCCCCFEA252F61E700C7CE9F /* SwiftUILabelExtension.swift */,
 				949BD15E2B74156800A10AB7 /* SwiftUIButtonExtension.swift */,
@@ -309,6 +319,8 @@
 		CCCCD034252F62D400C7CE9F /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				B092AAA72CDFEAF7007828D9 /* SwiftUIContentUnavailableViewExtensionTests.swift */,
+				B092AAA82CDFEAF7007828D9 /* SwiftUIMenuBarExtraExtensionTests.swift */,
 				CCCCD011252F622B00C7CE9F /* SwiftUIImageExtensionTests.swift */,
 				CCCCD014252F622B00C7CE9F /* SwiftUILabelExtensionTests.swift */,
 				949BD15C2B74155100A10AB7 /* SwiftUIButtonExtensionTests.swift */,
@@ -457,6 +469,8 @@
 				B0B852002C1DC9B000E87F17 /* SFSymbol+AllSymbols+5.3.swift in Sources */,
 				636A46BB28002819007E6028 /* SFSymbol+AllSymbols+1.0.swift in Sources */,
 				636A46CA28002819007E6028 /* SFSymbol+AllSymbols+2.0.swift in Sources */,
+				B092AAA52CDFCA3E007828D9 /* SwiftUIMenuBarExtraExtension.swift in Sources */,
+				B092AAA62CDFCA3E007828D9 /* SwiftUIContentUnavailableViewExtension.swift in Sources */,
 				B0AEA82C2801A8E000A02015 /* SFSymbol+3.3.swift in Sources */,
 				636A46BC28002819007E6028 /* SFSymbol+2.1.swift in Sources */,
 				949BD15F2B74156800A10AB7 /* SwiftUIButtonExtension.swift in Sources */,
@@ -490,6 +504,8 @@
 				CC1D812F27F758D200CACDC7 /* TestHelper.swift in Sources */,
 				949BD15D2B74155100A10AB7 /* SwiftUIButtonExtensionTests.swift in Sources */,
 				CCCCD064252F804400C7CE9F /* NSImageExtensionTests.swift in Sources */,
+				B092AAA92CDFEAF7007828D9 /* SwiftUIContentUnavailableViewExtensionTests.swift in Sources */,
+				B092AAAA2CDFEAF7007828D9 /* SwiftUIMenuBarExtraExtensionTests.swift in Sources */,
 				CCCCD017252F622B00C7CE9F /* UIApplicationShortcutIconExtensionTests.swift in Sources */,
 				CCCCD01A252F622B00C7CE9F /* UIImageExtensionTests.swift in Sources */,
 				B00FBD8E285E146400A7878B /* LocalizationTests.swift in Sources */,

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIContentUnavailableViewExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIContentUnavailableViewExtension.swift
@@ -3,17 +3,17 @@
 import SwiftUI
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-public extension ContentUnavailableView where Actions == EmptyView, Description == Text?, Label == SwiftUI.Label<Text, Image> {
+public extension ContentUnavailableView where Label == SwiftUI.Label<Text, Image>, Description == Text?, Actions == EmptyView {
 
     /// Creates an interface, consisting of a title generated from a localized string,
     /// a system symbol image and additional content, that you display when the
     /// content of your app is unavailable to users.
     ///
-    /// - Parameter titleKey: A title generated from a localized string.
+    /// - Parameter title: A title generated from a localized string.
     /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
     /// - Parameter description: The view that describes the interface.
-    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?, description: Text?) {
-        self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "", description: description)
+    init(_ title: LocalizedStringKey, systemSymbol: SFSymbol?, description: Text? = nil) {
+        self.init(title, systemImage: systemSymbol?.rawValue ?? "", description: description)
     }
 
     /// Creates a label with a system symbol image and a title generated from a
@@ -23,7 +23,7 @@ public extension ContentUnavailableView where Actions == EmptyView, Description 
     /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
     /// - Parameter description: The view that describes the interface.
     @_disfavoredOverload
-    init<S>(_ title: S, systemSymbol: SFSymbol?, description: Text?) where S: StringProtocol {
+    init(_ title: some StringProtocol, systemSymbol: SFSymbol?, description: Text? = nil) {
         self.init(title, systemImage: systemSymbol?.rawValue ?? "", description: description)
     }
 }

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIContentUnavailableViewExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIContentUnavailableViewExtension.swift
@@ -1,0 +1,31 @@
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public extension ContentUnavailableView where Actions == EmptyView, Description == Text?, Label == SwiftUI.Label<Text, Image> {
+
+    /// Creates an interface, consisting of a title generated from a localized string,
+    /// a system symbol image and additional content, that you display when the
+    /// content of your app is unavailable to users.
+    ///
+    /// - Parameter titleKey: A title generated from a localized string.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter description: The view that describes the interface.
+    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?, description: Text?) {
+        self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "", description: description)
+    }
+
+    /// Creates a label with a system symbol image and a title generated from a
+    /// string.
+    ///
+    /// - Parameter title: A string used as the title.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter description: The view that describes the interface.
+    @_disfavoredOverload
+    init<S>(_ title: S, systemSymbol: SFSymbol?, description: Text?) where S: StringProtocol {
+        self.init(title, systemImage: systemSymbol?.rawValue ?? "", description: description)
+    }
+}
+
+#endif

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIMenuBarExtraExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIMenuBarExtraExtension.swift
@@ -1,4 +1,4 @@
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && os(macOS) && !targetEnvironment(macCatalyst)
 
 import SwiftUI
 
@@ -33,7 +33,7 @@ public extension MenuBarExtra where Label == SwiftUI.Label<Text, Image> {
     /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
     /// - Parameter content: A `View` to display when the user selects the item.
     @_disfavoredOverload
-    init<S>(_ title: S, systemSymbol: SFSymbol?, @ViewBuilder content: () -> Content) where S: StringProtocol {
+    init(_ title: some StringProtocol, systemSymbol: SFSymbol?, @ViewBuilder content: () -> Content) {
         self.init(title, systemImage: systemSymbol?.rawValue ?? "", content: content)
     }
 
@@ -45,10 +45,9 @@ public extension MenuBarExtra where Label == SwiftUI.Label<Text, Image> {
     /// - Parameter isInserted: Whether the item is inserted in the menu bar. The item may or may not be visible, depending on the number of items present.
     /// - Parameter content: A `View` to display when the user selects the item.
     @_disfavoredOverload
-    init<S>(_ title: S, systemSymbol: SFSymbol?, isInserted: Binding<Bool>, @ViewBuilder content: () -> Content) where S: StringProtocol {
+    init(_ title: some StringProtocol, systemSymbol: SFSymbol?, isInserted: Binding<Bool>, @ViewBuilder content: () -> Content) {
         self.init(title, systemImage: systemSymbol?.rawValue ?? "", isInserted: isInserted, content: content)
     }
-
 }
 
 #endif

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIMenuBarExtraExtension.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/SwiftUIMenuBarExtraExtension.swift
@@ -1,0 +1,54 @@
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+@available(macOS 13.0, *)
+public extension MenuBarExtra where Label == SwiftUI.Label<Text, Image> {
+
+    /// Creates a menu bar extra with a system symbol image to use as the items
+    /// label. The provided title will be used by the accessibility system.
+    ///
+    /// - Parameter titleKey: The localized string key to use for the accessibility label of the item.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter content: A `View` to display when the user selects the item.
+    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?, @ViewBuilder content: () -> Content) {
+        self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "", content: content)
+    }
+
+    /// Creates a menu bar extra with a system symbol image to use as the items
+    /// label. The provided title will be used by the accessibility system.
+    ///
+    /// - Parameter titleKey: The localized string key to use for the accessibility label of the item.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter isInserted: Whether the item is inserted in the menu bar. The item may or may not be visible, depending on the number of items present.
+    /// - Parameter content: A `View` to display when the user selects the item.
+    init(_ titleKey: LocalizedStringKey, systemSymbol: SFSymbol?, isInserted: Binding<Bool>, @ViewBuilder content: () -> Content) {
+        self.init(titleKey, systemImage: systemSymbol?.rawValue ?? "", isInserted: isInserted, content: content)
+    }
+
+    /// Creates a menu bar extra with a system symbol image to use as the items
+    /// label. The provided title will be used by the accessibility system.
+    ///
+    /// - Parameter title: The string to use for the accessibility label of the item.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter content: A `View` to display when the user selects the item.
+    @_disfavoredOverload
+    init<S>(_ title: S, systemSymbol: SFSymbol?, @ViewBuilder content: () -> Content) where S: StringProtocol {
+        self.init(title, systemImage: systemSymbol?.rawValue ?? "", content: content)
+    }
+
+    /// Creates a menu bar extra with a system symbol image to use as the items
+    /// label. The provided title will be used by the accessibility system.
+    ///
+    /// - Parameter title: The string to use for the accessibility label of the item.
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    /// - Parameter isInserted: Whether the item is inserted in the menu bar. The item may or may not be visible, depending on the number of items present.
+    /// - Parameter content: A `View` to display when the user selects the item.
+    @_disfavoredOverload
+    init<S>(_ title: S, systemSymbol: SFSymbol?, isInserted: Binding<Bool>, @ViewBuilder content: () -> Content) where S: StringProtocol {
+        self.init(title, systemImage: systemSymbol?.rawValue ?? "", isInserted: isInserted, content: content)
+    }
+
+}
+
+#endif

--- a/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIContentUnavailableViewExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIContentUnavailableViewExtensionTests.swift
@@ -1,11 +1,7 @@
-@testable import SFSafeSymbols
-
-#if !os(watchOS)
-
-import XCTest
-
 #if canImport(SwiftUI)
 
+@testable import SFSafeSymbols
+import XCTest
 import SwiftUI
 
 class ContentUnavailableViewExtensionTests: XCTestCase {
@@ -15,8 +11,9 @@ class ContentUnavailableViewExtensionTests: XCTestCase {
             for symbol in TestHelper.allSymbolsWithVariants {
                 print("Testing validity of \"\(symbol.rawValue)\" via ContentUnavailableView init")
 
-                // If this doesn't crash, everything works fine
-                _ = ContentUnavailableView("Title", systemSymbol: symbol, description: .init(verbatim: "Description"))
+                // If these doesn't crash, everything works fine
+                _ = ContentUnavailableView("Title" as LocalizedStringKey, systemSymbol: symbol)
+                _ = ContentUnavailableView("Title" as String, systemSymbol: symbol)
             }
         } else {
             print("To test the ContentUnavailableView initializer, iOS 17, macOS 14.0 or tvOS 17 is required.")
@@ -33,6 +30,3 @@ class JustFail: XCTestCase {
 }
 
 #endif
-
-#endif
-

--- a/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIContentUnavailableViewExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIContentUnavailableViewExtensionTests.swift
@@ -1,0 +1,38 @@
+@testable import SFSafeSymbols
+
+#if !os(watchOS)
+
+import XCTest
+
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+class ContentUnavailableViewExtensionTests: XCTestCase {
+    /// Tests, whether the `ContentUnavailableView` retrieved via SFSafeSymbols can be retrieved without a crash
+    func testInit() {
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            for symbol in TestHelper.allSymbolsWithVariants {
+                print("Testing validity of \"\(symbol.rawValue)\" via ContentUnavailableView init")
+
+                // If this doesn't crash, everything works fine
+                _ = ContentUnavailableView("Title", systemSymbol: symbol, description: .init(verbatim: "Description"))
+            }
+        } else {
+            print("To test the ContentUnavailableView initializer, iOS 17, macOS 14.0 or tvOS 17 is required.")
+        }
+    }
+}
+
+#else
+
+class JustFail: XCTestCase {
+    func justFail() {
+        XCTFail("SwiftUI should be available when testing.")
+    }
+}
+
+#endif
+
+#endif
+

--- a/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIMenuBarExtraExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIMenuBarExtraExtensionTests.swift
@@ -1,0 +1,41 @@
+@testable import SFSafeSymbols
+
+#if !os(watchOS)
+
+import XCTest
+
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+class MenuBarExtraExtensionTests: XCTestCase {
+    /// Tests, whether the `MenuBarExtra` retrieved via SFSafeSymbols can be retrieved without a crash
+    func testInit() {
+        if #available(macOS 13.0, *) {
+            for symbol in TestHelper.allSymbolsWithVariants {
+                print("Testing validity of \"\(symbol.rawValue)\" via MenuBarExtra init")
+
+                // If this doesn't crash, everything works fine
+                _ = MenuBarExtra("Title", systemSymbol: symbol, isInserted: .constant(true)) {
+                    Text("Content")
+                }
+            }
+        } else {
+            print("To test the MenuBarExtra initializer, macOS 13.0 is required.")
+        }
+    }
+}
+
+#else
+
+class JustFail: XCTestCase {
+    func justFail() {
+        XCTFail("SwiftUI should be available when testing.")
+    }
+}
+
+#endif
+
+#endif
+
+

--- a/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIMenuBarExtraExtensionTests.swift
+++ b/Tests/SFSafeSymbolsTests/SwiftUI/SwiftUIMenuBarExtraExtensionTests.swift
@@ -1,11 +1,7 @@
+#if canImport(SwiftUI) && os(macOS) && !targetEnvironment(macCatalyst)
+
 @testable import SFSafeSymbols
-
-#if !os(watchOS)
-
 import XCTest
-
-#if canImport(SwiftUI)
-
 import SwiftUI
 
 class MenuBarExtraExtensionTests: XCTestCase {
@@ -15,8 +11,17 @@ class MenuBarExtraExtensionTests: XCTestCase {
             for symbol in TestHelper.allSymbolsWithVariants {
                 print("Testing validity of \"\(symbol.rawValue)\" via MenuBarExtra init")
 
-                // If this doesn't crash, everything works fine
-                _ = MenuBarExtra("Title", systemSymbol: symbol, isInserted: .constant(true)) {
+                // If these doesn't crash, everything works fine
+                _ = MenuBarExtra("Title" as LocalizedStringKey, systemSymbol: symbol, isInserted: .constant(true)) {
+                    Text("Content")
+                }
+                _ = MenuBarExtra("Title" as String, systemSymbol: symbol, isInserted: .constant(true)) {
+                    Text("Content")
+                }
+                _ = MenuBarExtra("Title" as LocalizedStringKey, systemSymbol: symbol) {
+                    Text("Content")
+                }
+                _ = MenuBarExtra("Title" as String, systemSymbol: symbol) {
                     Text("Content")
                 }
             }
@@ -26,16 +31,4 @@ class MenuBarExtraExtensionTests: XCTestCase {
     }
 }
 
-#else
-
-class JustFail: XCTestCase {
-    func justFail() {
-        XCTFail("SwiftUI should be available when testing.")
-    }
-}
-
 #endif
-
-#endif
-
-


### PR DESCRIPTION
Hello,

Thanks to all of you for maintaining such a great project! 

There seem to be initializers for two SwiftUI views: 
- `Image`
- `Label`

Those are definitely the most important views for displaying symbols, but there are two other SwiftUI types with initializers containing a `systemName: String` parameter: 
- [`MenuBarExtra`](https://developer.apple.com/documentation/swiftui/menubarextra/)
- [`ContentUnavailableView` (Beta)](https://developer.apple.com/documentation/swiftui/contentunavailableview/)

It would be nice to have "safe" initializers for all the SwiftUI views supporting SFSymbols.

I added a "safe" version for all the initializers provided by Apple for `MenuBarExtra` and `ContentUnavailableView` with the `systemName: String` parameter, as well as test cases for both of the types.