### PR TITLE
Add `Codable` conformance to `SFSymbol`

### DIFF
--- a/Sources/SFSafeSymbols/Symbols/SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol.swift
@@ -4,7 +4,7 @@
 // See https://developer.apple.com/documentation/swift/sendable#Sendable-Classes
 
 @available(iOS 13.0, macOS 11.0, tvOS 13.0, watchOS 6.0, visionOS 1.0, *)
-public class SFSymbol: RawRepresentable, Equatable, Hashable, @unchecked Sendable {
+public class SFSymbol: RawRepresentable, Codable, Equatable, Hashable, @unchecked Sendable {
     public let rawValue: String
 
     required public init(rawValue: String) {


### PR DESCRIPTION
This PR adds `Codable` conformance to the `SFSymbol` class.

## 🔍 Rationale
In many modern Swift apps, we pass symbols through persistence layers (UserDefaults, JSON, CloudKit, etc.) or across thread boundaries. While `SFSymbol` already conforms to `Equatable`, `Hashable`, and `@unchecked Sendable`, it was missing `Codable` support — which limits its use in `Codable` data structures.

## ✅ Implementation Details
The class is trivially `Codable` via its `rawValue: String` property.
Since `rawValue` is a `let`, and the class is not open for inheritance, this addition is safe and non-breaking.
No additional methods or logic were introduced, conformance is via default synthesised implementations.