### PR TITLE
Fix to build by pre-Xcode 26.0 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
-- Package cannot build below Xcode's verson 26.0
+- Fix to build by pre-Xcode 26.0 versions
 
 ## [7.0.0] - 2025-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
-- Fix to build by pre-Xcode 26.0 versions
+- Fix to build by pre-Xcode 26.0 versions (By [Phineas Guo](https://github.com/guoPhineas))
 
 ## [7.0.0] - 2025-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
-- None
+- Package cannot build below Xcode's verson 26.0
 
 ## [7.0.0] - 2025-10-26
 

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/Tab+SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/Tab+SFSymbol.swift
@@ -84,7 +84,7 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: Value, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value,  content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
@@ -118,7 +118,7 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: Value, role: TabRole?, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, role: role, content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
@@ -150,7 +150,7 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init<T>(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: T, @ViewBuilder content: () -> Content) where Value == T?, Label == DefaultTabLabel, T : Hashable {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
@@ -184,7 +184,7 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init<T>(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: T, role: TabRole?, @ViewBuilder content: () -> Content) where Value == T?, Label == DefaultTabLabel, T : Hashable {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, role: role, content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
@@ -249,7 +249,7 @@ public extension Tab where Value == Never, Content: View, Label: View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue,  content: content)
@@ -267,7 +267,7 @@ public extension Tab where Value == Never, Content: View, Label: View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, role: TabRole?, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.2)
         self.init(titleResource, systemImage: systemSymbol.rawValue, role: role, content: content)
         #else
         self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue,  content: content)

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/Tab+SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/Tab+SFSymbol.swift
@@ -84,7 +84,11 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: Value, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value,  content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
+        #endif
     }
     
     /// Creates a tab that the tab view presents when the tab view's selection
@@ -114,7 +118,11 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: Value, role: TabRole?, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, role: role, content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
+        #endif
     }
     
     /// Creates a tab that the tab view presents when the tab view's selection
@@ -142,7 +150,11 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init<T>(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: T, @ViewBuilder content: () -> Content) where Value == T?, Label == DefaultTabLabel, T : Hashable {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
+        #endif
     }
         
     /// Creates a tab that the tab view presents when the tab view's selection
@@ -172,7 +184,11 @@ public extension Tab where Value: Hashable, Content: View, Label : View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init<T>(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, value: T, role: TabRole?, @ViewBuilder content: () -> Content) where Value == T?, Label == DefaultTabLabel, T : Hashable {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, value: value, role: role, content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue, value: value, content: content)
+        #endif
     }
 }
 
@@ -233,7 +249,11 @@ public extension Tab where Value == Never, Content: View, Label: View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue,  content: content)
+        #endif
     }
 
     /// Creates a tab with a `SFSymbol` and a localized string resource label.
@@ -247,7 +267,11 @@ public extension Tab where Value == Never, Content: View, Label: View {
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     @_disfavoredOverload
     nonisolated init(_ titleResource: LocalizedStringResource, systemSymbol: SFSymbol, role: TabRole?, @ViewBuilder content: () -> Content) where Label == DefaultTabLabel {
+        #if canImport(FoundationModels)
         self.init(titleResource, systemImage: systemSymbol.rawValue, role: role, content: content)
+        #else
+        self.init(String(localized: titleResource), systemImage: systemSymbol.rawValue,  content: content)
+        #endif
     }
 }
 


### PR DESCRIPTION
## Overview
Adds support for building the package(v7) with Xcode versions below 26.0.
﻿
## Issue
- closes #148
﻿
## What changed
Added version detection via `#if canImport(FoundationModels)` to conditionally exclude code that requires Xcode 26.0+ APIs.
﻿
## Why this approach?
The `FoundationModels` framework appears to be a reliable indicator of Xcode 26.0+ availability in this context. This allows:
1. Maintaining a single codebase
2. Avoiding complex version parsing
3. Compile-time solution
﻿
## Compatibility impact
- ✅ Xcode <26.0: Can now build successfully
- ✅ Xcode ≥26.0: No behavior change
- 🔍 FoundationModels is only referenced in compile-time checks, not linked
﻿
## Considerations
This is a pragmatic solution for immediate compatibility needs. If there's a preferred architectural pattern for version detection in this project, I'm happy to adjust the implementation.