### PR TITLE
Switched to computed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
-- None
+- Switched to computed properties for a smaller binary size (By [Steven Sorial](https://github.com/StevenSorial))
 
 ### Fixed
 

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+1.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+1.0.swift
@@ -14,7 +14,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _0Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "0.circle")
+    static var _0Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "0.circle") }
 
     /// 􀓫
     /// 3 Localizations, 2 Layersets
@@ -27,7 +27,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _00Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "00.circle")
+    static var _00Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "00.circle") }
 
     /// 􀀹
     /// 3 Localizations, 3 Layersets
@@ -41,7 +41,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _0CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "0.circle.fill")
+    static var _0CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "0.circle.fill") }
 
     /// 􀔊
     /// 3 Localizations, 3 Layersets
@@ -55,7 +55,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _00CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "00.circle.fill")
+    static var _00CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "00.circle.fill") }
 
     /// 􀃈
     /// 3 Localizations, 2 Layersets
@@ -68,7 +68,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _0Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "0.square")
+    static var _0Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "0.square") }
 
     /// 􀔩
     /// 3 Localizations, 2 Layersets
@@ -81,7 +81,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _00Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "00.square")
+    static var _00Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "00.square") }
 
     /// 􀃉
     /// 3 Localizations, 3 Layersets
@@ -95,7 +95,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _0SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "0.square.fill")
+    static var _0SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "0.square.fill") }
 
     /// 􀕈
     /// 3 Localizations, 3 Layersets
@@ -109,7 +109,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _00SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "00.square.fill")
+    static var _00SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "00.square.fill") }
 
     /// 􀀺
     /// 3 Localizations, 2 Layersets
@@ -122,7 +122,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _1Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "1.circle")
+    static var _1Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "1.circle") }
 
     /// 􀓬
     /// 3 Localizations, 2 Layersets
@@ -135,7 +135,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _01Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "01.circle")
+    static var _01Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "01.circle") }
 
     /// 􀀻
     /// 3 Localizations, 3 Layersets
@@ -149,7 +149,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _1CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "1.circle.fill")
+    static var _1CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "1.circle.fill") }
 
     /// 􀔋
     /// 3 Localizations, 3 Layersets
@@ -163,7 +163,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _01CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "01.circle.fill")
+    static var _01CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "01.circle.fill") }
 
     /// 􀊮
     /// 3 Localizations, 2 Layersets
@@ -176,7 +176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let _1Magnifyingglass = SymbolWith2Localizations<Ar_v2, Hi_v3>(rawValue: "1.magnifyingglass")
+    static var _1Magnifyingglass: SymbolWith2Localizations<Ar_v2, Hi_v3> { .init(rawValue: "1.magnifyingglass") }
 
     /// 􀃊
     /// 3 Localizations, 2 Layersets
@@ -189,7 +189,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _1Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "1.square")
+    static var _1Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "1.square") }
 
     /// 􀔪
     /// 3 Localizations, 2 Layersets
@@ -202,7 +202,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _01Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "01.square")
+    static var _01Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "01.square") }
 
     /// 􀃋
     /// 3 Localizations, 3 Layersets
@@ -216,7 +216,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _1SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "1.square.fill")
+    static var _1SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "1.square.fill") }
 
     /// 􀕉
     /// 3 Localizations, 3 Layersets
@@ -230,7 +230,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _01SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "01.square.fill")
+    static var _01SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "01.square.fill") }
 
     /// 􀀼
     /// 3 Localizations, 2 Layersets
@@ -243,7 +243,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _2Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "2.circle")
+    static var _2Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "2.circle") }
 
     /// 􀓭
     /// 3 Localizations, 2 Layersets
@@ -256,7 +256,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _02Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "02.circle")
+    static var _02Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "02.circle") }
 
     /// 􀀽
     /// 3 Localizations, 3 Layersets
@@ -270,7 +270,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _2CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "2.circle.fill")
+    static var _2CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "2.circle.fill") }
 
     /// 􀔌
     /// 3 Localizations, 3 Layersets
@@ -284,7 +284,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _02CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "02.circle.fill")
+    static var _02CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "02.circle.fill") }
 
     /// 􀃌
     /// 3 Localizations, 2 Layersets
@@ -297,7 +297,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _2Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "2.square")
+    static var _2Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "2.square") }
 
     /// 􀔫
     /// 3 Localizations, 2 Layersets
@@ -310,7 +310,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _02Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "02.square")
+    static var _02Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "02.square") }
 
     /// 􀃍
     /// 3 Localizations, 3 Layersets
@@ -324,7 +324,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _2SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "2.square.fill")
+    static var _2SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "2.square.fill") }
 
     /// 􀕊
     /// 3 Localizations, 3 Layersets
@@ -338,7 +338,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _02SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "02.square.fill")
+    static var _02SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "02.square.fill") }
 
     /// 􀀾
     /// 3 Localizations, 2 Layersets
@@ -351,7 +351,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _3Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "3.circle")
+    static var _3Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "3.circle") }
 
     /// 􀓮
     /// 3 Localizations, 2 Layersets
@@ -364,7 +364,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _03Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "03.circle")
+    static var _03Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "03.circle") }
 
     /// 􀀿
     /// 3 Localizations, 3 Layersets
@@ -378,7 +378,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _3CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "3.circle.fill")
+    static var _3CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "3.circle.fill") }
 
     /// 􀔍
     /// 3 Localizations, 3 Layersets
@@ -392,7 +392,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _03CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "03.circle.fill")
+    static var _03CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "03.circle.fill") }
 
     /// 􀃎
     /// 3 Localizations, 2 Layersets
@@ -405,7 +405,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _3Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "3.square")
+    static var _3Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "3.square") }
 
     /// 􀔬
     /// 3 Localizations, 2 Layersets
@@ -418,7 +418,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _03Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "03.square")
+    static var _03Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "03.square") }
 
     /// 􀃏
     /// 3 Localizations, 3 Layersets
@@ -432,7 +432,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _3SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "3.square.fill")
+    static var _3SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "3.square.fill") }
 
     /// 􀕋
     /// 3 Localizations, 3 Layersets
@@ -446,7 +446,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _03SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "03.square.fill")
+    static var _03SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "03.square.fill") }
 
     /// 􀘗
     /// Single Localization, 2 Layersets
@@ -454,7 +454,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4AltCircle = SFSymbol(rawValue: "4.alt.circle")
+    static var _4AltCircle: SFSymbol { .init(rawValue: "4.alt.circle") }
 
     /// 􀘘
     /// Single Localization, 3 Layersets
@@ -463,7 +463,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4AltCircleFill = SFSymbol(rawValue: "4.alt.circle.fill")
+    static var _4AltCircleFill: SFSymbol { .init(rawValue: "4.alt.circle.fill") }
 
     /// 􀘙
     /// Single Localization, 2 Layersets
@@ -471,7 +471,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4AltSquare = SFSymbol(rawValue: "4.alt.square")
+    static var _4AltSquare: SFSymbol { .init(rawValue: "4.alt.square") }
 
     /// 􀘚
     /// Single Localization, 3 Layersets
@@ -480,7 +480,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4AltSquareFill = SFSymbol(rawValue: "4.alt.square.fill")
+    static var _4AltSquareFill: SFSymbol { .init(rawValue: "4.alt.square.fill") }
 
     /// 􀁀
     /// 3 Localizations, 2 Layersets
@@ -493,7 +493,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "4.circle")
+    static var _4Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "4.circle") }
 
     /// 􀓯
     /// 3 Localizations, 2 Layersets
@@ -506,7 +506,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _04Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "04.circle")
+    static var _04Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "04.circle") }
 
     /// 􀁁
     /// 3 Localizations, 3 Layersets
@@ -520,7 +520,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "4.circle.fill")
+    static var _4CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "4.circle.fill") }
 
     /// 􀔎
     /// 3 Localizations, 3 Layersets
@@ -534,7 +534,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _04CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "04.circle.fill")
+    static var _04CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "04.circle.fill") }
 
     /// 􀃐
     /// 3 Localizations, 2 Layersets
@@ -547,7 +547,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "4.square")
+    static var _4Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "4.square") }
 
     /// 􀔭
     /// 3 Localizations, 2 Layersets
@@ -560,7 +560,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _04Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "04.square")
+    static var _04Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "04.square") }
 
     /// 􀃑
     /// 3 Localizations, 3 Layersets
@@ -574,7 +574,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "4.square.fill")
+    static var _4SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "4.square.fill") }
 
     /// 􀕌
     /// 3 Localizations, 3 Layersets
@@ -588,7 +588,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _04SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "04.square.fill")
+    static var _04SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "04.square.fill") }
 
     /// 􀁂
     /// 3 Localizations, 2 Layersets
@@ -601,7 +601,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _5Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "5.circle")
+    static var _5Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "5.circle") }
 
     /// 􀓰
     /// 3 Localizations, 2 Layersets
@@ -614,7 +614,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _05Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "05.circle")
+    static var _05Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "05.circle") }
 
     /// 􀁃
     /// 3 Localizations, 3 Layersets
@@ -628,7 +628,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _5CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "5.circle.fill")
+    static var _5CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "5.circle.fill") }
 
     /// 􀔏
     /// 3 Localizations, 3 Layersets
@@ -642,7 +642,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _05CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "05.circle.fill")
+    static var _05CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "05.circle.fill") }
 
     /// 􀃒
     /// 3 Localizations, 2 Layersets
@@ -655,7 +655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _5Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "5.square")
+    static var _5Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "5.square") }
 
     /// 􀔮
     /// 3 Localizations, 2 Layersets
@@ -668,7 +668,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _05Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "05.square")
+    static var _05Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "05.square") }
 
     /// 􀃓
     /// 3 Localizations, 3 Layersets
@@ -682,7 +682,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _5SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "5.square.fill")
+    static var _5SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "5.square.fill") }
 
     /// 􀕍
     /// 3 Localizations, 3 Layersets
@@ -696,7 +696,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _05SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "05.square.fill")
+    static var _05SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "05.square.fill") }
 
     /// 􀑱
     /// Single Localization, 2 Layersets
@@ -704,7 +704,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6AltCircle = SFSymbol(rawValue: "6.alt.circle")
+    static var _6AltCircle: SFSymbol { .init(rawValue: "6.alt.circle") }
 
     /// 􀑲
     /// Single Localization, 3 Layersets
@@ -713,7 +713,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6AltCircleFill = SFSymbol(rawValue: "6.alt.circle.fill")
+    static var _6AltCircleFill: SFSymbol { .init(rawValue: "6.alt.circle.fill") }
 
     /// 􀑵
     /// Single Localization, 2 Layersets
@@ -721,7 +721,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6AltSquare = SFSymbol(rawValue: "6.alt.square")
+    static var _6AltSquare: SFSymbol { .init(rawValue: "6.alt.square") }
 
     /// 􀑶
     /// Single Localization, 3 Layersets
@@ -730,7 +730,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6AltSquareFill = SFSymbol(rawValue: "6.alt.square.fill")
+    static var _6AltSquareFill: SFSymbol { .init(rawValue: "6.alt.square.fill") }
 
     /// 􀁄
     /// 3 Localizations, 2 Layersets
@@ -743,7 +743,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "6.circle")
+    static var _6Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "6.circle") }
 
     /// 􀓱
     /// 3 Localizations, 2 Layersets
@@ -756,7 +756,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _06Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "06.circle")
+    static var _06Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "06.circle") }
 
     /// 􀁅
     /// 3 Localizations, 3 Layersets
@@ -770,7 +770,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "6.circle.fill")
+    static var _6CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "6.circle.fill") }
 
     /// 􀔐
     /// 3 Localizations, 3 Layersets
@@ -784,7 +784,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _06CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "06.circle.fill")
+    static var _06CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "06.circle.fill") }
 
     /// 􀃔
     /// 3 Localizations, 2 Layersets
@@ -797,7 +797,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "6.square")
+    static var _6Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "6.square") }
 
     /// 􀔯
     /// 3 Localizations, 2 Layersets
@@ -810,7 +810,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _06Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "06.square")
+    static var _06Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "06.square") }
 
     /// 􀃕
     /// 3 Localizations, 3 Layersets
@@ -824,7 +824,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _6SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "6.square.fill")
+    static var _6SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "6.square.fill") }
 
     /// 􀕎
     /// 3 Localizations, 3 Layersets
@@ -838,7 +838,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _06SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "06.square.fill")
+    static var _06SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "06.square.fill") }
 
     /// 􀁆
     /// 3 Localizations, 2 Layersets
@@ -851,7 +851,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _7Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "7.circle")
+    static var _7Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "7.circle") }
 
     /// 􀓲
     /// 3 Localizations, 2 Layersets
@@ -864,7 +864,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _07Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "07.circle")
+    static var _07Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "07.circle") }
 
     /// 􀁇
     /// 3 Localizations, 3 Layersets
@@ -878,7 +878,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _7CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "7.circle.fill")
+    static var _7CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "7.circle.fill") }
 
     /// 􀔑
     /// 3 Localizations, 3 Layersets
@@ -892,7 +892,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _07CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "07.circle.fill")
+    static var _07CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "07.circle.fill") }
 
     /// 􀃖
     /// 3 Localizations, 2 Layersets
@@ -905,7 +905,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _7Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "7.square")
+    static var _7Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "7.square") }
 
     /// 􀔰
     /// 3 Localizations, 2 Layersets
@@ -918,7 +918,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _07Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "07.square")
+    static var _07Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "07.square") }
 
     /// 􀃗
     /// 3 Localizations, 3 Layersets
@@ -932,7 +932,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _7SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "7.square.fill")
+    static var _7SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "7.square.fill") }
 
     /// 􀕏
     /// 3 Localizations, 3 Layersets
@@ -946,7 +946,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _07SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "07.square.fill")
+    static var _07SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "07.square.fill") }
 
     /// 􀁈
     /// 3 Localizations, 2 Layersets
@@ -959,7 +959,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _8Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "8.circle")
+    static var _8Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "8.circle") }
 
     /// 􀓳
     /// 3 Localizations, 2 Layersets
@@ -972,7 +972,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _08Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "08.circle")
+    static var _08Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "08.circle") }
 
     /// 􀁉
     /// 3 Localizations, 3 Layersets
@@ -986,7 +986,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _8CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "8.circle.fill")
+    static var _8CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "8.circle.fill") }
 
     /// 􀔒
     /// 3 Localizations, 3 Layersets
@@ -1000,7 +1000,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _08CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "08.circle.fill")
+    static var _08CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "08.circle.fill") }
 
     /// 􀃘
     /// 3 Localizations, 2 Layersets
@@ -1013,7 +1013,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _8Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "8.square")
+    static var _8Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "8.square") }
 
     /// 􀔱
     /// 3 Localizations, 2 Layersets
@@ -1026,7 +1026,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _08Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "08.square")
+    static var _08Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "08.square") }
 
     /// 􀃙
     /// 3 Localizations, 3 Layersets
@@ -1040,7 +1040,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _8SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "8.square.fill")
+    static var _8SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "8.square.fill") }
 
     /// 􀕐
     /// 3 Localizations, 3 Layersets
@@ -1054,7 +1054,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _08SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "08.square.fill")
+    static var _08SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "08.square.fill") }
 
     /// 􀑳
     /// Single Localization, 2 Layersets
@@ -1062,7 +1062,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9AltCircle = SFSymbol(rawValue: "9.alt.circle")
+    static var _9AltCircle: SFSymbol { .init(rawValue: "9.alt.circle") }
 
     /// 􀑴
     /// Single Localization, 3 Layersets
@@ -1071,7 +1071,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9AltCircleFill = SFSymbol(rawValue: "9.alt.circle.fill")
+    static var _9AltCircleFill: SFSymbol { .init(rawValue: "9.alt.circle.fill") }
 
     /// 􀑷
     /// Single Localization, 2 Layersets
@@ -1079,7 +1079,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9AltSquare = SFSymbol(rawValue: "9.alt.square")
+    static var _9AltSquare: SFSymbol { .init(rawValue: "9.alt.square") }
 
     /// 􀑸
     /// Single Localization, 3 Layersets
@@ -1088,7 +1088,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9AltSquareFill = SFSymbol(rawValue: "9.alt.square.fill")
+    static var _9AltSquareFill: SFSymbol { .init(rawValue: "9.alt.square.fill") }
 
     /// 􀁊
     /// 3 Localizations, 2 Layersets
@@ -1101,7 +1101,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9Circle = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "9.circle")
+    static var _9Circle: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "9.circle") }
 
     /// 􀓴
     /// 3 Localizations, 2 Layersets
@@ -1114,7 +1114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _09Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "09.circle")
+    static var _09Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "09.circle") }
 
     /// 􀁋
     /// 3 Localizations, 3 Layersets
@@ -1128,7 +1128,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9CircleFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "9.circle.fill")
+    static var _9CircleFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "9.circle.fill") }
 
     /// 􀔓
     /// 3 Localizations, 3 Layersets
@@ -1142,7 +1142,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _09CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "09.circle.fill")
+    static var _09CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "09.circle.fill") }
 
     /// 􀃚
     /// 3 Localizations, 2 Layersets
@@ -1155,7 +1155,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9Square = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "9.square")
+    static var _9Square: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "9.square") }
 
     /// 􀔲
     /// 3 Localizations, 2 Layersets
@@ -1168,7 +1168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _09Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "09.square")
+    static var _09Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "09.square") }
 
     /// 􀃛
     /// 3 Localizations, 3 Layersets
@@ -1182,7 +1182,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _9SquareFill = SymbolWith2Localizations<Ar_v4_1, Hi_v5_2>(rawValue: "9.square.fill")
+    static var _9SquareFill: SymbolWith2Localizations<Ar_v4_1, Hi_v5_2> { .init(rawValue: "9.square.fill") }
 
     /// 􀕑
     /// 3 Localizations, 3 Layersets
@@ -1196,7 +1196,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _09SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "09.square.fill")
+    static var _09SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "09.square.fill") }
 
     /// 􀓵
     /// 3 Localizations, 2 Layersets
@@ -1209,7 +1209,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _10Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "10.circle")
+    static var _10Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "10.circle") }
 
     /// 􀔔
     /// 3 Localizations, 3 Layersets
@@ -1223,7 +1223,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _10CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "10.circle.fill")
+    static var _10CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "10.circle.fill") }
 
     /// 􀔳
     /// 3 Localizations, 2 Layersets
@@ -1236,7 +1236,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _10Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "10.square")
+    static var _10Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "10.square") }
 
     /// 􀕒
     /// 3 Localizations, 3 Layersets
@@ -1250,7 +1250,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _10SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "10.square.fill")
+    static var _10SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "10.square.fill") }
 
     /// 􀓶
     /// 3 Localizations, 2 Layersets
@@ -1263,7 +1263,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _11Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "11.circle")
+    static var _11Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "11.circle") }
 
     /// 􀔕
     /// 3 Localizations, 3 Layersets
@@ -1277,7 +1277,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _11CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "11.circle.fill")
+    static var _11CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "11.circle.fill") }
 
     /// 􀔴
     /// 3 Localizations, 2 Layersets
@@ -1290,7 +1290,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _11Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "11.square")
+    static var _11Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "11.square") }
 
     /// 􀕓
     /// 3 Localizations, 3 Layersets
@@ -1304,7 +1304,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _11SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "11.square.fill")
+    static var _11SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "11.square.fill") }
 
     /// 􀓷
     /// 3 Localizations, 2 Layersets
@@ -1317,7 +1317,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _12Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "12.circle")
+    static var _12Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "12.circle") }
 
     /// 􀔖
     /// 3 Localizations, 3 Layersets
@@ -1331,7 +1331,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _12CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "12.circle.fill")
+    static var _12CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "12.circle.fill") }
 
     /// 􀔵
     /// 3 Localizations, 2 Layersets
@@ -1344,7 +1344,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _12Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "12.square")
+    static var _12Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "12.square") }
 
     /// 􀕔
     /// 3 Localizations, 3 Layersets
@@ -1358,7 +1358,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _12SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "12.square.fill")
+    static var _12SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "12.square.fill") }
 
     /// 􀓸
     /// 3 Localizations, 2 Layersets
@@ -1371,7 +1371,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _13Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "13.circle")
+    static var _13Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "13.circle") }
 
     /// 􀔗
     /// 3 Localizations, 3 Layersets
@@ -1385,7 +1385,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _13CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "13.circle.fill")
+    static var _13CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "13.circle.fill") }
 
     /// 􀔶
     /// 3 Localizations, 2 Layersets
@@ -1398,7 +1398,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _13Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "13.square")
+    static var _13Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "13.square") }
 
     /// 􀕕
     /// 3 Localizations, 3 Layersets
@@ -1412,7 +1412,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _13SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "13.square.fill")
+    static var _13SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "13.square.fill") }
 
     /// 􀓹
     /// 3 Localizations, 2 Layersets
@@ -1425,7 +1425,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _14Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "14.circle")
+    static var _14Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "14.circle") }
 
     /// 􀔘
     /// 3 Localizations, 3 Layersets
@@ -1439,7 +1439,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _14CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "14.circle.fill")
+    static var _14CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "14.circle.fill") }
 
     /// 􀔷
     /// 3 Localizations, 2 Layersets
@@ -1452,7 +1452,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _14Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "14.square")
+    static var _14Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "14.square") }
 
     /// 􀕖
     /// 3 Localizations, 3 Layersets
@@ -1466,7 +1466,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _14SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "14.square.fill")
+    static var _14SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "14.square.fill") }
 
     /// 􀓺
     /// 3 Localizations, 2 Layersets
@@ -1479,7 +1479,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _15Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "15.circle")
+    static var _15Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "15.circle") }
 
     /// 􀔙
     /// 3 Localizations, 3 Layersets
@@ -1493,7 +1493,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _15CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "15.circle.fill")
+    static var _15CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "15.circle.fill") }
 
     /// 􀔸
     /// 3 Localizations, 2 Layersets
@@ -1506,7 +1506,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _15Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "15.square")
+    static var _15Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "15.square") }
 
     /// 􀕗
     /// 3 Localizations, 3 Layersets
@@ -1520,7 +1520,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _15SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "15.square.fill")
+    static var _15SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "15.square.fill") }
 
     /// 􀓻
     /// 3 Localizations, 2 Layersets
@@ -1533,7 +1533,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _16Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "16.circle")
+    static var _16Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "16.circle") }
 
     /// 􀔚
     /// 3 Localizations, 3 Layersets
@@ -1547,7 +1547,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _16CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "16.circle.fill")
+    static var _16CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "16.circle.fill") }
 
     /// 􀔹
     /// 3 Localizations, 2 Layersets
@@ -1560,7 +1560,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _16Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "16.square")
+    static var _16Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "16.square") }
 
     /// 􀕘
     /// 3 Localizations, 3 Layersets
@@ -1574,7 +1574,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _16SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "16.square.fill")
+    static var _16SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "16.square.fill") }
 
     /// 􀓼
     /// 3 Localizations, 2 Layersets
@@ -1587,7 +1587,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _17Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "17.circle")
+    static var _17Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "17.circle") }
 
     /// 􀔛
     /// 3 Localizations, 3 Layersets
@@ -1601,7 +1601,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _17CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "17.circle.fill")
+    static var _17CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "17.circle.fill") }
 
     /// 􀔺
     /// 3 Localizations, 2 Layersets
@@ -1614,7 +1614,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _17Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "17.square")
+    static var _17Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "17.square") }
 
     /// 􀕙
     /// 3 Localizations, 3 Layersets
@@ -1628,7 +1628,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _17SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "17.square.fill")
+    static var _17SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "17.square.fill") }
 
     /// 􀓽
     /// 3 Localizations, 2 Layersets
@@ -1641,7 +1641,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _18Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "18.circle")
+    static var _18Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "18.circle") }
 
     /// 􀔜
     /// 3 Localizations, 3 Layersets
@@ -1655,7 +1655,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _18CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "18.circle.fill")
+    static var _18CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "18.circle.fill") }
 
     /// 􀔻
     /// 3 Localizations, 2 Layersets
@@ -1668,7 +1668,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _18Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "18.square")
+    static var _18Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "18.square") }
 
     /// 􀕚
     /// 3 Localizations, 3 Layersets
@@ -1682,7 +1682,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _18SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "18.square.fill")
+    static var _18SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "18.square.fill") }
 
     /// 􀓾
     /// 3 Localizations, 2 Layersets
@@ -1695,7 +1695,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _19Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "19.circle")
+    static var _19Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "19.circle") }
 
     /// 􀔝
     /// 3 Localizations, 3 Layersets
@@ -1709,7 +1709,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _19CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "19.circle.fill")
+    static var _19CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "19.circle.fill") }
 
     /// 􀔼
     /// 3 Localizations, 2 Layersets
@@ -1722,7 +1722,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _19Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "19.square")
+    static var _19Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "19.square") }
 
     /// 􀕛
     /// 3 Localizations, 3 Layersets
@@ -1736,7 +1736,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _19SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "19.square.fill")
+    static var _19SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "19.square.fill") }
 
     /// 􀓿
     /// 3 Localizations, 2 Layersets
@@ -1749,7 +1749,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _20Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "20.circle")
+    static var _20Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "20.circle") }
 
     /// 􀔞
     /// 3 Localizations, 3 Layersets
@@ -1763,7 +1763,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _20CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "20.circle.fill")
+    static var _20CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "20.circle.fill") }
 
     /// 􀔽
     /// 3 Localizations, 2 Layersets
@@ -1776,7 +1776,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _20Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "20.square")
+    static var _20Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "20.square") }
 
     /// 􀕜
     /// 3 Localizations, 3 Layersets
@@ -1790,7 +1790,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _20SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "20.square.fill")
+    static var _20SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "20.square.fill") }
 
     /// 􀔀
     /// 3 Localizations, 2 Layersets
@@ -1803,7 +1803,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _21Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "21.circle")
+    static var _21Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "21.circle") }
 
     /// 􀔟
     /// 3 Localizations, 3 Layersets
@@ -1817,7 +1817,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _21CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "21.circle.fill")
+    static var _21CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "21.circle.fill") }
 
     /// 􀔾
     /// 3 Localizations, 2 Layersets
@@ -1830,7 +1830,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _21Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "21.square")
+    static var _21Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "21.square") }
 
     /// 􀕝
     /// 3 Localizations, 3 Layersets
@@ -1844,7 +1844,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _21SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "21.square.fill")
+    static var _21SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "21.square.fill") }
 
     /// 􀔁
     /// 3 Localizations, 2 Layersets
@@ -1857,7 +1857,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _22Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "22.circle")
+    static var _22Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "22.circle") }
 
     /// 􀔠
     /// 3 Localizations, 3 Layersets
@@ -1871,7 +1871,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _22CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "22.circle.fill")
+    static var _22CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "22.circle.fill") }
 
     /// 􀔿
     /// 3 Localizations, 2 Layersets
@@ -1884,7 +1884,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _22Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "22.square")
+    static var _22Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "22.square") }
 
     /// 􀕞
     /// 3 Localizations, 3 Layersets
@@ -1898,7 +1898,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _22SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "22.square.fill")
+    static var _22SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "22.square.fill") }
 
     /// 􀔂
     /// 3 Localizations, 2 Layersets
@@ -1911,7 +1911,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _23Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "23.circle")
+    static var _23Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "23.circle") }
 
     /// 􀔡
     /// 3 Localizations, 3 Layersets
@@ -1925,7 +1925,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _23CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "23.circle.fill")
+    static var _23CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "23.circle.fill") }
 
     /// 􀕀
     /// 3 Localizations, 2 Layersets
@@ -1938,7 +1938,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _23Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "23.square")
+    static var _23Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "23.square") }
 
     /// 􀕟
     /// 3 Localizations, 3 Layersets
@@ -1952,7 +1952,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _23SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "23.square.fill")
+    static var _23SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "23.square.fill") }
 
     /// 􀔃
     /// 3 Localizations, 2 Layersets
@@ -1965,7 +1965,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _24Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "24.circle")
+    static var _24Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "24.circle") }
 
     /// 􀔢
     /// 3 Localizations, 3 Layersets
@@ -1979,7 +1979,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _24CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "24.circle.fill")
+    static var _24CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "24.circle.fill") }
 
     /// 􀕁
     /// 3 Localizations, 2 Layersets
@@ -1992,7 +1992,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _24Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "24.square")
+    static var _24Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "24.square") }
 
     /// 􀕠
     /// 3 Localizations, 3 Layersets
@@ -2006,7 +2006,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _24SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "24.square.fill")
+    static var _24SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "24.square.fill") }
 
     /// 􀔄
     /// 3 Localizations, 2 Layersets
@@ -2019,7 +2019,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _25Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "25.circle")
+    static var _25Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "25.circle") }
 
     /// 􀔣
     /// 3 Localizations, 3 Layersets
@@ -2033,7 +2033,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _25CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "25.circle.fill")
+    static var _25CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "25.circle.fill") }
 
     /// 􀕂
     /// 3 Localizations, 2 Layersets
@@ -2046,7 +2046,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _25Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "25.square")
+    static var _25Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "25.square") }
 
     /// 􀕡
     /// 3 Localizations, 3 Layersets
@@ -2060,7 +2060,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _25SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "25.square.fill")
+    static var _25SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "25.square.fill") }
 
     /// 􀔅
     /// 3 Localizations, 2 Layersets
@@ -2073,7 +2073,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _26Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "26.circle")
+    static var _26Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "26.circle") }
 
     /// 􀔤
     /// 3 Localizations, 3 Layersets
@@ -2087,7 +2087,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _26CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "26.circle.fill")
+    static var _26CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "26.circle.fill") }
 
     /// 􀕃
     /// 3 Localizations, 2 Layersets
@@ -2100,7 +2100,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _26Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "26.square")
+    static var _26Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "26.square") }
 
     /// 􀕢
     /// 3 Localizations, 3 Layersets
@@ -2114,7 +2114,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _26SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "26.square.fill")
+    static var _26SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "26.square.fill") }
 
     /// 􀔆
     /// 3 Localizations, 2 Layersets
@@ -2127,7 +2127,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _27Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "27.circle")
+    static var _27Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "27.circle") }
 
     /// 􀔥
     /// 3 Localizations, 3 Layersets
@@ -2141,7 +2141,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _27CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "27.circle.fill")
+    static var _27CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "27.circle.fill") }
 
     /// 􀕄
     /// 3 Localizations, 2 Layersets
@@ -2154,7 +2154,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _27Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "27.square")
+    static var _27Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "27.square") }
 
     /// 􀕣
     /// 3 Localizations, 3 Layersets
@@ -2168,7 +2168,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _27SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "27.square.fill")
+    static var _27SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "27.square.fill") }
 
     /// 􀔇
     /// 3 Localizations, 2 Layersets
@@ -2181,7 +2181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _28Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "28.circle")
+    static var _28Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "28.circle") }
 
     /// 􀔦
     /// 3 Localizations, 3 Layersets
@@ -2195,7 +2195,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _28CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "28.circle.fill")
+    static var _28CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "28.circle.fill") }
 
     /// 􀕅
     /// 3 Localizations, 2 Layersets
@@ -2208,7 +2208,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _28Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "28.square")
+    static var _28Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "28.square") }
 
     /// 􀕤
     /// 3 Localizations, 3 Layersets
@@ -2222,7 +2222,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _28SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "28.square.fill")
+    static var _28SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "28.square.fill") }
 
     /// 􀔈
     /// 3 Localizations, 2 Layersets
@@ -2235,7 +2235,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _29Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "29.circle")
+    static var _29Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "29.circle") }
 
     /// 􀔧
     /// 3 Localizations, 3 Layersets
@@ -2249,7 +2249,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _29CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "29.circle.fill")
+    static var _29CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "29.circle.fill") }
 
     /// 􀕆
     /// 3 Localizations, 2 Layersets
@@ -2262,7 +2262,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _29Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "29.square")
+    static var _29Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "29.square") }
 
     /// 􀕥
     /// 3 Localizations, 3 Layersets
@@ -2276,7 +2276,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _29SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "29.square.fill")
+    static var _29SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "29.square.fill") }
 
     /// 􀔉
     /// 3 Localizations, 2 Layersets
@@ -2289,7 +2289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _30Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "30.circle")
+    static var _30Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "30.circle") }
 
     /// 􀔨
     /// 3 Localizations, 3 Layersets
@@ -2303,7 +2303,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _30CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "30.circle.fill")
+    static var _30CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "30.circle.fill") }
 
     /// 􀕇
     /// 3 Localizations, 2 Layersets
@@ -2316,7 +2316,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _30Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "30.square")
+    static var _30Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "30.square") }
 
     /// 􀕦
     /// 3 Localizations, 3 Layersets
@@ -2330,7 +2330,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _30SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "30.square.fill")
+    static var _30SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "30.square.fill") }
 
     /// 􀘠
     /// 3 Localizations, 2 Layersets
@@ -2343,7 +2343,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _31Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "31.circle")
+    static var _31Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "31.circle") }
 
     /// 􀘡
     /// 3 Localizations, 3 Layersets
@@ -2357,7 +2357,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _31CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "31.circle.fill")
+    static var _31CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "31.circle.fill") }
 
     /// 􀘢
     /// 3 Localizations, 2 Layersets
@@ -2370,7 +2370,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _31Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "31.square")
+    static var _31Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "31.square") }
 
     /// 􀘣
     /// 3 Localizations, 3 Layersets
@@ -2384,7 +2384,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _31SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "31.square.fill")
+    static var _31SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "31.square.fill") }
 
     /// 􀚗
     /// 3 Localizations, 2 Layersets
@@ -2397,7 +2397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _32Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "32.circle")
+    static var _32Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "32.circle") }
 
     /// 􀚘
     /// 3 Localizations, 3 Layersets
@@ -2411,7 +2411,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _32CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "32.circle.fill")
+    static var _32CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "32.circle.fill") }
 
     /// 􀚽
     /// 3 Localizations, 2 Layersets
@@ -2424,7 +2424,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _32Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "32.square")
+    static var _32Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "32.square") }
 
     /// 􀚾
     /// 3 Localizations, 3 Layersets
@@ -2438,7 +2438,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _32SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "32.square.fill")
+    static var _32SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "32.square.fill") }
 
     /// 􀚙
     /// 3 Localizations, 2 Layersets
@@ -2451,7 +2451,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _33Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "33.circle")
+    static var _33Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "33.circle") }
 
     /// 􀚚
     /// 3 Localizations, 3 Layersets
@@ -2465,7 +2465,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _33CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "33.circle.fill")
+    static var _33CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "33.circle.fill") }
 
     /// 􀚿
     /// 3 Localizations, 2 Layersets
@@ -2478,7 +2478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _33Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "33.square")
+    static var _33Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "33.square") }
 
     /// 􀛀
     /// 3 Localizations, 3 Layersets
@@ -2492,7 +2492,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _33SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "33.square.fill")
+    static var _33SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "33.square.fill") }
 
     /// 􀚛
     /// 3 Localizations, 2 Layersets
@@ -2505,7 +2505,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _34Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "34.circle")
+    static var _34Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "34.circle") }
 
     /// 􀚜
     /// 3 Localizations, 3 Layersets
@@ -2519,7 +2519,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _34CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "34.circle.fill")
+    static var _34CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "34.circle.fill") }
 
     /// 􀛁
     /// 3 Localizations, 2 Layersets
@@ -2532,7 +2532,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _34Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "34.square")
+    static var _34Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "34.square") }
 
     /// 􀛂
     /// 3 Localizations, 3 Layersets
@@ -2546,7 +2546,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _34SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "34.square.fill")
+    static var _34SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "34.square.fill") }
 
     /// 􀚝
     /// 3 Localizations, 2 Layersets
@@ -2559,7 +2559,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _35Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "35.circle")
+    static var _35Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "35.circle") }
 
     /// 􀚞
     /// 3 Localizations, 3 Layersets
@@ -2573,7 +2573,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _35CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "35.circle.fill")
+    static var _35CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "35.circle.fill") }
 
     /// 􀛃
     /// 3 Localizations, 2 Layersets
@@ -2586,7 +2586,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _35Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "35.square")
+    static var _35Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "35.square") }
 
     /// 􀛄
     /// 3 Localizations, 3 Layersets
@@ -2600,7 +2600,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _35SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "35.square.fill")
+    static var _35SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "35.square.fill") }
 
     /// 􀚟
     /// 3 Localizations, 2 Layersets
@@ -2613,7 +2613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _36Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "36.circle")
+    static var _36Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "36.circle") }
 
     /// 􀚠
     /// 3 Localizations, 3 Layersets
@@ -2627,7 +2627,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _36CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "36.circle.fill")
+    static var _36CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "36.circle.fill") }
 
     /// 􀛅
     /// 3 Localizations, 2 Layersets
@@ -2640,7 +2640,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _36Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "36.square")
+    static var _36Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "36.square") }
 
     /// 􀛆
     /// 3 Localizations, 3 Layersets
@@ -2654,7 +2654,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _36SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "36.square.fill")
+    static var _36SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "36.square.fill") }
 
     /// 􀚡
     /// 3 Localizations, 2 Layersets
@@ -2667,7 +2667,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _37Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "37.circle")
+    static var _37Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "37.circle") }
 
     /// 􀚢
     /// 3 Localizations, 3 Layersets
@@ -2681,7 +2681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _37CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "37.circle.fill")
+    static var _37CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "37.circle.fill") }
 
     /// 􀛇
     /// 3 Localizations, 2 Layersets
@@ -2694,7 +2694,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _37Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "37.square")
+    static var _37Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "37.square") }
 
     /// 􀛈
     /// 3 Localizations, 3 Layersets
@@ -2708,7 +2708,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _37SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "37.square.fill")
+    static var _37SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "37.square.fill") }
 
     /// 􀚣
     /// 3 Localizations, 2 Layersets
@@ -2721,7 +2721,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _38Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "38.circle")
+    static var _38Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "38.circle") }
 
     /// 􀚤
     /// 3 Localizations, 3 Layersets
@@ -2735,7 +2735,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _38CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "38.circle.fill")
+    static var _38CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "38.circle.fill") }
 
     /// 􀛉
     /// 3 Localizations, 2 Layersets
@@ -2748,7 +2748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _38Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "38.square")
+    static var _38Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "38.square") }
 
     /// 􀛊
     /// 3 Localizations, 3 Layersets
@@ -2762,7 +2762,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _38SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "38.square.fill")
+    static var _38SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "38.square.fill") }
 
     /// 􀚥
     /// 3 Localizations, 2 Layersets
@@ -2775,7 +2775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _39Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "39.circle")
+    static var _39Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "39.circle") }
 
     /// 􀚦
     /// 3 Localizations, 3 Layersets
@@ -2789,7 +2789,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _39CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "39.circle.fill")
+    static var _39CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "39.circle.fill") }
 
     /// 􀛋
     /// 3 Localizations, 2 Layersets
@@ -2802,7 +2802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _39Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "39.square")
+    static var _39Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "39.square") }
 
     /// 􀛌
     /// 3 Localizations, 3 Layersets
@@ -2816,7 +2816,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _39SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "39.square.fill")
+    static var _39SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "39.square.fill") }
 
     /// 􀚧
     /// 3 Localizations, 2 Layersets
@@ -2829,7 +2829,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _40Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "40.circle")
+    static var _40Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "40.circle") }
 
     /// 􀚨
     /// 3 Localizations, 3 Layersets
@@ -2843,7 +2843,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _40CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "40.circle.fill")
+    static var _40CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "40.circle.fill") }
 
     /// 􀛍
     /// 3 Localizations, 2 Layersets
@@ -2856,7 +2856,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _40Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "40.square")
+    static var _40Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "40.square") }
 
     /// 􀛎
     /// 3 Localizations, 3 Layersets
@@ -2870,7 +2870,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _40SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "40.square.fill")
+    static var _40SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "40.square.fill") }
 
     /// 􀚩
     /// 3 Localizations, 2 Layersets
@@ -2883,7 +2883,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _41Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "41.circle")
+    static var _41Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "41.circle") }
 
     /// 􀚪
     /// 3 Localizations, 3 Layersets
@@ -2897,7 +2897,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _41CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "41.circle.fill")
+    static var _41CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "41.circle.fill") }
 
     /// 􀛏
     /// 3 Localizations, 2 Layersets
@@ -2910,7 +2910,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _41Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "41.square")
+    static var _41Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "41.square") }
 
     /// 􀛐
     /// 3 Localizations, 3 Layersets
@@ -2924,7 +2924,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _41SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "41.square.fill")
+    static var _41SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "41.square.fill") }
 
     /// 􀚫
     /// 3 Localizations, 2 Layersets
@@ -2937,7 +2937,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _42Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "42.circle")
+    static var _42Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "42.circle") }
 
     /// 􀚬
     /// 3 Localizations, 3 Layersets
@@ -2951,7 +2951,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _42CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "42.circle.fill")
+    static var _42CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "42.circle.fill") }
 
     /// 􀛑
     /// 3 Localizations, 2 Layersets
@@ -2964,7 +2964,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _42Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "42.square")
+    static var _42Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "42.square") }
 
     /// 􀛒
     /// 3 Localizations, 3 Layersets
@@ -2978,7 +2978,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _42SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "42.square.fill")
+    static var _42SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "42.square.fill") }
 
     /// 􀚭
     /// 3 Localizations, 2 Layersets
@@ -2991,7 +2991,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _43Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "43.circle")
+    static var _43Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "43.circle") }
 
     /// 􀚮
     /// 3 Localizations, 3 Layersets
@@ -3005,7 +3005,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _43CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "43.circle.fill")
+    static var _43CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "43.circle.fill") }
 
     /// 􀛓
     /// 3 Localizations, 2 Layersets
@@ -3018,7 +3018,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _43Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "43.square")
+    static var _43Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "43.square") }
 
     /// 􀛔
     /// 3 Localizations, 3 Layersets
@@ -3032,7 +3032,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _43SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "43.square.fill")
+    static var _43SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "43.square.fill") }
 
     /// 􀚯
     /// 3 Localizations, 2 Layersets
@@ -3045,7 +3045,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _44Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "44.circle")
+    static var _44Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "44.circle") }
 
     /// 􀚰
     /// 3 Localizations, 3 Layersets
@@ -3059,7 +3059,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _44CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "44.circle.fill")
+    static var _44CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "44.circle.fill") }
 
     /// 􀛕
     /// 3 Localizations, 2 Layersets
@@ -3072,7 +3072,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _44Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "44.square")
+    static var _44Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "44.square") }
 
     /// 􀛖
     /// 3 Localizations, 3 Layersets
@@ -3086,7 +3086,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _44SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "44.square.fill")
+    static var _44SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "44.square.fill") }
 
     /// 􀚱
     /// 3 Localizations, 2 Layersets
@@ -3099,7 +3099,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _45Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "45.circle")
+    static var _45Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "45.circle") }
 
     /// 􀚲
     /// 3 Localizations, 3 Layersets
@@ -3113,7 +3113,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _45CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "45.circle.fill")
+    static var _45CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "45.circle.fill") }
 
     /// 􀛗
     /// 3 Localizations, 2 Layersets
@@ -3126,7 +3126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _45Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "45.square")
+    static var _45Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "45.square") }
 
     /// 􀛘
     /// 3 Localizations, 3 Layersets
@@ -3140,7 +3140,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _45SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "45.square.fill")
+    static var _45SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "45.square.fill") }
 
     /// 􀚳
     /// 3 Localizations, 2 Layersets
@@ -3153,7 +3153,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _46Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "46.circle")
+    static var _46Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "46.circle") }
 
     /// 􀚴
     /// 3 Localizations, 3 Layersets
@@ -3167,7 +3167,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _46CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "46.circle.fill")
+    static var _46CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "46.circle.fill") }
 
     /// 􀛙
     /// 3 Localizations, 2 Layersets
@@ -3180,7 +3180,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _46Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "46.square")
+    static var _46Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "46.square") }
 
     /// 􀛚
     /// 3 Localizations, 3 Layersets
@@ -3194,7 +3194,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _46SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "46.square.fill")
+    static var _46SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "46.square.fill") }
 
     /// 􀚵
     /// 3 Localizations, 2 Layersets
@@ -3207,7 +3207,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _47Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "47.circle")
+    static var _47Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "47.circle") }
 
     /// 􀚶
     /// 3 Localizations, 3 Layersets
@@ -3221,7 +3221,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _47CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "47.circle.fill")
+    static var _47CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "47.circle.fill") }
 
     /// 􀛛
     /// 3 Localizations, 2 Layersets
@@ -3234,7 +3234,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _47Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "47.square")
+    static var _47Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "47.square") }
 
     /// 􀛜
     /// 3 Localizations, 3 Layersets
@@ -3248,7 +3248,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _47SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "47.square.fill")
+    static var _47SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "47.square.fill") }
 
     /// 􀚷
     /// 3 Localizations, 2 Layersets
@@ -3261,7 +3261,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _48Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "48.circle")
+    static var _48Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "48.circle") }
 
     /// 􀚸
     /// 3 Localizations, 3 Layersets
@@ -3275,7 +3275,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _48CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "48.circle.fill")
+    static var _48CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "48.circle.fill") }
 
     /// 􀛝
     /// 3 Localizations, 2 Layersets
@@ -3288,7 +3288,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _48Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "48.square")
+    static var _48Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "48.square") }
 
     /// 􀛞
     /// 3 Localizations, 3 Layersets
@@ -3302,7 +3302,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _48SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "48.square.fill")
+    static var _48SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "48.square.fill") }
 
     /// 􀚹
     /// 3 Localizations, 2 Layersets
@@ -3315,7 +3315,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _49Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "49.circle")
+    static var _49Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "49.circle") }
 
     /// 􀚺
     /// 3 Localizations, 3 Layersets
@@ -3329,7 +3329,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _49CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "49.circle.fill")
+    static var _49CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "49.circle.fill") }
 
     /// 􀛟
     /// 3 Localizations, 2 Layersets
@@ -3342,7 +3342,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _49Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "49.square")
+    static var _49Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "49.square") }
 
     /// 􀛠
     /// 3 Localizations, 3 Layersets
@@ -3356,7 +3356,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _49SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "49.square.fill")
+    static var _49SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "49.square.fill") }
 
     /// 􀚻
     /// 3 Localizations, 2 Layersets
@@ -3369,7 +3369,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _50Circle = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "50.circle")
+    static var _50Circle: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "50.circle") }
 
     /// 􀚼
     /// 3 Localizations, 3 Layersets
@@ -3383,7 +3383,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _50CircleFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "50.circle.fill")
+    static var _50CircleFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "50.circle.fill") }
 
     /// 􀛡
     /// 3 Localizations, 2 Layersets
@@ -3396,7 +3396,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _50Square = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "50.square")
+    static var _50Square: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "50.square") }
 
     /// 􀛢
     /// 3 Localizations, 3 Layersets
@@ -3410,7 +3410,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _50SquareFill = SymbolWith2Localizations<Ar_v5_2, Hi_v5_2>(rawValue: "50.square.fill")
+    static var _50SquareFill: SymbolWith2Localizations<Ar_v5_2, Hi_v5_2> { .init(rawValue: "50.square.fill") }
 
     /// 􀅏
     /// Single Localization, Single Layerset
@@ -3422,7 +3422,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.2, renamed: "character")
     @available(watchOS, introduced: 6.0, deprecated: 7.1, renamed: "character")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "character")
-    static let a = SFSymbol(rawValue: "a")
+    static var a: SFSymbol { .init(rawValue: "a") }
 
     /// 􀀄
     /// Single Localization, 2 Layersets
@@ -3430,7 +3430,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let aCircle = SFSymbol(rawValue: "a.circle")
+    static var aCircle: SFSymbol { .init(rawValue: "a.circle") }
 
     /// 􀀅
     /// Single Localization, 3 Layersets
@@ -3439,7 +3439,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let aCircleFill = SFSymbol(rawValue: "a.circle.fill")
+    static var aCircleFill: SFSymbol { .init(rawValue: "a.circle.fill") }
 
     /// 􀂔
     /// Single Localization, 2 Layersets
@@ -3447,7 +3447,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let aSquare = SFSymbol(rawValue: "a.square")
+    static var aSquare: SFSymbol { .init(rawValue: "a.square") }
 
     /// 􀂕
     /// Single Localization, 3 Layersets
@@ -3456,7 +3456,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let aSquareFill = SFSymbol(rawValue: "a.square.fill")
+    static var aSquareFill: SFSymbol { .init(rawValue: "a.square.fill") }
 
     /// 􀑓
     /// Single Localization, 2 Layersets
@@ -3464,7 +3464,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let airplane = SFSymbol(rawValue: "airplane")
+    static var airplane: SFSymbol { .init(rawValue: "airplane") }
 
     /// 􀑢
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3480,7 +3480,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "airplayAudio")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "airplayAudio")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayAudio")
-    static let airplayaudio = SFSymbol(rawValue: "airplayaudio")
+    static var airplayaudio: SFSymbol { .init(rawValue: "airplayaudio") }
 
     /// 􀑡
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3495,7 +3495,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "airplayVideo")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "airplayVideo")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayVideo")
-    static let airplayvideo = SFSymbol(rawValue: "airplayvideo")
+    static var airplayvideo: SFSymbol { .init(rawValue: "airplayvideo") }
 
     /// 􀐭
     /// Single Localization, 3 Layersets
@@ -3504,28 +3504,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let alarm = SFSymbol(rawValue: "alarm")
+    static var alarm: SFSymbol { .init(rawValue: "alarm") }
 
     /// 􀐮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let alarmFill = SFSymbol(rawValue: "alarm.fill")
+    static var alarmFill: SFSymbol { .init(rawValue: "alarm.fill") }
 
     /// 􀆖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let alt = SFSymbol(rawValue: "alt")
+    static var alt: SFSymbol { .init(rawValue: "alt") }
 
     /// 􀌚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ant = SFSymbol(rawValue: "ant")
+    static var ant: SFSymbol { .init(rawValue: "ant") }
 
     /// 􀌜
     /// Single Localization, 2 Layersets
@@ -3533,7 +3533,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let antCircle = SFSymbol(rawValue: "ant.circle")
+    static var antCircle: SFSymbol { .init(rawValue: "ant.circle") }
 
     /// 􀌝
     /// Single Localization, 3 Layersets
@@ -3542,14 +3542,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let antCircleFill = SFSymbol(rawValue: "ant.circle.fill")
+    static var antCircleFill: SFSymbol { .init(rawValue: "ant.circle.fill") }
 
     /// 􀌛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let antFill = SFSymbol(rawValue: "ant.fill")
+    static var antFill: SFSymbol { .init(rawValue: "ant.fill") }
 
     /// 􀖀
     /// Single Localization, 3 Layersets
@@ -3558,14 +3558,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let antennaRadiowavesLeftAndRight = SFSymbol(rawValue: "antenna.radiowaves.left.and.right")
+    static var antennaRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right") }
 
     /// 􀑋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let app = SFSymbol(rawValue: "app")
+    static var app: SFSymbol { .init(rawValue: "app") }
 
     /// 􀑏
     /// Single Localization, 3 Layersets
@@ -3574,7 +3574,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let appBadge = SFSymbol(rawValue: "app.badge")
+    static var appBadge: SFSymbol { .init(rawValue: "app.badge") }
 
     /// 􀑐
     /// Single Localization, 3 Layersets
@@ -3583,42 +3583,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let appBadgeFill = SFSymbol(rawValue: "app.badge.fill")
+    static var appBadgeFill: SFSymbol { .init(rawValue: "app.badge.fill") }
 
     /// 􀑌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appFill = SFSymbol(rawValue: "app.fill")
+    static var appFill: SFSymbol { .init(rawValue: "app.fill") }
 
     /// 􀑑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appGift = SFSymbol(rawValue: "app.gift")
+    static var appGift: SFSymbol { .init(rawValue: "app.gift") }
 
     /// 􀑒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appGiftFill = SFSymbol(rawValue: "app.gift.fill")
+    static var appGiftFill: SFSymbol { .init(rawValue: "app.gift.fill") }
 
     /// 􀈭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let archivebox = SFSymbol(rawValue: "archivebox")
+    static var archivebox: SFSymbol { .init(rawValue: "archivebox") }
 
     /// 􀈮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let archiveboxFill = SFSymbol(rawValue: "archivebox.fill")
+    static var archiveboxFill: SFSymbol { .init(rawValue: "archivebox.fill") }
 
     /// 􀘸
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3627,7 +3627,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s ARKit.
-    static let arkit = SFSymbol(rawValue: "arkit")
+    static var arkit: SFSymbol { .init(rawValue: "arkit") }
 
     /// 􀊯
     /// Single Localization, Single Layerset
@@ -3639,7 +3639,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangle2Circlepath")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangle2Circlepath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangle2Circlepath")
-    static let arrow2Circlepath = SFSymbol(rawValue: "arrow.2.circlepath")
+    static var arrow2Circlepath: SFSymbol { .init(rawValue: "arrow.2.circlepath") }
 
     /// 􀖊
     /// Single Localization, Single Layerset
@@ -3651,7 +3651,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangle2CirclepathCircle")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangle2CirclepathCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangle2CirclepathCircle")
-    static let arrow2CirclepathCircle = SFSymbol(rawValue: "arrow.2.circlepath.circle")
+    static var arrow2CirclepathCircle: SFSymbol { .init(rawValue: "arrow.2.circlepath.circle") }
 
     /// 􀖋
     /// Single Localization, Single Layerset
@@ -3663,21 +3663,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangle2CirclepathCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangle2CirclepathCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangle2CirclepathCircleFill")
-    static let arrow2CirclepathCircleFill = SFSymbol(rawValue: "arrow.2.circlepath.circle.fill")
+    static var arrow2CirclepathCircleFill: SFSymbol { .init(rawValue: "arrow.2.circlepath.circle.fill") }
 
     /// 􀅌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrow2Squarepath = SFSymbol(rawValue: "arrow.2.squarepath")
+    static var arrow2Squarepath: SFSymbol { .init(rawValue: "arrow.2.squarepath") }
 
     /// 􀙛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrow3Trianglepath = SFSymbol(rawValue: "arrow.3.trianglepath")
+    static var arrow3Trianglepath: SFSymbol { .init(rawValue: "arrow.3.trianglepath") }
 
     /// 􀙠
     /// Single Localization, Single Layerset
@@ -3689,14 +3689,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangleBranch")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangleBranch")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangleBranch")
-    static let arrowBranch = SFSymbol(rawValue: "arrow.branch")
+    static var arrowBranch: SFSymbol { .init(rawValue: "arrow.branch") }
 
     /// 􀅈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowClockwise = SFSymbol(rawValue: "arrow.clockwise")
+    static var arrowClockwise: SFSymbol { .init(rawValue: "arrow.clockwise") }
 
     /// 􀚁
     /// Single Localization, 2 Layersets
@@ -3704,7 +3704,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowClockwiseCircle = SFSymbol(rawValue: "arrow.clockwise.circle")
+    static var arrowClockwiseCircle: SFSymbol { .init(rawValue: "arrow.clockwise.circle") }
 
     /// 􀚂
     /// Single Localization, 3 Layersets
@@ -3713,7 +3713,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowClockwiseCircleFill = SFSymbol(rawValue: "arrow.clockwise.circle.fill")
+    static var arrowClockwiseCircleFill: SFSymbol { .init(rawValue: "arrow.clockwise.circle.fill") }
 
     /// 􀙷
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3728,7 +3728,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadClockwiseIcloud")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadClockwiseIcloud")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadClockwiseIcloud")
-    static let arrowClockwiseIcloud = SFSymbol(rawValue: "arrow.clockwise.icloud")
+    static var arrowClockwiseIcloud: SFSymbol { .init(rawValue: "arrow.clockwise.icloud") }
 
     /// 􀙸
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3744,14 +3744,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadClockwiseIcloudFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadClockwiseIcloudFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadClockwiseIcloudFill")
-    static let arrowClockwiseIcloudFill = SFSymbol(rawValue: "arrow.clockwise.icloud.fill")
+    static var arrowClockwiseIcloudFill: SFSymbol { .init(rawValue: "arrow.clockwise.icloud.fill") }
 
     /// 􀅉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowCounterclockwise = SFSymbol(rawValue: "arrow.counterclockwise")
+    static var arrowCounterclockwise: SFSymbol { .init(rawValue: "arrow.counterclockwise") }
 
     /// 􀚃
     /// Single Localization, 2 Layersets
@@ -3759,7 +3759,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowCounterclockwiseCircle = SFSymbol(rawValue: "arrow.counterclockwise.circle")
+    static var arrowCounterclockwiseCircle: SFSymbol { .init(rawValue: "arrow.counterclockwise.circle") }
 
     /// 􀚄
     /// Single Localization, 3 Layersets
@@ -3768,7 +3768,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowCounterclockwiseCircleFill = SFSymbol(rawValue: "arrow.counterclockwise.circle.fill")
+    static var arrowCounterclockwiseCircleFill: SFSymbol { .init(rawValue: "arrow.counterclockwise.circle.fill") }
 
     /// 􀙹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3783,7 +3783,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadCounterclockwiseIcloud")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadCounterclockwiseIcloud")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadCounterclockwiseIcloud")
-    static let arrowCounterclockwiseIcloud = SFSymbol(rawValue: "arrow.counterclockwise.icloud")
+    static var arrowCounterclockwiseIcloud: SFSymbol { .init(rawValue: "arrow.counterclockwise.icloud") }
 
     /// 􀙺
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3799,14 +3799,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadCounterclockwiseIcloudFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadCounterclockwiseIcloudFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadCounterclockwiseIcloudFill")
-    static let arrowCounterclockwiseIcloudFill = SFSymbol(rawValue: "arrow.counterclockwise.icloud.fill")
+    static var arrowCounterclockwiseIcloudFill: SFSymbol { .init(rawValue: "arrow.counterclockwise.icloud.fill") }
 
     /// 􀄩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDown = SFSymbol(rawValue: "arrow.down")
+    static var arrowDown: SFSymbol { .init(rawValue: "arrow.down") }
 
     /// 􀁸
     /// Single Localization, 2 Layersets
@@ -3814,7 +3814,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownCircle = SFSymbol(rawValue: "arrow.down.circle")
+    static var arrowDownCircle: SFSymbol { .init(rawValue: "arrow.down.circle") }
 
     /// 􀁹
     /// Single Localization, 3 Layersets
@@ -3823,7 +3823,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownCircleFill = SFSymbol(rawValue: "arrow.down.circle.fill")
+    static var arrowDownCircleFill: SFSymbol { .init(rawValue: "arrow.down.circle.fill") }
 
     /// 􀈽
     /// Single Localization, 2 Layersets
@@ -3836,7 +3836,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowDownDocument")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowDownDocument")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowDownDocument")
-    static let arrowDownDoc = SFSymbol(rawValue: "arrow.down.doc")
+    static var arrowDownDoc: SFSymbol { .init(rawValue: "arrow.down.doc") }
 
     /// 􀈾
     /// Single Localization, 3 Layersets
@@ -3850,14 +3850,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowDownDocumentFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowDownDocumentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowDownDocumentFill")
-    static let arrowDownDocFill = SFSymbol(rawValue: "arrow.down.doc.fill")
+    static var arrowDownDocFill: SFSymbol { .init(rawValue: "arrow.down.doc.fill") }
 
     /// 􀄰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownLeft = SFSymbol(rawValue: "arrow.down.left")
+    static var arrowDownLeft: SFSymbol { .init(rawValue: "arrow.down.left") }
 
     /// 􀂆
     /// Single Localization, 2 Layersets
@@ -3865,7 +3865,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownLeftCircle = SFSymbol(rawValue: "arrow.down.left.circle")
+    static var arrowDownLeftCircle: SFSymbol { .init(rawValue: "arrow.down.left.circle") }
 
     /// 􀂇
     /// Single Localization, 3 Layersets
@@ -3874,7 +3874,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownLeftCircleFill = SFSymbol(rawValue: "arrow.down.left.circle.fill")
+    static var arrowDownLeftCircleFill: SFSymbol { .init(rawValue: "arrow.down.left.circle.fill") }
 
     /// 􀄖
     /// Single Localization, 2 Layersets
@@ -3882,7 +3882,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownLeftSquare = SFSymbol(rawValue: "arrow.down.left.square")
+    static var arrowDownLeftSquare: SFSymbol { .init(rawValue: "arrow.down.left.square") }
 
     /// 􀄗
     /// Single Localization, 3 Layersets
@@ -3891,7 +3891,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownLeftSquareFill = SFSymbol(rawValue: "arrow.down.left.square.fill")
+    static var arrowDownLeftSquareFill: SFSymbol { .init(rawValue: "arrow.down.left.square.fill") }
 
     /// 􀍑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3901,7 +3901,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let arrowDownLeftVideo = SFSymbol(rawValue: "arrow.down.left.video")
+    static var arrowDownLeftVideo: SFSymbol { .init(rawValue: "arrow.down.left.video") }
 
     /// 􀍒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3912,21 +3912,21 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let arrowDownLeftVideoFill = SFSymbol(rawValue: "arrow.down.left.video.fill")
+    static var arrowDownLeftVideoFill: SFSymbol { .init(rawValue: "arrow.down.left.video.fill") }
 
     /// 􀄱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownRight = SFSymbol(rawValue: "arrow.down.right")
+    static var arrowDownRight: SFSymbol { .init(rawValue: "arrow.down.right") }
 
     /// 􀅋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownRightAndArrowUpLeft = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left")
+    static var arrowDownRightAndArrowUpLeft: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left") }
 
     /// 􀂈
     /// Single Localization, 2 Layersets
@@ -3934,7 +3934,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownRightCircle = SFSymbol(rawValue: "arrow.down.right.circle")
+    static var arrowDownRightCircle: SFSymbol { .init(rawValue: "arrow.down.right.circle") }
 
     /// 􀂉
     /// Single Localization, 3 Layersets
@@ -3943,7 +3943,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownRightCircleFill = SFSymbol(rawValue: "arrow.down.right.circle.fill")
+    static var arrowDownRightCircleFill: SFSymbol { .init(rawValue: "arrow.down.right.circle.fill") }
 
     /// 􀄘
     /// Single Localization, 2 Layersets
@@ -3951,7 +3951,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownRightSquare = SFSymbol(rawValue: "arrow.down.right.square")
+    static var arrowDownRightSquare: SFSymbol { .init(rawValue: "arrow.down.right.square") }
 
     /// 􀄙
     /// Single Localization, 3 Layersets
@@ -3960,7 +3960,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownRightSquareFill = SFSymbol(rawValue: "arrow.down.right.square.fill")
+    static var arrowDownRightSquareFill: SFSymbol { .init(rawValue: "arrow.down.right.square.fill") }
 
     /// 􀄈
     /// Single Localization, 2 Layersets
@@ -3968,7 +3968,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownSquare = SFSymbol(rawValue: "arrow.down.square")
+    static var arrowDownSquare: SFSymbol { .init(rawValue: "arrow.down.square") }
 
     /// 􀄉
     /// Single Localization, 3 Layersets
@@ -3977,14 +3977,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownSquareFill = SFSymbol(rawValue: "arrow.down.square.fill")
+    static var arrowDownSquareFill: SFSymbol { .init(rawValue: "arrow.down.square.fill") }
 
     /// 􀅀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownToLine = SFSymbol(rawValue: "arrow.down.to.line")
+    static var arrowDownToLine: SFSymbol { .init(rawValue: "arrow.down.to.line") }
 
     /// 􀅄
     /// Single Localization, Single Layerset
@@ -3996,21 +3996,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "arrowDownToLineCompact")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "arrowDownToLineCompact")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowDownToLineCompact")
-    static let arrowDownToLineAlt = SFSymbol(rawValue: "arrow.down.to.line.alt")
+    static var arrowDownToLineAlt: SFSymbol { .init(rawValue: "arrow.down.to.line.alt") }
 
     /// 􀄪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowLeft = SFSymbol(rawValue: "arrow.left")
+    static var arrowLeft: SFSymbol { .init(rawValue: "arrow.left") }
 
     /// 􀄾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowLeftAndRight = SFSymbol(rawValue: "arrow.left.and.right")
+    static var arrowLeftAndRight: SFSymbol { .init(rawValue: "arrow.left.and.right") }
 
     /// 􀑾
     /// Single Localization, 2 Layersets
@@ -4018,7 +4018,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftAndRightCircle = SFSymbol(rawValue: "arrow.left.and.right.circle")
+    static var arrowLeftAndRightCircle: SFSymbol { .init(rawValue: "arrow.left.and.right.circle") }
 
     /// 􀑿
     /// Single Localization, 3 Layersets
@@ -4027,7 +4027,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftAndRightCircleFill = SFSymbol(rawValue: "arrow.left.and.right.circle.fill")
+    static var arrowLeftAndRightCircleFill: SFSymbol { .init(rawValue: "arrow.left.and.right.circle.fill") }
 
     /// 􀒀
     /// Single Localization, 2 Layersets
@@ -4035,7 +4035,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftAndRightSquare = SFSymbol(rawValue: "arrow.left.and.right.square")
+    static var arrowLeftAndRightSquare: SFSymbol { .init(rawValue: "arrow.left.and.right.square") }
 
     /// 􀒁
     /// Single Localization, 3 Layersets
@@ -4044,7 +4044,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowLeftAndRightSquareFill = SFSymbol(rawValue: "arrow.left.and.right.square.fill")
+    static var arrowLeftAndRightSquareFill: SFSymbol { .init(rawValue: "arrow.left.and.right.square.fill") }
 
     /// 􀁺
     /// Single Localization, 2 Layersets
@@ -4052,7 +4052,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftCircle = SFSymbol(rawValue: "arrow.left.circle")
+    static var arrowLeftCircle: SFSymbol { .init(rawValue: "arrow.left.circle") }
 
     /// 􀁻
     /// Single Localization, 3 Layersets
@@ -4061,7 +4061,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftCircleFill = SFSymbol(rawValue: "arrow.left.circle.fill")
+    static var arrowLeftCircleFill: SFSymbol { .init(rawValue: "arrow.left.circle.fill") }
 
     /// 􀄊
     /// Single Localization, 2 Layersets
@@ -4069,7 +4069,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftSquare = SFSymbol(rawValue: "arrow.left.square")
+    static var arrowLeftSquare: SFSymbol { .init(rawValue: "arrow.left.square") }
 
     /// 􀄋
     /// Single Localization, 3 Layersets
@@ -4078,14 +4078,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowLeftSquareFill = SFSymbol(rawValue: "arrow.left.square.fill")
+    static var arrowLeftSquareFill: SFSymbol { .init(rawValue: "arrow.left.square.fill") }
 
     /// 􀅁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowLeftToLine = SFSymbol(rawValue: "arrow.left.to.line")
+    static var arrowLeftToLine: SFSymbol { .init(rawValue: "arrow.left.to.line") }
 
     /// 􀅅
     /// Single Localization, Single Layerset
@@ -4097,7 +4097,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "arrowLeftToLineCompact")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "arrowLeftToLineCompact")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftToLineCompact")
-    static let arrowLeftToLineAlt = SFSymbol(rawValue: "arrow.left.to.line.alt")
+    static var arrowLeftToLineAlt: SFSymbol { .init(rawValue: "arrow.left.to.line.alt") }
 
     /// 􀖄
     /// Single Localization, Single Layerset
@@ -4109,14 +4109,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangleMerge")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangleMerge")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangleMerge")
-    static let arrowMerge = SFSymbol(rawValue: "arrow.merge")
+    static var arrowMerge: SFSymbol { .init(rawValue: "arrow.merge") }
 
     /// 􀄫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowRight = SFSymbol(rawValue: "arrow.right")
+    static var arrowRight: SFSymbol { .init(rawValue: "arrow.right") }
 
     /// 􀄭
     /// Single Localization, 2 Layersets
@@ -4129,7 +4129,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftArrowRight")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowLeftArrowRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftArrowRight")
-    static let arrowRightArrowLeft = SFSymbol(rawValue: "arrow.right.arrow.left")
+    static var arrowRightArrowLeft: SFSymbol { .init(rawValue: "arrow.right.arrow.left") }
 
     /// 􀂀
     /// Single Localization, 2 Layersets
@@ -4142,7 +4142,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftArrowRightCircle")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowLeftArrowRightCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftArrowRightCircle")
-    static let arrowRightArrowLeftCircle = SFSymbol(rawValue: "arrow.right.arrow.left.circle")
+    static var arrowRightArrowLeftCircle: SFSymbol { .init(rawValue: "arrow.right.arrow.left.circle") }
 
     /// 􀂁
     /// Single Localization, 3 Layersets
@@ -4156,7 +4156,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftArrowRightCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowLeftArrowRightCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftArrowRightCircleFill")
-    static let arrowRightArrowLeftCircleFill = SFSymbol(rawValue: "arrow.right.arrow.left.circle.fill")
+    static var arrowRightArrowLeftCircleFill: SFSymbol { .init(rawValue: "arrow.right.arrow.left.circle.fill") }
 
     /// 􀄐
     /// Single Localization, 2 Layersets
@@ -4169,7 +4169,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftArrowRightSquare")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowLeftArrowRightSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftArrowRightSquare")
-    static let arrowRightArrowLeftSquare = SFSymbol(rawValue: "arrow.right.arrow.left.square")
+    static var arrowRightArrowLeftSquare: SFSymbol { .init(rawValue: "arrow.right.arrow.left.square") }
 
     /// 􀄑
     /// Single Localization, 3 Layersets
@@ -4183,7 +4183,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftArrowRightSquareFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowLeftArrowRightSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftArrowRightSquareFill")
-    static let arrowRightArrowLeftSquareFill = SFSymbol(rawValue: "arrow.right.arrow.left.square.fill")
+    static var arrowRightArrowLeftSquareFill: SFSymbol { .init(rawValue: "arrow.right.arrow.left.square.fill") }
 
     /// 􀁼
     /// Single Localization, 2 Layersets
@@ -4191,7 +4191,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowRightCircle = SFSymbol(rawValue: "arrow.right.circle")
+    static var arrowRightCircle: SFSymbol { .init(rawValue: "arrow.right.circle") }
 
     /// 􀁽
     /// Single Localization, 3 Layersets
@@ -4200,7 +4200,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowRightCircleFill = SFSymbol(rawValue: "arrow.right.circle.fill")
+    static var arrowRightCircleFill: SFSymbol { .init(rawValue: "arrow.right.circle.fill") }
 
     /// 􀄌
     /// Single Localization, 2 Layersets
@@ -4208,7 +4208,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowRightSquare = SFSymbol(rawValue: "arrow.right.square")
+    static var arrowRightSquare: SFSymbol { .init(rawValue: "arrow.right.square") }
 
     /// 􀄍
     /// Single Localization, 3 Layersets
@@ -4217,14 +4217,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowRightSquareFill = SFSymbol(rawValue: "arrow.right.square.fill")
+    static var arrowRightSquareFill: SFSymbol { .init(rawValue: "arrow.right.square.fill") }
 
     /// 􀅂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowRightToLine = SFSymbol(rawValue: "arrow.right.to.line")
+    static var arrowRightToLine: SFSymbol { .init(rawValue: "arrow.right.to.line") }
 
     /// 􀅆
     /// Single Localization, Single Layerset
@@ -4236,7 +4236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "arrowRightToLineCompact")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "arrowRightToLineCompact")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowRightToLineCompact")
-    static let arrowRightToLineAlt = SFSymbol(rawValue: "arrow.right.to.line.alt")
+    static var arrowRightToLineAlt: SFSymbol { .init(rawValue: "arrow.right.to.line.alt") }
 
     /// 􀖅
     /// Single Localization, Single Layerset
@@ -4248,77 +4248,77 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangleSwap")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangleSwap")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangleSwap")
-    static let arrowSwap = SFSymbol(rawValue: "arrow.swap")
+    static var arrowSwap: SFSymbol { .init(rawValue: "arrow.swap") }
 
     /// 􀄴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnDownLeft = SFSymbol(rawValue: "arrow.turn.down.left")
+    static var arrowTurnDownLeft: SFSymbol { .init(rawValue: "arrow.turn.down.left") }
 
     /// 􀄵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnDownRight = SFSymbol(rawValue: "arrow.turn.down.right")
+    static var arrowTurnDownRight: SFSymbol { .init(rawValue: "arrow.turn.down.right") }
 
     /// 􀄷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnLeftDown = SFSymbol(rawValue: "arrow.turn.left.down")
+    static var arrowTurnLeftDown: SFSymbol { .init(rawValue: "arrow.turn.left.down") }
 
     /// 􀄶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnLeftUp = SFSymbol(rawValue: "arrow.turn.left.up")
+    static var arrowTurnLeftUp: SFSymbol { .init(rawValue: "arrow.turn.left.up") }
 
     /// 􀄳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnRightDown = SFSymbol(rawValue: "arrow.turn.right.down")
+    static var arrowTurnRightDown: SFSymbol { .init(rawValue: "arrow.turn.right.down") }
 
     /// 􀄲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnRightUp = SFSymbol(rawValue: "arrow.turn.right.up")
+    static var arrowTurnRightUp: SFSymbol { .init(rawValue: "arrow.turn.right.up") }
 
     /// 􀄸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnUpLeft = SFSymbol(rawValue: "arrow.turn.up.left")
+    static var arrowTurnUpLeft: SFSymbol { .init(rawValue: "arrow.turn.up.left") }
 
     /// 􀄹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTurnUpRight = SFSymbol(rawValue: "arrow.turn.up.right")
+    static var arrowTurnUpRight: SFSymbol { .init(rawValue: "arrow.turn.up.right") }
 
     /// 􀄨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUp = SFSymbol(rawValue: "arrow.up")
+    static var arrowUp: SFSymbol { .init(rawValue: "arrow.up") }
 
     /// 􀑹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpAndDown = SFSymbol(rawValue: "arrow.up.and.down")
+    static var arrowUpAndDown: SFSymbol { .init(rawValue: "arrow.up.and.down") }
 
     /// 􀑺
     /// Single Localization, 2 Layersets
@@ -4326,7 +4326,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndDownCircle = SFSymbol(rawValue: "arrow.up.and.down.circle")
+    static var arrowUpAndDownCircle: SFSymbol { .init(rawValue: "arrow.up.and.down.circle") }
 
     /// 􀑻
     /// Single Localization, 3 Layersets
@@ -4335,7 +4335,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndDownCircleFill = SFSymbol(rawValue: "arrow.up.and.down.circle.fill")
+    static var arrowUpAndDownCircleFill: SFSymbol { .init(rawValue: "arrow.up.and.down.circle.fill") }
 
     /// 􀑼
     /// Single Localization, 2 Layersets
@@ -4343,7 +4343,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndDownSquare = SFSymbol(rawValue: "arrow.up.and.down.square")
+    static var arrowUpAndDownSquare: SFSymbol { .init(rawValue: "arrow.up.and.down.square") }
 
     /// 􀑽
     /// Single Localization, 3 Layersets
@@ -4352,7 +4352,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpAndDownSquareFill = SFSymbol(rawValue: "arrow.up.and.down.square.fill")
+    static var arrowUpAndDownSquareFill: SFSymbol { .init(rawValue: "arrow.up.and.down.square.fill") }
 
     /// 􀄬
     /// Single Localization, 2 Layersets
@@ -4360,7 +4360,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowUpArrowDown = SFSymbol(rawValue: "arrow.up.arrow.down")
+    static var arrowUpArrowDown: SFSymbol { .init(rawValue: "arrow.up.arrow.down") }
 
     /// 􀁾
     /// Single Localization, 2 Layersets
@@ -4368,7 +4368,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpArrowDownCircle = SFSymbol(rawValue: "arrow.up.arrow.down.circle")
+    static var arrowUpArrowDownCircle: SFSymbol { .init(rawValue: "arrow.up.arrow.down.circle") }
 
     /// 􀁿
     /// Single Localization, 3 Layersets
@@ -4377,7 +4377,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpArrowDownCircleFill = SFSymbol(rawValue: "arrow.up.arrow.down.circle.fill")
+    static var arrowUpArrowDownCircleFill: SFSymbol { .init(rawValue: "arrow.up.arrow.down.circle.fill") }
 
     /// 􀄎
     /// Single Localization, 2 Layersets
@@ -4385,7 +4385,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpArrowDownSquare = SFSymbol(rawValue: "arrow.up.arrow.down.square")
+    static var arrowUpArrowDownSquare: SFSymbol { .init(rawValue: "arrow.up.arrow.down.square") }
 
     /// 􀄏
     /// Single Localization, 3 Layersets
@@ -4394,7 +4394,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpArrowDownSquareFill = SFSymbol(rawValue: "arrow.up.arrow.down.square.fill")
+    static var arrowUpArrowDownSquareFill: SFSymbol { .init(rawValue: "arrow.up.arrow.down.square.fill") }
 
     /// 􀈵
     /// Single Localization, 2 Layersets
@@ -4402,7 +4402,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBin = SFSymbol(rawValue: "arrow.up.bin")
+    static var arrowUpBin: SFSymbol { .init(rawValue: "arrow.up.bin") }
 
     /// 􀈶
     /// Single Localization, 3 Layersets
@@ -4411,7 +4411,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpBinFill = SFSymbol(rawValue: "arrow.up.bin.fill")
+    static var arrowUpBinFill: SFSymbol { .init(rawValue: "arrow.up.bin.fill") }
 
     /// 􀁶
     /// Single Localization, 2 Layersets
@@ -4419,7 +4419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpCircle = SFSymbol(rawValue: "arrow.up.circle")
+    static var arrowUpCircle: SFSymbol { .init(rawValue: "arrow.up.circle") }
 
     /// 􀁷
     /// Single Localization, 3 Layersets
@@ -4428,7 +4428,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpCircleFill = SFSymbol(rawValue: "arrow.up.circle.fill")
+    static var arrowUpCircleFill: SFSymbol { .init(rawValue: "arrow.up.circle.fill") }
 
     /// 􀈻
     /// Single Localization, 2 Layersets
@@ -4441,7 +4441,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowUpDocument")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowUpDocument")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowUpDocument")
-    static let arrowUpDoc = SFSymbol(rawValue: "arrow.up.doc")
+    static var arrowUpDoc: SFSymbol { .init(rawValue: "arrow.up.doc") }
 
     /// 􀈼
     /// Single Localization, 3 Layersets
@@ -4455,21 +4455,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowUpDocumentFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowUpDocumentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowUpDocumentFill")
-    static let arrowUpDocFill = SFSymbol(rawValue: "arrow.up.doc.fill")
+    static var arrowUpDocFill: SFSymbol { .init(rawValue: "arrow.up.doc.fill") }
 
     /// 􀄮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpLeft = SFSymbol(rawValue: "arrow.up.left")
+    static var arrowUpLeft: SFSymbol { .init(rawValue: "arrow.up.left") }
 
     /// 􀅊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpLeftAndArrowDownRight = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right")
+    static var arrowUpLeftAndArrowDownRight: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right") }
 
     /// 􀂂
     /// Single Localization, 2 Layersets
@@ -4477,7 +4477,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpLeftCircle = SFSymbol(rawValue: "arrow.up.left.circle")
+    static var arrowUpLeftCircle: SFSymbol { .init(rawValue: "arrow.up.left.circle") }
 
     /// 􀂃
     /// Single Localization, 3 Layersets
@@ -4486,7 +4486,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpLeftCircleFill = SFSymbol(rawValue: "arrow.up.left.circle.fill")
+    static var arrowUpLeftCircleFill: SFSymbol { .init(rawValue: "arrow.up.left.circle.fill") }
 
     /// 􀄒
     /// Single Localization, 2 Layersets
@@ -4494,7 +4494,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpLeftSquare = SFSymbol(rawValue: "arrow.up.left.square")
+    static var arrowUpLeftSquare: SFSymbol { .init(rawValue: "arrow.up.left.square") }
 
     /// 􀄓
     /// Single Localization, 3 Layersets
@@ -4503,14 +4503,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpLeftSquareFill = SFSymbol(rawValue: "arrow.up.left.square.fill")
+    static var arrowUpLeftSquareFill: SFSymbol { .init(rawValue: "arrow.up.left.square.fill") }
 
     /// 􀄯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpRight = SFSymbol(rawValue: "arrow.up.right")
+    static var arrowUpRight: SFSymbol { .init(rawValue: "arrow.up.right") }
 
     /// 􀂄
     /// Single Localization, 2 Layersets
@@ -4518,7 +4518,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpRightCircle = SFSymbol(rawValue: "arrow.up.right.circle")
+    static var arrowUpRightCircle: SFSymbol { .init(rawValue: "arrow.up.right.circle") }
 
     /// 􀂅
     /// Single Localization, 3 Layersets
@@ -4527,7 +4527,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpRightCircleFill = SFSymbol(rawValue: "arrow.up.right.circle.fill")
+    static var arrowUpRightCircleFill: SFSymbol { .init(rawValue: "arrow.up.right.circle.fill") }
 
     /// 􀙞
     /// Single Localization, Single Layerset
@@ -4539,7 +4539,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangleTurnUpRightDiamond")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangleTurnUpRightDiamond")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangleTurnUpRightDiamond")
-    static let arrowUpRightDiamond = SFSymbol(rawValue: "arrow.up.right.diamond")
+    static var arrowUpRightDiamond: SFSymbol { .init(rawValue: "arrow.up.right.diamond") }
 
     /// 􀙟
     /// Single Localization, Single Layerset
@@ -4551,7 +4551,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangleTurnUpRightDiamondFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangleTurnUpRightDiamondFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangleTurnUpRightDiamondFill")
-    static let arrowUpRightDiamondFill = SFSymbol(rawValue: "arrow.up.right.diamond.fill")
+    static var arrowUpRightDiamondFill: SFSymbol { .init(rawValue: "arrow.up.right.diamond.fill") }
 
     /// 􀄔
     /// Single Localization, 2 Layersets
@@ -4559,7 +4559,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpRightSquare = SFSymbol(rawValue: "arrow.up.right.square")
+    static var arrowUpRightSquare: SFSymbol { .init(rawValue: "arrow.up.right.square") }
 
     /// 􀄕
     /// Single Localization, 3 Layersets
@@ -4568,7 +4568,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpRightSquareFill = SFSymbol(rawValue: "arrow.up.right.square.fill")
+    static var arrowUpRightSquareFill: SFSymbol { .init(rawValue: "arrow.up.right.square.fill") }
 
     /// 􀍏
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4578,7 +4578,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let arrowUpRightVideo = SFSymbol(rawValue: "arrow.up.right.video")
+    static var arrowUpRightVideo: SFSymbol { .init(rawValue: "arrow.up.right.video") }
 
     /// 􀍐
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4589,7 +4589,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let arrowUpRightVideoFill = SFSymbol(rawValue: "arrow.up.right.video.fill")
+    static var arrowUpRightVideoFill: SFSymbol { .init(rawValue: "arrow.up.right.video.fill") }
 
     /// 􀄆
     /// Single Localization, 2 Layersets
@@ -4597,7 +4597,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpSquare = SFSymbol(rawValue: "arrow.up.square")
+    static var arrowUpSquare: SFSymbol { .init(rawValue: "arrow.up.square") }
 
     /// 􀄇
     /// Single Localization, 3 Layersets
@@ -4606,14 +4606,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpSquareFill = SFSymbol(rawValue: "arrow.up.square.fill")
+    static var arrowUpSquareFill: SFSymbol { .init(rawValue: "arrow.up.square.fill") }
 
     /// 􀄿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpToLine = SFSymbol(rawValue: "arrow.up.to.line")
+    static var arrowUpToLine: SFSymbol { .init(rawValue: "arrow.up.to.line") }
 
     /// 􀅃
     /// Single Localization, Single Layerset
@@ -4625,14 +4625,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "arrowUpToLineCompact")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "arrowUpToLineCompact")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowUpToLineCompact")
-    static let arrowUpToLineAlt = SFSymbol(rawValue: "arrow.up.to.line.alt")
+    static var arrowUpToLineAlt: SFSymbol { .init(rawValue: "arrow.up.to.line.alt") }
 
     /// 􀄻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnDown = SFSymbol(rawValue: "arrow.uturn.down")
+    static var arrowUturnDown: SFSymbol { .init(rawValue: "arrow.uturn.down") }
 
     /// 􀂌
     /// Single Localization, 2 Layersets
@@ -4640,7 +4640,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnDownCircle = SFSymbol(rawValue: "arrow.uturn.down.circle")
+    static var arrowUturnDownCircle: SFSymbol { .init(rawValue: "arrow.uturn.down.circle") }
 
     /// 􀂍
     /// Single Localization, 3 Layersets
@@ -4649,7 +4649,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnDownCircleFill = SFSymbol(rawValue: "arrow.uturn.down.circle.fill")
+    static var arrowUturnDownCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.down.circle.fill") }
 
     /// 􀄜
     /// Single Localization, 2 Layersets
@@ -4657,7 +4657,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnDownSquare = SFSymbol(rawValue: "arrow.uturn.down.square")
+    static var arrowUturnDownSquare: SFSymbol { .init(rawValue: "arrow.uturn.down.square") }
 
     /// 􀄝
     /// Single Localization, 3 Layersets
@@ -4666,14 +4666,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnDownSquareFill = SFSymbol(rawValue: "arrow.uturn.down.square.fill")
+    static var arrowUturnDownSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.down.square.fill") }
 
     /// 􀄼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnLeft = SFSymbol(rawValue: "arrow.uturn.left")
+    static var arrowUturnLeft: SFSymbol { .init(rawValue: "arrow.uturn.left") }
 
     /// 􀂎
     /// Single Localization, 2 Layersets
@@ -4681,7 +4681,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnLeftCircle = SFSymbol(rawValue: "arrow.uturn.left.circle")
+    static var arrowUturnLeftCircle: SFSymbol { .init(rawValue: "arrow.uturn.left.circle") }
 
     /// 􀂏
     /// Single Localization, 3 Layersets
@@ -4690,7 +4690,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnLeftCircleFill = SFSymbol(rawValue: "arrow.uturn.left.circle.fill")
+    static var arrowUturnLeftCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.left.circle.fill") }
 
     /// 􀄞
     /// Single Localization, 2 Layersets
@@ -4698,7 +4698,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnLeftSquare = SFSymbol(rawValue: "arrow.uturn.left.square")
+    static var arrowUturnLeftSquare: SFSymbol { .init(rawValue: "arrow.uturn.left.square") }
 
     /// 􀄟
     /// Single Localization, 3 Layersets
@@ -4707,14 +4707,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnLeftSquareFill = SFSymbol(rawValue: "arrow.uturn.left.square.fill")
+    static var arrowUturnLeftSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.left.square.fill") }
 
     /// 􀄽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnRight = SFSymbol(rawValue: "arrow.uturn.right")
+    static var arrowUturnRight: SFSymbol { .init(rawValue: "arrow.uturn.right") }
 
     /// 􀂐
     /// Single Localization, 2 Layersets
@@ -4722,7 +4722,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnRightCircle = SFSymbol(rawValue: "arrow.uturn.right.circle")
+    static var arrowUturnRightCircle: SFSymbol { .init(rawValue: "arrow.uturn.right.circle") }
 
     /// 􀂑
     /// Single Localization, 3 Layersets
@@ -4731,7 +4731,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnRightCircleFill = SFSymbol(rawValue: "arrow.uturn.right.circle.fill")
+    static var arrowUturnRightCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.right.circle.fill") }
 
     /// 􀄠
     /// Single Localization, 2 Layersets
@@ -4739,7 +4739,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnRightSquare = SFSymbol(rawValue: "arrow.uturn.right.square")
+    static var arrowUturnRightSquare: SFSymbol { .init(rawValue: "arrow.uturn.right.square") }
 
     /// 􀄡
     /// Single Localization, 3 Layersets
@@ -4748,14 +4748,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnRightSquareFill = SFSymbol(rawValue: "arrow.uturn.right.square.fill")
+    static var arrowUturnRightSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.right.square.fill") }
 
     /// 􀄺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnUp = SFSymbol(rawValue: "arrow.uturn.up")
+    static var arrowUturnUp: SFSymbol { .init(rawValue: "arrow.uturn.up") }
 
     /// 􀂊
     /// Single Localization, 2 Layersets
@@ -4763,7 +4763,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnUpCircle = SFSymbol(rawValue: "arrow.uturn.up.circle")
+    static var arrowUturnUpCircle: SFSymbol { .init(rawValue: "arrow.uturn.up.circle") }
 
     /// 􀂋
     /// Single Localization, 3 Layersets
@@ -4772,7 +4772,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnUpCircleFill = SFSymbol(rawValue: "arrow.uturn.up.circle.fill")
+    static var arrowUturnUpCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.up.circle.fill") }
 
     /// 􀄚
     /// Single Localization, 2 Layersets
@@ -4780,7 +4780,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnUpSquare = SFSymbol(rawValue: "arrow.uturn.up.square")
+    static var arrowUturnUpSquare: SFSymbol { .init(rawValue: "arrow.uturn.up.square") }
 
     /// 􀄛
     /// Single Localization, 3 Layersets
@@ -4789,28 +4789,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnUpSquareFill = SFSymbol(rawValue: "arrow.uturn.up.square.fill")
+    static var arrowUturnUpSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.up.square.fill") }
 
     /// 􀉌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpLeft = SFSymbol(rawValue: "arrowshape.turn.up.left")
+    static var arrowshapeTurnUpLeft: SFSymbol { .init(rawValue: "arrowshape.turn.up.left") }
 
     /// 􀉔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpLeft2 = SFSymbol(rawValue: "arrowshape.turn.up.left.2")
+    static var arrowshapeTurnUpLeft2: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.2") }
 
     /// 􀉕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpLeft2Fill = SFSymbol(rawValue: "arrowshape.turn.up.left.2.fill")
+    static var arrowshapeTurnUpLeft2Fill: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.2.fill") }
 
     /// 􀉎
     /// Single Localization, 2 Layersets
@@ -4818,7 +4818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpLeftCircle = SFSymbol(rawValue: "arrowshape.turn.up.left.circle")
+    static var arrowshapeTurnUpLeftCircle: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.circle") }
 
     /// 􀉏
     /// Single Localization, 3 Layersets
@@ -4827,21 +4827,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpLeftCircleFill = SFSymbol(rawValue: "arrowshape.turn.up.left.circle.fill")
+    static var arrowshapeTurnUpLeftCircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.circle.fill") }
 
     /// 􀉍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpLeftFill = SFSymbol(rawValue: "arrowshape.turn.up.left.fill")
+    static var arrowshapeTurnUpLeftFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.fill") }
 
     /// 􀉐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpRight = SFSymbol(rawValue: "arrowshape.turn.up.right")
+    static var arrowshapeTurnUpRight: SFSymbol { .init(rawValue: "arrowshape.turn.up.right") }
 
     /// 􀉒
     /// Single Localization, 2 Layersets
@@ -4849,7 +4849,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpRightCircle = SFSymbol(rawValue: "arrowshape.turn.up.right.circle")
+    static var arrowshapeTurnUpRightCircle: SFSymbol { .init(rawValue: "arrowshape.turn.up.right.circle") }
 
     /// 􀉓
     /// Single Localization, 3 Layersets
@@ -4858,21 +4858,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpRightCircleFill = SFSymbol(rawValue: "arrowshape.turn.up.right.circle.fill")
+    static var arrowshapeTurnUpRightCircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.right.circle.fill") }
 
     /// 􀉑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpRightFill = SFSymbol(rawValue: "arrowshape.turn.up.right.fill")
+    static var arrowshapeTurnUpRightFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.right.fill") }
 
     /// 􀓃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleDown = SFSymbol(rawValue: "arrowtriangle.down")
+    static var arrowtriangleDown: SFSymbol { .init(rawValue: "arrowtriangle.down") }
 
     /// 􀁨
     /// Single Localization, 2 Layersets
@@ -4880,7 +4880,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleDownCircle = SFSymbol(rawValue: "arrowtriangle.down.circle")
+    static var arrowtriangleDownCircle: SFSymbol { .init(rawValue: "arrowtriangle.down.circle") }
 
     /// 􀁩
     /// Single Localization, 3 Layersets
@@ -4889,14 +4889,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleDownCircleFill = SFSymbol(rawValue: "arrowtriangle.down.circle.fill")
+    static var arrowtriangleDownCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.down.circle.fill") }
 
     /// 􀄥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleDownFill = SFSymbol(rawValue: "arrowtriangle.down.fill")
+    static var arrowtriangleDownFill: SFSymbol { .init(rawValue: "arrowtriangle.down.fill") }
 
     /// 􀃸
     /// Single Localization, 2 Layersets
@@ -4904,7 +4904,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleDownSquare = SFSymbol(rawValue: "arrowtriangle.down.square")
+    static var arrowtriangleDownSquare: SFSymbol { .init(rawValue: "arrowtriangle.down.square") }
 
     /// 􀃹
     /// Single Localization, 3 Layersets
@@ -4913,14 +4913,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleDownSquareFill = SFSymbol(rawValue: "arrowtriangle.down.square.fill")
+    static var arrowtriangleDownSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.down.square.fill") }
 
     /// 􀓄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleLeft = SFSymbol(rawValue: "arrowtriangle.left")
+    static var arrowtriangleLeft: SFSymbol { .init(rawValue: "arrowtriangle.left") }
 
     /// 􀁪
     /// Single Localization, 2 Layersets
@@ -4928,7 +4928,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleLeftCircle = SFSymbol(rawValue: "arrowtriangle.left.circle")
+    static var arrowtriangleLeftCircle: SFSymbol { .init(rawValue: "arrowtriangle.left.circle") }
 
     /// 􀁫
     /// Single Localization, 3 Layersets
@@ -4937,14 +4937,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleLeftCircleFill = SFSymbol(rawValue: "arrowtriangle.left.circle.fill")
+    static var arrowtriangleLeftCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.left.circle.fill") }
 
     /// 􀄦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleLeftFill = SFSymbol(rawValue: "arrowtriangle.left.fill")
+    static var arrowtriangleLeftFill: SFSymbol { .init(rawValue: "arrowtriangle.left.fill") }
 
     /// 􀃺
     /// Single Localization, 2 Layersets
@@ -4952,7 +4952,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleLeftSquare = SFSymbol(rawValue: "arrowtriangle.left.square")
+    static var arrowtriangleLeftSquare: SFSymbol { .init(rawValue: "arrowtriangle.left.square") }
 
     /// 􀃻
     /// Single Localization, 3 Layersets
@@ -4961,14 +4961,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleLeftSquareFill = SFSymbol(rawValue: "arrowtriangle.left.square.fill")
+    static var arrowtriangleLeftSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.left.square.fill") }
 
     /// 􀓅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleRight = SFSymbol(rawValue: "arrowtriangle.right")
+    static var arrowtriangleRight: SFSymbol { .init(rawValue: "arrowtriangle.right") }
 
     /// 􀁬
     /// Single Localization, 2 Layersets
@@ -4976,7 +4976,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleRightCircle = SFSymbol(rawValue: "arrowtriangle.right.circle")
+    static var arrowtriangleRightCircle: SFSymbol { .init(rawValue: "arrowtriangle.right.circle") }
 
     /// 􀁭
     /// Single Localization, 3 Layersets
@@ -4985,14 +4985,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleRightCircleFill = SFSymbol(rawValue: "arrowtriangle.right.circle.fill")
+    static var arrowtriangleRightCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.right.circle.fill") }
 
     /// 􀄧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleRightFill = SFSymbol(rawValue: "arrowtriangle.right.fill")
+    static var arrowtriangleRightFill: SFSymbol { .init(rawValue: "arrowtriangle.right.fill") }
 
     /// 􀃼
     /// Single Localization, 2 Layersets
@@ -5000,7 +5000,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleRightSquare = SFSymbol(rawValue: "arrowtriangle.right.square")
+    static var arrowtriangleRightSquare: SFSymbol { .init(rawValue: "arrowtriangle.right.square") }
 
     /// 􀃽
     /// Single Localization, 3 Layersets
@@ -5009,14 +5009,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleRightSquareFill = SFSymbol(rawValue: "arrowtriangle.right.square.fill")
+    static var arrowtriangleRightSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.right.square.fill") }
 
     /// 􀓂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleUp = SFSymbol(rawValue: "arrowtriangle.up")
+    static var arrowtriangleUp: SFSymbol { .init(rawValue: "arrowtriangle.up") }
 
     /// 􀁦
     /// Single Localization, 2 Layersets
@@ -5024,7 +5024,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleUpCircle = SFSymbol(rawValue: "arrowtriangle.up.circle")
+    static var arrowtriangleUpCircle: SFSymbol { .init(rawValue: "arrowtriangle.up.circle") }
 
     /// 􀁧
     /// Single Localization, 3 Layersets
@@ -5033,14 +5033,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleUpCircleFill = SFSymbol(rawValue: "arrowtriangle.up.circle.fill")
+    static var arrowtriangleUpCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.up.circle.fill") }
 
     /// 􀄤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleUpFill = SFSymbol(rawValue: "arrowtriangle.up.fill")
+    static var arrowtriangleUpFill: SFSymbol { .init(rawValue: "arrowtriangle.up.fill") }
 
     /// 􀃶
     /// Single Localization, 2 Layersets
@@ -5048,7 +5048,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleUpSquare = SFSymbol(rawValue: "arrowtriangle.up.square")
+    static var arrowtriangleUpSquare: SFSymbol { .init(rawValue: "arrowtriangle.up.square") }
 
     /// 􀃷
     /// Single Localization, 3 Layersets
@@ -5057,7 +5057,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleUpSquareFill = SFSymbol(rawValue: "arrowtriangle.up.square.fill")
+    static var arrowtriangleUpSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.up.square.fill") }
 
     /// 􀕬
     /// Single Localization, 2 Layersets
@@ -5065,7 +5065,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let asteriskCircle = SFSymbol(rawValue: "asterisk.circle")
+    static var asteriskCircle: SFSymbol { .init(rawValue: "asterisk.circle") }
 
     /// 􀕭
     /// Single Localization, 3 Layersets
@@ -5074,7 +5074,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let asteriskCircleFill = SFSymbol(rawValue: "asterisk.circle.fill")
+    static var asteriskCircleFill: SFSymbol { .init(rawValue: "asterisk.circle.fill") }
 
     /// 􀅷
     /// Single Localization, 2 Layersets
@@ -5082,7 +5082,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let at = SFSymbol(rawValue: "at")
+    static var at: SFSymbol { .init(rawValue: "at") }
 
     /// 􀅹
     /// Single Localization, 3 Layersets
@@ -5091,7 +5091,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let atBadgeMinus = SFSymbol(rawValue: "at.badge.minus")
+    static var atBadgeMinus: SFSymbol { .init(rawValue: "at.badge.minus") }
 
     /// 􀅸
     /// Single Localization, 3 Layersets
@@ -5100,7 +5100,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let atBadgePlus = SFSymbol(rawValue: "at.badge.plus")
+    static var atBadgePlus: SFSymbol { .init(rawValue: "at.badge.plus") }
 
     /// 􀖹
     /// Single Localization, 2 Layersets
@@ -5108,7 +5108,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let australsignCircle = SFSymbol(rawValue: "australsign.circle")
+    static var australsignCircle: SFSymbol { .init(rawValue: "australsign.circle") }
 
     /// 􀖺
     /// Single Localization, 3 Layersets
@@ -5117,7 +5117,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let australsignCircleFill = SFSymbol(rawValue: "australsign.circle.fill")
+    static var australsignCircleFill: SFSymbol { .init(rawValue: "australsign.circle.fill") }
 
     /// 􀗹
     /// Single Localization, 2 Layersets
@@ -5125,7 +5125,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let australsignSquare = SFSymbol(rawValue: "australsign.square")
+    static var australsignSquare: SFSymbol { .init(rawValue: "australsign.square") }
 
     /// 􀗺
     /// Single Localization, 3 Layersets
@@ -5134,7 +5134,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let australsignSquareFill = SFSymbol(rawValue: "australsign.square.fill")
+    static var australsignSquareFill: SFSymbol { .init(rawValue: "australsign.square.fill") }
 
     /// 􀀆
     /// Single Localization, 2 Layersets
@@ -5142,7 +5142,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bCircle = SFSymbol(rawValue: "b.circle")
+    static var bCircle: SFSymbol { .init(rawValue: "b.circle") }
 
     /// 􀀇
     /// Single Localization, 3 Layersets
@@ -5151,7 +5151,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bCircleFill = SFSymbol(rawValue: "b.circle.fill")
+    static var bCircleFill: SFSymbol { .init(rawValue: "b.circle.fill") }
 
     /// 􀂖
     /// Single Localization, 2 Layersets
@@ -5159,7 +5159,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bSquare = SFSymbol(rawValue: "b.square")
+    static var bSquare: SFSymbol { .init(rawValue: "b.square") }
 
     /// 􀂗
     /// Single Localization, 3 Layersets
@@ -5168,49 +5168,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bSquareFill = SFSymbol(rawValue: "b.square.fill")
+    static var bSquareFill: SFSymbol { .init(rawValue: "b.square.fill") }
 
     /// 􀊉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backward = SFSymbol(rawValue: "backward")
+    static var backward: SFSymbol { .init(rawValue: "backward") }
 
     /// 􀊍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardEnd = SFSymbol(rawValue: "backward.end")
+    static var backwardEnd: SFSymbol { .init(rawValue: "backward.end") }
 
     /// 􀊑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardEndAlt = SFSymbol(rawValue: "backward.end.alt")
+    static var backwardEndAlt: SFSymbol { .init(rawValue: "backward.end.alt") }
 
     /// 􀊒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardEndAltFill = SFSymbol(rawValue: "backward.end.alt.fill")
+    static var backwardEndAltFill: SFSymbol { .init(rawValue: "backward.end.alt.fill") }
 
     /// 􀊎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardEndFill = SFSymbol(rawValue: "backward.end.fill")
+    static var backwardEndFill: SFSymbol { .init(rawValue: "backward.end.fill") }
 
     /// 􀊊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardFill = SFSymbol(rawValue: "backward.fill")
+    static var backwardFill: SFSymbol { .init(rawValue: "backward.fill") }
 
     /// 􀊪
     /// Single Localization, 3 Layersets
@@ -5219,14 +5219,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let badgePlusRadiowavesRight = SFSymbol(rawValue: "badge.plus.radiowaves.right")
+    static var badgePlusRadiowavesRight: SFSymbol { .init(rawValue: "badge.plus.radiowaves.right") }
 
     /// 􀍣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bag = SFSymbol(rawValue: "bag")
+    static var bag: SFSymbol { .init(rawValue: "bag") }
 
     /// 􀍧
     /// Single Localization, 3 Layersets
@@ -5235,7 +5235,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagBadgeMinus = SFSymbol(rawValue: "bag.badge.minus")
+    static var bagBadgeMinus: SFSymbol { .init(rawValue: "bag.badge.minus") }
 
     /// 􀍥
     /// Single Localization, 3 Layersets
@@ -5244,14 +5244,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagBadgePlus = SFSymbol(rawValue: "bag.badge.plus")
+    static var bagBadgePlus: SFSymbol { .init(rawValue: "bag.badge.plus") }
 
     /// 􀍤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bagFill = SFSymbol(rawValue: "bag.fill")
+    static var bagFill: SFSymbol { .init(rawValue: "bag.fill") }
 
     /// 􀍨
     /// Single Localization, 3 Layersets
@@ -5260,7 +5260,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagFillBadgeMinus = SFSymbol(rawValue: "bag.fill.badge.minus")
+    static var bagFillBadgeMinus: SFSymbol { .init(rawValue: "bag.fill.badge.minus") }
 
     /// 􀍦
     /// Single Localization, 3 Layersets
@@ -5269,7 +5269,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagFillBadgePlus = SFSymbol(rawValue: "bag.fill.badge.plus")
+    static var bagFillBadgePlus: SFSymbol { .init(rawValue: "bag.fill.badge.plus") }
 
     /// 􀗑
     /// Single Localization, 2 Layersets
@@ -5277,7 +5277,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bahtsignCircle = SFSymbol(rawValue: "bahtsign.circle")
+    static var bahtsignCircle: SFSymbol { .init(rawValue: "bahtsign.circle") }
 
     /// 􀗒
     /// Single Localization, 3 Layersets
@@ -5286,7 +5286,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bahtsignCircleFill = SFSymbol(rawValue: "bahtsign.circle.fill")
+    static var bahtsignCircleFill: SFSymbol { .init(rawValue: "bahtsign.circle.fill") }
 
     /// 􀘑
     /// Single Localization, 2 Layersets
@@ -5294,7 +5294,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bahtsignSquare = SFSymbol(rawValue: "bahtsign.square")
+    static var bahtsignSquare: SFSymbol { .init(rawValue: "bahtsign.square") }
 
     /// 􀘒
     /// Single Localization, 3 Layersets
@@ -5303,7 +5303,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bahtsignSquareFill = SFSymbol(rawValue: "bahtsign.square.fill")
+    static var bahtsignSquareFill: SFSymbol { .init(rawValue: "bahtsign.square.fill") }
 
     /// 􀎓
     /// Single Localization, 2 Layersets
@@ -5311,21 +5311,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bandage = SFSymbol(rawValue: "bandage")
+    static var bandage: SFSymbol { .init(rawValue: "bandage") }
 
     /// 􀎔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bandageFill = SFSymbol(rawValue: "bandage.fill")
+    static var bandageFill: SFSymbol { .init(rawValue: "bandage.fill") }
 
     /// 􀘱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let barcode = SFSymbol(rawValue: "barcode")
+    static var barcode: SFSymbol { .init(rawValue: "barcode") }
 
     /// 􀎺
     /// Single Localization, 2 Layersets
@@ -5333,7 +5333,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let barcodeViewfinder = SFSymbol(rawValue: "barcode.viewfinder")
+    static var barcodeViewfinder: SFSymbol { .init(rawValue: "barcode.viewfinder") }
 
     /// 􀛪
     /// Single Localization, 2 Layersets
@@ -5346,7 +5346,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "battery0percent")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "battery0percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery0percent")
-    static let battery0 = SFSymbol(rawValue: "battery.0")
+    static var battery0: SFSymbol { .init(rawValue: "battery.0") }
 
     /// 􀛩
     /// Single Localization, 3 Layersets
@@ -5360,7 +5360,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "battery25percent")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "battery25percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery25percent")
-    static let battery25 = SFSymbol(rawValue: "battery.25")
+    static var battery25: SFSymbol { .init(rawValue: "battery.25") }
 
     /// 􀛨
     /// Single Localization, 3 Layersets
@@ -5374,7 +5374,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "battery100percent")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "battery100percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery100percent")
-    static let battery100 = SFSymbol(rawValue: "battery.100")
+    static var battery100: SFSymbol { .init(rawValue: "battery.100") }
 
     /// 􀙩
     /// Single Localization, 2 Layersets
@@ -5382,7 +5382,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bedDouble = SFSymbol(rawValue: "bed.double")
+    static var bedDouble: SFSymbol { .init(rawValue: "bed.double") }
 
     /// 􀙪
     /// Single Localization, 3 Layersets
@@ -5391,7 +5391,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bedDoubleFill = SFSymbol(rawValue: "bed.double.fill")
+    static var bedDoubleFill: SFSymbol { .init(rawValue: "bed.double.fill") }
 
     /// 􀋙
     /// Single Localization, 2 Layersets
@@ -5399,7 +5399,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bell = SFSymbol(rawValue: "bell")
+    static var bell: SFSymbol { .init(rawValue: "bell") }
 
     /// 􀋛
     /// Single Localization, 3 Layersets
@@ -5408,7 +5408,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellCircle = SFSymbol(rawValue: "bell.circle")
+    static var bellCircle: SFSymbol { .init(rawValue: "bell.circle") }
 
     /// 􀋜
     /// Single Localization, 3 Layersets
@@ -5417,7 +5417,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellCircleFill = SFSymbol(rawValue: "bell.circle.fill")
+    static var bellCircleFill: SFSymbol { .init(rawValue: "bell.circle.fill") }
 
     /// 􀋚
     /// Single Localization, 2 Layersets
@@ -5425,7 +5425,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellFill = SFSymbol(rawValue: "bell.fill")
+    static var bellFill: SFSymbol { .init(rawValue: "bell.fill") }
 
     /// 􀋝
     /// Single Localization, 3 Layersets
@@ -5434,7 +5434,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let bellSlash = SFSymbol(rawValue: "bell.slash")
+    static var bellSlash: SFSymbol { .init(rawValue: "bell.slash") }
 
     /// 􀋞
     /// Single Localization, 3 Layersets
@@ -5443,7 +5443,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let bellSlashFill = SFSymbol(rawValue: "bell.slash.fill")
+    static var bellSlashFill: SFSymbol { .init(rawValue: "bell.slash.fill") }
 
     /// 􀈱
     /// Single Localization, 2 Layersets
@@ -5456,7 +5456,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "xmarkBin")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "xmarkBin")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "xmarkBin")
-    static let binXmark = SFSymbol(rawValue: "bin.xmark")
+    static var binXmark: SFSymbol { .init(rawValue: "bin.xmark") }
 
     /// 􀈲
     /// Single Localization, 3 Layersets
@@ -5470,7 +5470,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "xmarkBinFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "xmarkBinFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "xmarkBinFill")
-    static let binXmarkFill = SFSymbol(rawValue: "bin.xmark.fill")
+    static var binXmarkFill: SFSymbol { .init(rawValue: "bin.xmark.fill") }
 
     /// 􀗕
     /// Single Localization, 2 Layersets
@@ -5478,7 +5478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bitcoinsignCircle = SFSymbol(rawValue: "bitcoinsign.circle")
+    static var bitcoinsignCircle: SFSymbol { .init(rawValue: "bitcoinsign.circle") }
 
     /// 􀗖
     /// Single Localization, 3 Layersets
@@ -5487,7 +5487,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bitcoinsignCircleFill = SFSymbol(rawValue: "bitcoinsign.circle.fill")
+    static var bitcoinsignCircleFill: SFSymbol { .init(rawValue: "bitcoinsign.circle.fill") }
 
     /// 􀘕
     /// Single Localization, 2 Layersets
@@ -5495,7 +5495,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bitcoinsignSquare = SFSymbol(rawValue: "bitcoinsign.square")
+    static var bitcoinsignSquare: SFSymbol { .init(rawValue: "bitcoinsign.square") }
 
     /// 􀘖
     /// Single Localization, 3 Layersets
@@ -5504,7 +5504,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bitcoinsignSquareFill = SFSymbol(rawValue: "bitcoinsign.square.fill")
+    static var bitcoinsignSquareFill: SFSymbol { .init(rawValue: "bitcoinsign.square.fill") }
 
     /// 􀅓
     /// Single Localization, 2 Layersets
@@ -5512,7 +5512,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bold = SFSymbol(rawValue: "bold")
+    static var bold: SFSymbol { .init(rawValue: "bold") }
 
     /// 􀅗
     /// Single Localization, 3 Layersets
@@ -5521,7 +5521,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boldItalicUnderline = SFSymbol(rawValue: "bold.italic.underline")
+    static var boldItalicUnderline: SFSymbol { .init(rawValue: "bold.italic.underline") }
 
     /// 􀅘
     /// Single Localization, 3 Layersets
@@ -5530,7 +5530,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boldUnderline = SFSymbol(rawValue: "bold.underline")
+    static var boldUnderline: SFSymbol { .init(rawValue: "bold.underline") }
 
     /// 􀋥
     /// Single Localization, 2 Layersets
@@ -5538,7 +5538,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let bolt = SFSymbol(rawValue: "bolt")
+    static var bolt: SFSymbol { .init(rawValue: "bolt") }
 
     /// 􀘳
     /// Single Localization, 3 Layersets
@@ -5552,7 +5552,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "boltBadgeAutomatic")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "boltBadgeAutomatic")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "boltBadgeAutomatic")
-    static let boltBadgeA = SFSymbol(rawValue: "bolt.badge.a")
+    static var boltBadgeA: SFSymbol { .init(rawValue: "bolt.badge.a") }
 
     /// 􀘴
     /// Single Localization, 3 Layersets
@@ -5566,7 +5566,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "boltBadgeAutomaticFill")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "boltBadgeAutomaticFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "boltBadgeAutomaticFill")
-    static let boltBadgeAFill = SFSymbol(rawValue: "bolt.badge.a.fill")
+    static var boltBadgeAFill: SFSymbol { .init(rawValue: "bolt.badge.a.fill") }
 
     /// 􀋧
     /// Single Localization, 3 Layersets
@@ -5575,7 +5575,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltCircle = SFSymbol(rawValue: "bolt.circle")
+    static var boltCircle: SFSymbol { .init(rawValue: "bolt.circle") }
 
     /// 􀋨
     /// Single Localization, 3 Layersets
@@ -5584,7 +5584,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltCircleFill = SFSymbol(rawValue: "bolt.circle.fill")
+    static var boltCircleFill: SFSymbol { .init(rawValue: "bolt.circle.fill") }
 
     /// 􀋦
     /// Single Localization, 2 Layersets
@@ -5592,14 +5592,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltFill = SFSymbol(rawValue: "bolt.fill")
+    static var boltFill: SFSymbol { .init(rawValue: "bolt.fill") }
 
     /// 􀒗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let boltHorizontal = SFSymbol(rawValue: "bolt.horizontal")
+    static var boltHorizontal: SFSymbol { .init(rawValue: "bolt.horizontal") }
 
     /// 􀒙
     /// Single Localization, 2 Layersets
@@ -5607,7 +5607,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltHorizontalCircle = SFSymbol(rawValue: "bolt.horizontal.circle")
+    static var boltHorizontalCircle: SFSymbol { .init(rawValue: "bolt.horizontal.circle") }
 
     /// 􀒚
     /// Single Localization, 3 Layersets
@@ -5616,14 +5616,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltHorizontalCircleFill = SFSymbol(rawValue: "bolt.horizontal.circle.fill")
+    static var boltHorizontalCircleFill: SFSymbol { .init(rawValue: "bolt.horizontal.circle.fill") }
 
     /// 􀒘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let boltHorizontalFill = SFSymbol(rawValue: "bolt.horizontal.fill")
+    static var boltHorizontalFill: SFSymbol { .init(rawValue: "bolt.horizontal.fill") }
 
     /// 􀘿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5633,7 +5633,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let boltHorizontalIcloud = SFSymbol(rawValue: "bolt.horizontal.icloud")
+    static var boltHorizontalIcloud: SFSymbol { .init(rawValue: "bolt.horizontal.icloud") }
 
     /// 􀙀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5644,7 +5644,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let boltHorizontalIcloudFill = SFSymbol(rawValue: "bolt.horizontal.icloud.fill")
+    static var boltHorizontalIcloudFill: SFSymbol { .init(rawValue: "bolt.horizontal.icloud.fill") }
 
     /// 􀋩
     /// Single Localization, 3 Layersets
@@ -5653,7 +5653,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let boltSlash = SFSymbol(rawValue: "bolt.slash")
+    static var boltSlash: SFSymbol { .init(rawValue: "bolt.slash") }
 
     /// 􀋪
     /// Single Localization, 3 Layersets
@@ -5662,14 +5662,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let boltSlashFill = SFSymbol(rawValue: "bolt.slash.fill")
+    static var boltSlashFill: SFSymbol { .init(rawValue: "bolt.slash.fill") }
 
     /// 􀉚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let book = SFSymbol(rawValue: "book")
+    static var book: SFSymbol { .init(rawValue: "book") }
 
     /// 􀉜
     /// Single Localization, 2 Layersets
@@ -5677,7 +5677,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookCircle = SFSymbol(rawValue: "book.circle")
+    static var bookCircle: SFSymbol { .init(rawValue: "book.circle") }
 
     /// 􀉝
     /// Single Localization, 3 Layersets
@@ -5686,14 +5686,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookCircleFill = SFSymbol(rawValue: "book.circle.fill")
+    static var bookCircleFill: SFSymbol { .init(rawValue: "book.circle.fill") }
 
     /// 􀉛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bookFill = SFSymbol(rawValue: "book.fill")
+    static var bookFill: SFSymbol { .init(rawValue: "book.fill") }
 
     /// 􀉞
     /// Single Localization, 2 Layersets
@@ -5701,7 +5701,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookmark = SFSymbol(rawValue: "bookmark")
+    static var bookmark: SFSymbol { .init(rawValue: "bookmark") }
 
     /// 􀉟
     /// Single Localization, 2 Layersets
@@ -5709,7 +5709,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let bookmarkFill = SFSymbol(rawValue: "bookmark.fill")
+    static var bookmarkFill: SFSymbol { .init(rawValue: "bookmark.fill") }
 
     /// 􀎜
     /// Single Localization, 2 Layersets
@@ -5717,7 +5717,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let briefcase = SFSymbol(rawValue: "briefcase")
+    static var briefcase: SFSymbol { .init(rawValue: "briefcase") }
 
     /// 􀎝
     /// Single Localization, 2 Layersets
@@ -5725,14 +5725,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let briefcaseFill = SFSymbol(rawValue: "briefcase.fill")
+    static var briefcaseFill: SFSymbol { .init(rawValue: "briefcase.fill") }
 
     /// 􀌪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleLeft = SFSymbol(rawValue: "bubble.left")
+    static var bubbleLeft: SFSymbol { .init(rawValue: "bubble.left") }
 
     /// 􀒤
     /// Single Localization, 3 Layersets
@@ -5741,7 +5741,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bubbleLeftAndBubbleRight = SFSymbol(rawValue: "bubble.left.and.bubble.right")
+    static var bubbleLeftAndBubbleRight: SFSymbol { .init(rawValue: "bubble.left.and.bubble.right") }
 
     /// 􀘲
     /// Single Localization, 2 Layersets
@@ -5749,77 +5749,77 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bubbleLeftAndBubbleRightFill = SFSymbol(rawValue: "bubble.left.and.bubble.right.fill")
+    static var bubbleLeftAndBubbleRightFill: SFSymbol { .init(rawValue: "bubble.left.and.bubble.right.fill") }
 
     /// 􀌫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleLeftFill = SFSymbol(rawValue: "bubble.left.fill")
+    static var bubbleLeftFill: SFSymbol { .init(rawValue: "bubble.left.fill") }
 
     /// 􀌸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleMiddleBottom = SFSymbol(rawValue: "bubble.middle.bottom")
+    static var bubbleMiddleBottom: SFSymbol { .init(rawValue: "bubble.middle.bottom") }
 
     /// 􀌹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleMiddleBottomFill = SFSymbol(rawValue: "bubble.middle.bottom.fill")
+    static var bubbleMiddleBottomFill: SFSymbol { .init(rawValue: "bubble.middle.bottom.fill") }
 
     /// 􀌼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleMiddleTop = SFSymbol(rawValue: "bubble.middle.top")
+    static var bubbleMiddleTop: SFSymbol { .init(rawValue: "bubble.middle.top") }
 
     /// 􀌽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleMiddleTopFill = SFSymbol(rawValue: "bubble.middle.top.fill")
+    static var bubbleMiddleTopFill: SFSymbol { .init(rawValue: "bubble.middle.top.fill") }
 
     /// 􀌨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleRight = SFSymbol(rawValue: "bubble.right")
+    static var bubbleRight: SFSymbol { .init(rawValue: "bubble.right") }
 
     /// 􀌩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleRightFill = SFSymbol(rawValue: "bubble.right.fill")
+    static var bubbleRightFill: SFSymbol { .init(rawValue: "bubble.right.fill") }
 
     /// 􀓜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let burn = SFSymbol(rawValue: "burn")
+    static var burn: SFSymbol { .init(rawValue: "burn") }
 
     /// 􀑂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let burst = SFSymbol(rawValue: "burst")
+    static var burst: SFSymbol { .init(rawValue: "burst") }
 
     /// 􀘞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let burstFill = SFSymbol(rawValue: "burst.fill")
+    static var burstFill: SFSymbol { .init(rawValue: "burst.fill") }
 
     /// 􀀈
     /// Single Localization, 2 Layersets
@@ -5827,7 +5827,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cCircle = SFSymbol(rawValue: "c.circle")
+    static var cCircle: SFSymbol { .init(rawValue: "c.circle") }
 
     /// 􀀉
     /// Single Localization, 3 Layersets
@@ -5836,7 +5836,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cCircleFill = SFSymbol(rawValue: "c.circle.fill")
+    static var cCircleFill: SFSymbol { .init(rawValue: "c.circle.fill") }
 
     /// 􀂘
     /// Single Localization, 2 Layersets
@@ -5844,7 +5844,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cSquare = SFSymbol(rawValue: "c.square")
+    static var cSquare: SFSymbol { .init(rawValue: "c.square") }
 
     /// 􀂙
     /// Single Localization, 3 Layersets
@@ -5853,7 +5853,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cSquareFill = SFSymbol(rawValue: "c.square.fill")
+    static var cSquareFill: SFSymbol { .init(rawValue: "c.square.fill") }
 
     /// 􀉉
     /// Single Localization, 2 Layersets
@@ -5861,7 +5861,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendar = SFSymbol(rawValue: "calendar")
+    static var calendar: SFSymbol { .init(rawValue: "calendar") }
 
     /// 􀉋
     /// Single Localization, 3 Layersets
@@ -5870,7 +5870,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarBadgeMinus = SFSymbol(rawValue: "calendar.badge.minus")
+    static var calendarBadgeMinus: SFSymbol { .init(rawValue: "calendar.badge.minus") }
 
     /// 􀉊
     /// Single Localization, 3 Layersets
@@ -5879,7 +5879,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarBadgePlus = SFSymbol(rawValue: "calendar.badge.plus")
+    static var calendarBadgePlus: SFSymbol { .init(rawValue: "calendar.badge.plus") }
 
     /// 􀒎
     /// Single Localization, 3 Layersets
@@ -5888,7 +5888,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarCircle = SFSymbol(rawValue: "calendar.circle")
+    static var calendarCircle: SFSymbol { .init(rawValue: "calendar.circle") }
 
     /// 􀒏
     /// Single Localization, 3 Layersets
@@ -5897,14 +5897,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarCircleFill = SFSymbol(rawValue: "calendar.circle.fill")
+    static var calendarCircleFill: SFSymbol { .init(rawValue: "calendar.circle.fill") }
 
     /// 􀌞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let camera = SFSymbol(rawValue: "camera")
+    static var camera: SFSymbol { .init(rawValue: "camera") }
 
     /// 􀌠
     /// Single Localization, 2 Layersets
@@ -5912,7 +5912,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraCircle = SFSymbol(rawValue: "camera.circle")
+    static var cameraCircle: SFSymbol { .init(rawValue: "camera.circle") }
 
     /// 􀌡
     /// Single Localization, 3 Layersets
@@ -5921,14 +5921,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraCircleFill = SFSymbol(rawValue: "camera.circle.fill")
+    static var cameraCircleFill: SFSymbol { .init(rawValue: "camera.circle.fill") }
 
     /// 􀌟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cameraFill = SFSymbol(rawValue: "camera.fill")
+    static var cameraFill: SFSymbol { .init(rawValue: "camera.fill") }
 
     /// 􀝁
     /// Single Localization, 3 Layersets
@@ -5937,7 +5937,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraOnRectangle = SFSymbol(rawValue: "camera.on.rectangle")
+    static var cameraOnRectangle: SFSymbol { .init(rawValue: "camera.on.rectangle") }
 
     /// 􀝂
     /// Single Localization, 2 Layersets
@@ -5945,7 +5945,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraOnRectangleFill = SFSymbol(rawValue: "camera.on.rectangle.fill")
+    static var cameraOnRectangleFill: SFSymbol { .init(rawValue: "camera.on.rectangle.fill") }
 
     /// 􀌢
     /// Single Localization, Single Layerset
@@ -5957,7 +5957,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangle2CirclepathCamera")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangle2CirclepathCamera")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangle2CirclepathCamera")
-    static let cameraRotate = SFSymbol(rawValue: "camera.rotate")
+    static var cameraRotate: SFSymbol { .init(rawValue: "camera.rotate") }
 
     /// 􀌣
     /// Single Localization, Single Layerset
@@ -5969,7 +5969,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowTriangle2CirclepathCameraFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "arrowTriangle2CirclepathCameraFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowTriangle2CirclepathCameraFill")
-    static let cameraRotateFill = SFSymbol(rawValue: "camera.rotate.fill")
+    static var cameraRotateFill: SFSymbol { .init(rawValue: "camera.rotate.fill") }
 
     /// 􀎼
     /// Single Localization, 2 Layersets
@@ -5977,35 +5977,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraViewfinder = SFSymbol(rawValue: "camera.viewfinder")
+    static var cameraViewfinder: SFSymbol { .init(rawValue: "camera.viewfinder") }
 
     /// 􀆡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capslock = SFSymbol(rawValue: "capslock")
+    static var capslock: SFSymbol { .init(rawValue: "capslock") }
 
     /// 􀆢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capslockFill = SFSymbol(rawValue: "capslock.fill")
+    static var capslockFill: SFSymbol { .init(rawValue: "capslock.fill") }
 
     /// 􀝶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsule = SFSymbol(rawValue: "capsule")
+    static var capsule: SFSymbol { .init(rawValue: "capsule") }
 
     /// 􀝷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsuleFill = SFSymbol(rawValue: "capsule.fill")
+    static var capsuleFill: SFSymbol { .init(rawValue: "capsule.fill") }
 
     /// 􀌴
     /// Single Localization, 2 Layersets
@@ -6013,7 +6013,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let captionsBubble = SFSymbol(rawValue: "captions.bubble")
+    static var captionsBubble: SFSymbol { .init(rawValue: "captions.bubble") }
 
     /// 􀌵
     /// Single Localization, 3 Layersets
@@ -6022,7 +6022,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let captionsBubbleFill = SFSymbol(rawValue: "captions.bubble.fill")
+    static var captionsBubbleFill: SFSymbol { .init(rawValue: "captions.bubble.fill") }
 
     /// 􀙙
     /// Single Localization, 2 Layersets
@@ -6030,14 +6030,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let carFill = SFSymbol(rawValue: "car.fill")
+    static var carFill: SFSymbol { .init(rawValue: "car.fill") }
 
     /// 􀍩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cart = SFSymbol(rawValue: "cart")
+    static var cart: SFSymbol { .init(rawValue: "cart") }
 
     /// 􀍭
     /// Single Localization, 3 Layersets
@@ -6046,7 +6046,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartBadgeMinus = SFSymbol(rawValue: "cart.badge.minus")
+    static var cartBadgeMinus: SFSymbol { .init(rawValue: "cart.badge.minus") }
 
     /// 􀍫
     /// Single Localization, 3 Layersets
@@ -6055,14 +6055,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartBadgePlus = SFSymbol(rawValue: "cart.badge.plus")
+    static var cartBadgePlus: SFSymbol { .init(rawValue: "cart.badge.plus") }
 
     /// 􀍪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cartFill = SFSymbol(rawValue: "cart.fill")
+    static var cartFill: SFSymbol { .init(rawValue: "cart.fill") }
 
     /// 􀍮
     /// Single Localization, 3 Layersets
@@ -6071,7 +6071,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartFillBadgeMinus = SFSymbol(rawValue: "cart.fill.badge.minus")
+    static var cartFillBadgeMinus: SFSymbol { .init(rawValue: "cart.fill.badge.minus") }
 
     /// 􀍬
     /// Single Localization, 3 Layersets
@@ -6080,7 +6080,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartFillBadgePlus = SFSymbol(rawValue: "cart.fill.badge.plus")
+    static var cartFillBadgePlus: SFSymbol { .init(rawValue: "cart.fill.badge.plus") }
 
     /// 􀗃
     /// Single Localization, 2 Layersets
@@ -6088,7 +6088,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cedisignCircle = SFSymbol(rawValue: "cedisign.circle")
+    static var cedisignCircle: SFSymbol { .init(rawValue: "cedisign.circle") }
 
     /// 􀗄
     /// Single Localization, 3 Layersets
@@ -6097,7 +6097,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cedisignCircleFill = SFSymbol(rawValue: "cedisign.circle.fill")
+    static var cedisignCircleFill: SFSymbol { .init(rawValue: "cedisign.circle.fill") }
 
     /// 􀘃
     /// Single Localization, 2 Layersets
@@ -6105,7 +6105,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cedisignSquare = SFSymbol(rawValue: "cedisign.square")
+    static var cedisignSquare: SFSymbol { .init(rawValue: "cedisign.square") }
 
     /// 􀘄
     /// Single Localization, 3 Layersets
@@ -6114,7 +6114,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cedisignSquareFill = SFSymbol(rawValue: "cedisign.square.fill")
+    static var cedisignSquareFill: SFSymbol { .init(rawValue: "cedisign.square.fill") }
 
     /// 􀖙
     /// Single Localization, 2 Layersets
@@ -6122,7 +6122,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let centsignCircle = SFSymbol(rawValue: "centsign.circle")
+    static var centsignCircle: SFSymbol { .init(rawValue: "centsign.circle") }
 
     /// 􀖚
     /// Single Localization, 3 Layersets
@@ -6131,7 +6131,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let centsignCircleFill = SFSymbol(rawValue: "centsign.circle.fill")
+    static var centsignCircleFill: SFSymbol { .init(rawValue: "centsign.circle.fill") }
 
     /// 􀗙
     /// Single Localization, 2 Layersets
@@ -6139,7 +6139,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let centsignSquare = SFSymbol(rawValue: "centsign.square")
+    static var centsignSquare: SFSymbol { .init(rawValue: "centsign.square") }
 
     /// 􀗚
     /// Single Localization, 3 Layersets
@@ -6148,7 +6148,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let centsignSquareFill = SFSymbol(rawValue: "centsign.square.fill")
+    static var centsignSquareFill: SFSymbol { .init(rawValue: "centsign.square.fill") }
 
     /// 􀐾
     /// Single Localization, 3 Layersets
@@ -6157,7 +6157,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartBar = SFSymbol(rawValue: "chart.bar")
+    static var chartBar: SFSymbol { .init(rawValue: "chart.bar") }
 
     /// 􀐿
     /// Single Localization, 3 Layersets
@@ -6166,21 +6166,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartBarFill = SFSymbol(rawValue: "chart.bar.fill")
+    static var chartBarFill: SFSymbol { .init(rawValue: "chart.bar.fill") }
 
     /// 􀑀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chartPie = SFSymbol(rawValue: "chart.pie")
+    static var chartPie: SFSymbol { .init(rawValue: "chart.pie") }
 
     /// 􀜋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chartPieFill = SFSymbol(rawValue: "chart.pie.fill")
+    static var chartPieFill: SFSymbol { .init(rawValue: "chart.pie.fill") }
 
     /// 􀆅
     /// Single Localization, 2 Layersets
@@ -6188,7 +6188,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmark = SFSymbol(rawValue: "checkmark")
+    static var checkmark: SFSymbol { .init(rawValue: "checkmark") }
 
     /// 􀁢
     /// Single Localization, 3 Layersets
@@ -6197,7 +6197,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkCircle = SFSymbol(rawValue: "checkmark.circle")
+    static var checkmarkCircle: SFSymbol { .init(rawValue: "checkmark.circle") }
 
     /// 􀁣
     /// Single Localization, 3 Layersets
@@ -6206,7 +6206,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkCircleFill = SFSymbol(rawValue: "checkmark.circle.fill")
+    static var checkmarkCircleFill: SFSymbol { .init(rawValue: "checkmark.circle.fill") }
 
     /// 􀏋
     /// Single Localization, 3 Layersets
@@ -6215,7 +6215,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkRectangle = SFSymbol(rawValue: "checkmark.rectangle")
+    static var checkmarkRectangle: SFSymbol { .init(rawValue: "checkmark.rectangle") }
 
     /// 􀏌
     /// Single Localization, 3 Layersets
@@ -6224,7 +6224,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkRectangleFill = SFSymbol(rawValue: "checkmark.rectangle.fill")
+    static var checkmarkRectangleFill: SFSymbol { .init(rawValue: "checkmark.rectangle.fill") }
 
     /// 􀇺
     /// Single Localization, 2 Layersets
@@ -6232,7 +6232,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkSeal = SFSymbol(rawValue: "checkmark.seal")
+    static var checkmarkSeal: SFSymbol { .init(rawValue: "checkmark.seal") }
 
     /// 􀇻
     /// Single Localization, 3 Layersets
@@ -6241,7 +6241,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkSealFill = SFSymbol(rawValue: "checkmark.seal.fill")
+    static var checkmarkSealFill: SFSymbol { .init(rawValue: "checkmark.seal.fill") }
 
     /// 􀞛
     /// Single Localization, 2 Layersets
@@ -6249,7 +6249,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkShield = SFSymbol(rawValue: "checkmark.shield")
+    static var checkmarkShield: SFSymbol { .init(rawValue: "checkmark.shield") }
 
     /// 􀞜
     /// Single Localization, 3 Layersets
@@ -6258,7 +6258,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkShieldFill = SFSymbol(rawValue: "checkmark.shield.fill")
+    static var checkmarkShieldFill: SFSymbol { .init(rawValue: "checkmark.shield.fill") }
 
     /// 􀃲
     /// Single Localization, 3 Layersets
@@ -6267,7 +6267,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkSquare = SFSymbol(rawValue: "checkmark.square")
+    static var checkmarkSquare: SFSymbol { .init(rawValue: "checkmark.square") }
 
     /// 􀃳
     /// Single Localization, 3 Layersets
@@ -6276,42 +6276,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let checkmarkSquareFill = SFSymbol(rawValue: "checkmark.square.fill")
+    static var checkmarkSquareFill: SFSymbol { .init(rawValue: "checkmark.square.fill") }
 
     /// 􀆑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactDown = SFSymbol(rawValue: "chevron.compact.down")
+    static var chevronCompactDown: SFSymbol { .init(rawValue: "chevron.compact.down") }
 
     /// 􀆒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactLeft = SFSymbol(rawValue: "chevron.compact.left")
+    static var chevronCompactLeft: SFSymbol { .init(rawValue: "chevron.compact.left") }
 
     /// 􀆓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactRight = SFSymbol(rawValue: "chevron.compact.right")
+    static var chevronCompactRight: SFSymbol { .init(rawValue: "chevron.compact.right") }
 
     /// 􀆐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactUp = SFSymbol(rawValue: "chevron.compact.up")
+    static var chevronCompactUp: SFSymbol { .init(rawValue: "chevron.compact.up") }
 
     /// 􀆈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDown = SFSymbol(rawValue: "chevron.down")
+    static var chevronDown: SFSymbol { .init(rawValue: "chevron.down") }
 
     /// 􀁰
     /// Single Localization, 2 Layersets
@@ -6319,7 +6319,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronDownCircle = SFSymbol(rawValue: "chevron.down.circle")
+    static var chevronDownCircle: SFSymbol { .init(rawValue: "chevron.down.circle") }
 
     /// 􀁱
     /// Single Localization, 3 Layersets
@@ -6328,7 +6328,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronDownCircleFill = SFSymbol(rawValue: "chevron.down.circle.fill")
+    static var chevronDownCircleFill: SFSymbol { .init(rawValue: "chevron.down.circle.fill") }
 
     /// 􀄀
     /// Single Localization, 2 Layersets
@@ -6336,7 +6336,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronDownSquare = SFSymbol(rawValue: "chevron.down.square")
+    static var chevronDownSquare: SFSymbol { .init(rawValue: "chevron.down.square") }
 
     /// 􀄁
     /// Single Localization, 3 Layersets
@@ -6345,21 +6345,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronDownSquareFill = SFSymbol(rawValue: "chevron.down.square.fill")
+    static var chevronDownSquareFill: SFSymbol { .init(rawValue: "chevron.down.square.fill") }
 
     /// 􀆉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeft = SFSymbol(rawValue: "chevron.left")
+    static var chevronLeft: SFSymbol { .init(rawValue: "chevron.left") }
 
     /// 􀆋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeft2 = SFSymbol(rawValue: "chevron.left.2")
+    static var chevronLeft2: SFSymbol { .init(rawValue: "chevron.left.2") }
 
     /// 􀁲
     /// Single Localization, 2 Layersets
@@ -6367,7 +6367,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronLeftCircle = SFSymbol(rawValue: "chevron.left.circle")
+    static var chevronLeftCircle: SFSymbol { .init(rawValue: "chevron.left.circle") }
 
     /// 􀁳
     /// Single Localization, 3 Layersets
@@ -6376,7 +6376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronLeftCircleFill = SFSymbol(rawValue: "chevron.left.circle.fill")
+    static var chevronLeftCircleFill: SFSymbol { .init(rawValue: "chevron.left.circle.fill") }
 
     /// 􀙚
     /// Single Localization, Single Layerset
@@ -6388,7 +6388,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "chevronLeftForwardslashChevronRight")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "chevronLeftForwardslashChevronRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "chevronLeftForwardslashChevronRight")
-    static let chevronLeftSlashChevronRight = SFSymbol(rawValue: "chevron.left.slash.chevron.right")
+    static var chevronLeftSlashChevronRight: SFSymbol { .init(rawValue: "chevron.left.slash.chevron.right") }
 
     /// 􀄂
     /// Single Localization, 2 Layersets
@@ -6396,7 +6396,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronLeftSquare = SFSymbol(rawValue: "chevron.left.square")
+    static var chevronLeftSquare: SFSymbol { .init(rawValue: "chevron.left.square") }
 
     /// 􀄃
     /// Single Localization, 3 Layersets
@@ -6405,21 +6405,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronLeftSquareFill = SFSymbol(rawValue: "chevron.left.square.fill")
+    static var chevronLeftSquareFill: SFSymbol { .init(rawValue: "chevron.left.square.fill") }
 
     /// 􀆊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronRight = SFSymbol(rawValue: "chevron.right")
+    static var chevronRight: SFSymbol { .init(rawValue: "chevron.right") }
 
     /// 􀆌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronRight2 = SFSymbol(rawValue: "chevron.right.2")
+    static var chevronRight2: SFSymbol { .init(rawValue: "chevron.right.2") }
 
     /// 􀁴
     /// Single Localization, 2 Layersets
@@ -6427,7 +6427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronRightCircle = SFSymbol(rawValue: "chevron.right.circle")
+    static var chevronRightCircle: SFSymbol { .init(rawValue: "chevron.right.circle") }
 
     /// 􀁵
     /// Single Localization, 3 Layersets
@@ -6436,7 +6436,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronRightCircleFill = SFSymbol(rawValue: "chevron.right.circle.fill")
+    static var chevronRightCircleFill: SFSymbol { .init(rawValue: "chevron.right.circle.fill") }
 
     /// 􀄄
     /// Single Localization, 2 Layersets
@@ -6444,7 +6444,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronRightSquare = SFSymbol(rawValue: "chevron.right.square")
+    static var chevronRightSquare: SFSymbol { .init(rawValue: "chevron.right.square") }
 
     /// 􀄅
     /// Single Localization, 3 Layersets
@@ -6453,21 +6453,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronRightSquareFill = SFSymbol(rawValue: "chevron.right.square.fill")
+    static var chevronRightSquareFill: SFSymbol { .init(rawValue: "chevron.right.square.fill") }
 
     /// 􀆇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUp = SFSymbol(rawValue: "chevron.up")
+    static var chevronUp: SFSymbol { .init(rawValue: "chevron.up") }
 
     /// 􀆏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpChevronDown = SFSymbol(rawValue: "chevron.up.chevron.down")
+    static var chevronUpChevronDown: SFSymbol { .init(rawValue: "chevron.up.chevron.down") }
 
     /// 􀁮
     /// Single Localization, 2 Layersets
@@ -6475,7 +6475,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronUpCircle = SFSymbol(rawValue: "chevron.up.circle")
+    static var chevronUpCircle: SFSymbol { .init(rawValue: "chevron.up.circle") }
 
     /// 􀁯
     /// Single Localization, 3 Layersets
@@ -6484,7 +6484,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronUpCircleFill = SFSymbol(rawValue: "chevron.up.circle.fill")
+    static var chevronUpCircleFill: SFSymbol { .init(rawValue: "chevron.up.circle.fill") }
 
     /// 􀃾
     /// Single Localization, 2 Layersets
@@ -6492,7 +6492,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronUpSquare = SFSymbol(rawValue: "chevron.up.square")
+    static var chevronUpSquare: SFSymbol { .init(rawValue: "chevron.up.square") }
 
     /// 􀃿
     /// Single Localization, 3 Layersets
@@ -6501,14 +6501,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronUpSquareFill = SFSymbol(rawValue: "chevron.up.square.fill")
+    static var chevronUpSquareFill: SFSymbol { .init(rawValue: "chevron.up.square.fill") }
 
     /// 􀀀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circle = SFSymbol(rawValue: "circle")
+    static var circle: SFSymbol { .init(rawValue: "circle") }
 
     /// 􀜚
     /// Single Localization, Single Layerset
@@ -6520,28 +6520,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "sleep")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "sleep")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sleep")
-    static let circleBottomthirdSplit = SFSymbol(rawValue: "circle.bottomthird.split")
+    static var circleBottomthirdSplit: SFSymbol { .init(rawValue: "circle.bottomthird.split") }
 
     /// 􀀁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleFill = SFSymbol(rawValue: "circle.fill")
+    static var circleFill: SFSymbol { .init(rawValue: "circle.fill") }
 
     /// 􀇸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid3x3 = SFSymbol(rawValue: "circle.grid.3x3")
+    static var circleGrid3x3: SFSymbol { .init(rawValue: "circle.grid.3x3") }
 
     /// 􀇹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid3x3Fill = SFSymbol(rawValue: "circle.grid.3x3.fill")
+    static var circleGrid3x3Fill: SFSymbol { .init(rawValue: "circle.grid.3x3.fill") }
 
     /// 􀙢
     /// Single Localization, Single Layerset
@@ -6553,7 +6553,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "circlesHexagongrid")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "circlesHexagongrid")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circlesHexagongrid")
-    static let circleGridHex = SFSymbol(rawValue: "circle.grid.hex")
+    static var circleGridHex: SFSymbol { .init(rawValue: "circle.grid.hex") }
 
     /// 􀙣
     /// Single Localization, Single Layerset
@@ -6565,7 +6565,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "circlesHexagongridFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "circlesHexagongridFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circlesHexagongridFill")
-    static let circleGridHexFill = SFSymbol(rawValue: "circle.grid.hex.fill")
+    static var circleGridHexFill: SFSymbol { .init(rawValue: "circle.grid.hex.fill") }
 
     /// 􀀂
     /// Single Localization, Single Layerset
@@ -6577,7 +6577,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "circleLefthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "circleLefthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleLefthalfFilled")
-    static let circleLefthalfFill = SFSymbol(rawValue: "circle.lefthalf.fill")
+    static var circleLefthalfFill: SFSymbol { .init(rawValue: "circle.lefthalf.fill") }
 
     /// 􀀃
     /// Single Localization, Single Layerset
@@ -6589,7 +6589,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "circleRighthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "circleRighthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleRighthalfFilled")
-    static let circleRighthalfFill = SFSymbol(rawValue: "circle.righthalf.fill")
+    static var circleRighthalfFill: SFSymbol { .init(rawValue: "circle.righthalf.fill") }
 
     /// 􀆙
     /// Single Localization, 3 Layersets
@@ -6598,7 +6598,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let clear = SFSymbol(rawValue: "clear")
+    static var clear: SFSymbol { .init(rawValue: "clear") }
 
     /// 􀆚
     /// Single Localization, 3 Layersets
@@ -6607,7 +6607,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let clearFill = SFSymbol(rawValue: "clear.fill")
+    static var clearFill: SFSymbol { .init(rawValue: "clear.fill") }
 
     /// 􀐫
     /// Single Localization, 3 Layersets
@@ -6616,21 +6616,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let clock = SFSymbol(rawValue: "clock")
+    static var clock: SFSymbol { .init(rawValue: "clock") }
 
     /// 􀐬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let clockFill = SFSymbol(rawValue: "clock.fill")
+    static var clockFill: SFSymbol { .init(rawValue: "clock.fill") }
 
     /// 􀇂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cloud = SFSymbol(rawValue: "cloud")
+    static var cloud: SFSymbol { .init(rawValue: "cloud") }
 
     /// 􀇒
     /// Single Localization, 2 Layersets
@@ -6638,7 +6638,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudBolt = SFSymbol(rawValue: "cloud.bolt")
+    static var cloudBolt: SFSymbol { .init(rawValue: "cloud.bolt") }
 
     /// 􀇓
     /// Single Localization, 3 Layersets
@@ -6647,7 +6647,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudBoltFill = SFSymbol(rawValue: "cloud.bolt.fill")
+    static var cloudBoltFill: SFSymbol { .init(rawValue: "cloud.bolt.fill") }
 
     /// 􀇞
     /// Single Localization, 2 Layersets
@@ -6655,7 +6655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudBoltRain = SFSymbol(rawValue: "cloud.bolt.rain")
+    static var cloudBoltRain: SFSymbol { .init(rawValue: "cloud.bolt.rain") }
 
     /// 􀇟
     /// Single Localization, 3 Layersets
@@ -6664,7 +6664,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudBoltRainFill = SFSymbol(rawValue: "cloud.bolt.rain.fill")
+    static var cloudBoltRainFill: SFSymbol { .init(rawValue: "cloud.bolt.rain.fill") }
 
     /// 􀇄
     /// Single Localization, 2 Layersets
@@ -6672,7 +6672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudDrizzle = SFSymbol(rawValue: "cloud.drizzle")
+    static var cloudDrizzle: SFSymbol { .init(rawValue: "cloud.drizzle") }
 
     /// 􀇅
     /// Single Localization, 3 Layersets
@@ -6681,7 +6681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudDrizzleFill = SFSymbol(rawValue: "cloud.drizzle.fill")
+    static var cloudDrizzleFill: SFSymbol { .init(rawValue: "cloud.drizzle.fill") }
 
     /// 􀇃
     /// Single Localization, 2 Layersets
@@ -6689,7 +6689,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let cloudFill = SFSymbol(rawValue: "cloud.fill")
+    static var cloudFill: SFSymbol { .init(rawValue: "cloud.fill") }
 
     /// 􀇊
     /// Single Localization, 2 Layersets
@@ -6697,7 +6697,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudFog = SFSymbol(rawValue: "cloud.fog")
+    static var cloudFog: SFSymbol { .init(rawValue: "cloud.fog") }
 
     /// 􀇋
     /// Single Localization, 3 Layersets
@@ -6706,7 +6706,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudFogFill = SFSymbol(rawValue: "cloud.fog.fill")
+    static var cloudFogFill: SFSymbol { .init(rawValue: "cloud.fog.fill") }
 
     /// 􀇌
     /// Single Localization, 2 Layersets
@@ -6714,7 +6714,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudHail = SFSymbol(rawValue: "cloud.hail")
+    static var cloudHail: SFSymbol { .init(rawValue: "cloud.hail") }
 
     /// 􀇍
     /// Single Localization, 3 Layersets
@@ -6723,7 +6723,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudHailFill = SFSymbol(rawValue: "cloud.hail.fill")
+    static var cloudHailFill: SFSymbol { .init(rawValue: "cloud.hail.fill") }
 
     /// 􀇈
     /// Single Localization, 2 Layersets
@@ -6731,7 +6731,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudHeavyrain = SFSymbol(rawValue: "cloud.heavyrain")
+    static var cloudHeavyrain: SFSymbol { .init(rawValue: "cloud.heavyrain") }
 
     /// 􀇉
     /// Single Localization, 3 Layersets
@@ -6740,7 +6740,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudHeavyrainFill = SFSymbol(rawValue: "cloud.heavyrain.fill")
+    static var cloudHeavyrainFill: SFSymbol { .init(rawValue: "cloud.heavyrain.fill") }
 
     /// 􀇚
     /// Single Localization, 3 Layersets
@@ -6749,7 +6749,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudMoon = SFSymbol(rawValue: "cloud.moon")
+    static var cloudMoon: SFSymbol { .init(rawValue: "cloud.moon") }
 
     /// 􀇠
     /// Single Localization, 3 Layersets
@@ -6758,7 +6758,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudMoonBolt = SFSymbol(rawValue: "cloud.moon.bolt")
+    static var cloudMoonBolt: SFSymbol { .init(rawValue: "cloud.moon.bolt") }
 
     /// 􀇡
     /// Single Localization, 3 Layersets
@@ -6767,7 +6767,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudMoonBoltFill = SFSymbol(rawValue: "cloud.moon.bolt.fill")
+    static var cloudMoonBoltFill: SFSymbol { .init(rawValue: "cloud.moon.bolt.fill") }
 
     /// 􀇛
     /// Single Localization, 3 Layersets
@@ -6776,7 +6776,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudMoonFill = SFSymbol(rawValue: "cloud.moon.fill")
+    static var cloudMoonFill: SFSymbol { .init(rawValue: "cloud.moon.fill") }
 
     /// 􀇜
     /// Single Localization, 3 Layersets
@@ -6785,7 +6785,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudMoonRain = SFSymbol(rawValue: "cloud.moon.rain")
+    static var cloudMoonRain: SFSymbol { .init(rawValue: "cloud.moon.rain") }
 
     /// 􀇝
     /// Single Localization, 3 Layersets
@@ -6794,7 +6794,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudMoonRainFill = SFSymbol(rawValue: "cloud.moon.rain.fill")
+    static var cloudMoonRainFill: SFSymbol { .init(rawValue: "cloud.moon.rain.fill") }
 
     /// 􀇆
     /// Single Localization, 2 Layersets
@@ -6802,7 +6802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudRain = SFSymbol(rawValue: "cloud.rain")
+    static var cloudRain: SFSymbol { .init(rawValue: "cloud.rain") }
 
     /// 􀇇
     /// Single Localization, 3 Layersets
@@ -6811,7 +6811,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudRainFill = SFSymbol(rawValue: "cloud.rain.fill")
+    static var cloudRainFill: SFSymbol { .init(rawValue: "cloud.rain.fill") }
 
     /// 􀇐
     /// Single Localization, 2 Layersets
@@ -6819,7 +6819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSleet = SFSymbol(rawValue: "cloud.sleet")
+    static var cloudSleet: SFSymbol { .init(rawValue: "cloud.sleet") }
 
     /// 􀇑
     /// Single Localization, 3 Layersets
@@ -6828,7 +6828,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSleetFill = SFSymbol(rawValue: "cloud.sleet.fill")
+    static var cloudSleetFill: SFSymbol { .init(rawValue: "cloud.sleet.fill") }
 
     /// 􀇎
     /// Single Localization, 2 Layersets
@@ -6836,7 +6836,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSnow = SFSymbol(rawValue: "cloud.snow")
+    static var cloudSnow: SFSymbol { .init(rawValue: "cloud.snow") }
 
     /// 􀇏
     /// Single Localization, 3 Layersets
@@ -6845,7 +6845,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSnowFill = SFSymbol(rawValue: "cloud.snow.fill")
+    static var cloudSnowFill: SFSymbol { .init(rawValue: "cloud.snow.fill") }
 
     /// 􀇔
     /// Single Localization, 3 Layersets
@@ -6854,7 +6854,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudSun = SFSymbol(rawValue: "cloud.sun")
+    static var cloudSun: SFSymbol { .init(rawValue: "cloud.sun") }
 
     /// 􀇘
     /// Single Localization, 3 Layersets
@@ -6863,7 +6863,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudSunBolt = SFSymbol(rawValue: "cloud.sun.bolt")
+    static var cloudSunBolt: SFSymbol { .init(rawValue: "cloud.sun.bolt") }
 
     /// 􀇙
     /// Single Localization, 3 Layersets
@@ -6872,7 +6872,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSunBoltFill = SFSymbol(rawValue: "cloud.sun.bolt.fill")
+    static var cloudSunBoltFill: SFSymbol { .init(rawValue: "cloud.sun.bolt.fill") }
 
     /// 􀇕
     /// Single Localization, 3 Layersets
@@ -6881,7 +6881,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSunFill = SFSymbol(rawValue: "cloud.sun.fill")
+    static var cloudSunFill: SFSymbol { .init(rawValue: "cloud.sun.fill") }
 
     /// 􀇖
     /// Single Localization, 3 Layersets
@@ -6890,7 +6890,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cloudSunRain = SFSymbol(rawValue: "cloud.sun.rain")
+    static var cloudSunRain: SFSymbol { .init(rawValue: "cloud.sun.rain") }
 
     /// 􀇗
     /// Single Localization, 3 Layersets
@@ -6899,7 +6899,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cloudSunRainFill = SFSymbol(rawValue: "cloud.sun.rain.fill")
+    static var cloudSunRainFill: SFSymbol { .init(rawValue: "cloud.sun.rain.fill") }
 
     /// 􀗁
     /// Single Localization, 2 Layersets
@@ -6907,7 +6907,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let coloncurrencysignCircle = SFSymbol(rawValue: "coloncurrencysign.circle")
+    static var coloncurrencysignCircle: SFSymbol { .init(rawValue: "coloncurrencysign.circle") }
 
     /// 􀗂
     /// Single Localization, 3 Layersets
@@ -6916,7 +6916,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let coloncurrencysignCircleFill = SFSymbol(rawValue: "coloncurrencysign.circle.fill")
+    static var coloncurrencysignCircleFill: SFSymbol { .init(rawValue: "coloncurrencysign.circle.fill") }
 
     /// 􀘁
     /// Single Localization, 2 Layersets
@@ -6924,7 +6924,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let coloncurrencysignSquare = SFSymbol(rawValue: "coloncurrencysign.square")
+    static var coloncurrencysignSquare: SFSymbol { .init(rawValue: "coloncurrencysign.square") }
 
     /// 􀘂
     /// Single Localization, 3 Layersets
@@ -6933,42 +6933,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let coloncurrencysignSquareFill = SFSymbol(rawValue: "coloncurrencysign.square.fill")
+    static var coloncurrencysignSquareFill: SFSymbol { .init(rawValue: "coloncurrencysign.square.fill") }
 
     /// 􀆔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let command = SFSymbol(rawValue: "command")
+    static var command: SFSymbol { .init(rawValue: "command") }
 
     /// 􀆍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let control = SFSymbol(rawValue: "control")
+    static var control: SFSymbol { .init(rawValue: "control") }
 
     /// 􀍯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let creditcard = SFSymbol(rawValue: "creditcard")
+    static var creditcard: SFSymbol { .init(rawValue: "creditcard") }
 
     /// 􀍰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let creditcardFill = SFSymbol(rawValue: "creditcard.fill")
+    static var creditcardFill: SFSymbol { .init(rawValue: "creditcard.fill") }
 
     /// 􀍳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let crop = SFSymbol(rawValue: "crop")
+    static var crop: SFSymbol { .init(rawValue: "crop") }
 
     /// 􀍴
     /// Single Localization, 2 Layersets
@@ -6976,7 +6976,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cropRotate = SFSymbol(rawValue: "crop.rotate")
+    static var cropRotate: SFSymbol { .init(rawValue: "crop.rotate") }
 
     /// 􀗅
     /// Single Localization, 2 Layersets
@@ -6984,7 +6984,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cruzeirosignCircle = SFSymbol(rawValue: "cruzeirosign.circle")
+    static var cruzeirosignCircle: SFSymbol { .init(rawValue: "cruzeirosign.circle") }
 
     /// 􀗆
     /// Single Localization, 3 Layersets
@@ -6993,7 +6993,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cruzeirosignCircleFill = SFSymbol(rawValue: "cruzeirosign.circle.fill")
+    static var cruzeirosignCircleFill: SFSymbol { .init(rawValue: "cruzeirosign.circle.fill") }
 
     /// 􀘅
     /// Single Localization, 2 Layersets
@@ -7001,7 +7001,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cruzeirosignSquare = SFSymbol(rawValue: "cruzeirosign.square")
+    static var cruzeirosignSquare: SFSymbol { .init(rawValue: "cruzeirosign.square") }
 
     /// 􀘆
     /// Single Localization, 3 Layersets
@@ -7010,14 +7010,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cruzeirosignSquareFill = SFSymbol(rawValue: "cruzeirosign.square.fill")
+    static var cruzeirosignSquareFill: SFSymbol { .init(rawValue: "cruzeirosign.square.fill") }
 
     /// 􀐘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cube = SFSymbol(rawValue: "cube")
+    static var cube: SFSymbol { .init(rawValue: "cube") }
 
     /// 􀐚
     /// Single Localization, Single Layerset
@@ -7029,7 +7029,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shippingbox")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shippingbox")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shippingbox")
-    static let cubeBox = SFSymbol(rawValue: "cube.box")
+    static var cubeBox: SFSymbol { .init(rawValue: "cube.box") }
 
     /// 􀐛
     /// Single Localization, Single Layerset
@@ -7041,14 +7041,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shippingboxFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shippingboxFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shippingboxFill")
-    static let cubeBoxFill = SFSymbol(rawValue: "cube.box.fill")
+    static var cubeBoxFill: SFSymbol { .init(rawValue: "cube.box.fill") }
 
     /// 􀐙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cubeFill = SFSymbol(rawValue: "cube.fill")
+    static var cubeFill: SFSymbol { .init(rawValue: "cube.fill") }
 
     /// 􀇰
     /// Single Localization, Single Layerset
@@ -7060,7 +7060,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "cursorarrowRays")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "cursorarrowRays")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "cursorarrowRays")
-    static let cursorRays = SFSymbol(rawValue: "cursor.rays")
+    static var cursorRays: SFSymbol { .init(rawValue: "cursor.rays") }
 
     /// 􀀊
     /// Single Localization, 2 Layersets
@@ -7068,7 +7068,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dCircle = SFSymbol(rawValue: "d.circle")
+    static var dCircle: SFSymbol { .init(rawValue: "d.circle") }
 
     /// 􀀋
     /// Single Localization, 3 Layersets
@@ -7077,7 +7077,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dCircleFill = SFSymbol(rawValue: "d.circle.fill")
+    static var dCircleFill: SFSymbol { .init(rawValue: "d.circle.fill") }
 
     /// 􀂚
     /// Single Localization, 2 Layersets
@@ -7085,7 +7085,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dSquare = SFSymbol(rawValue: "d.square")
+    static var dSquare: SFSymbol { .init(rawValue: "d.square") }
 
     /// 􀂛
     /// Single Localization, 3 Layersets
@@ -7094,7 +7094,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dSquareFill = SFSymbol(rawValue: "d.square.fill")
+    static var dSquareFill: SFSymbol { .init(rawValue: "d.square.fill") }
 
     /// 􀋶
     /// Single Localization, 3 Layersets
@@ -7103,7 +7103,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let decreaseIndent = SFSymbol(rawValue: "decrease.indent")
+    static var decreaseIndent: SFSymbol { .init(rawValue: "decrease.indent") }
 
     /// 􀝿
     /// Single Localization, 3 Layersets
@@ -7112,7 +7112,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let decreaseQuotelevel = SFSymbol(rawValue: "decrease.quotelevel")
+    static var decreaseQuotelevel: SFSymbol { .init(rawValue: "decrease.quotelevel") }
 
     /// 􀆛
     /// Single Localization, 3 Layersets
@@ -7121,7 +7121,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let deleteLeft = SFSymbol(rawValue: "delete.left")
+    static var deleteLeft: SFSymbol { .init(rawValue: "delete.left") }
 
     /// 􀆜
     /// Single Localization, 3 Layersets
@@ -7130,7 +7130,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let deleteLeftFill = SFSymbol(rawValue: "delete.left.fill")
+    static var deleteLeftFill: SFSymbol { .init(rawValue: "delete.left.fill") }
 
     /// 􀆗
     /// Single Localization, 3 Layersets
@@ -7139,7 +7139,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let deleteRight = SFSymbol(rawValue: "delete.right")
+    static var deleteRight: SFSymbol { .init(rawValue: "delete.right") }
 
     /// 􀆘
     /// Single Localization, 3 Layersets
@@ -7148,7 +7148,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let deleteRightFill = SFSymbol(rawValue: "delete.right.fill")
+    static var deleteRightFill: SFSymbol { .init(rawValue: "delete.right.fill") }
 
     /// 􀙗
     /// Single Localization, 2 Layersets
@@ -7156,7 +7156,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let desktopcomputer = SFSymbol(rawValue: "desktopcomputer")
+    static var desktopcomputer: SFSymbol { .init(rawValue: "desktopcomputer") }
 
     /// 􀍺
     /// Single Localization, Single Layerset
@@ -7168,7 +7168,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "dialMin")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "dialMin")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialMin")
-    static let dial = SFSymbol(rawValue: "dial")
+    static var dial: SFSymbol { .init(rawValue: "dial") }
 
     /// 􀍻
     /// Single Localization, Single Layerset
@@ -7180,14 +7180,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "dialMinFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "dialMinFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialMinFill")
-    static let dialFill = SFSymbol(rawValue: "dial.fill")
+    static var dialFill: SFSymbol { .init(rawValue: "dial.fill") }
 
     /// 􀅿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let divide = SFSymbol(rawValue: "divide")
+    static var divide: SFSymbol { .init(rawValue: "divide") }
 
     /// 􀁒
     /// Single Localization, 2 Layersets
@@ -7195,7 +7195,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let divideCircle = SFSymbol(rawValue: "divide.circle")
+    static var divideCircle: SFSymbol { .init(rawValue: "divide.circle") }
 
     /// 􀁓
     /// Single Localization, 3 Layersets
@@ -7204,7 +7204,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let divideCircleFill = SFSymbol(rawValue: "divide.circle.fill")
+    static var divideCircleFill: SFSymbol { .init(rawValue: "divide.circle.fill") }
 
     /// 􀃢
     /// Single Localization, 2 Layersets
@@ -7212,7 +7212,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let divideSquare = SFSymbol(rawValue: "divide.square")
+    static var divideSquare: SFSymbol { .init(rawValue: "divide.square") }
 
     /// 􀃣
     /// Single Localization, 3 Layersets
@@ -7221,7 +7221,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let divideSquareFill = SFSymbol(rawValue: "divide.square.fill")
+    static var divideSquareFill: SFSymbol { .init(rawValue: "divide.square.fill") }
 
     /// 􀈷
     /// Single Localization, Single Layerset
@@ -7233,7 +7233,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "document")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "document")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "document")
-    static let doc = SFSymbol(rawValue: "doc")
+    static var doc: SFSymbol { .init(rawValue: "doc") }
 
     /// 􀉇
     /// 2 Localizations, Single Layerset
@@ -7249,7 +7249,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "appendPage")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "appendPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "appendPage")
-    static let docAppend = SymbolWith1Localization<Rtl_v2>(rawValue: "doc.append")
+    static var docAppend: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "doc.append") }
 
     /// 􀈹
     /// Single Localization, 2 Layersets
@@ -7262,7 +7262,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentCircle")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentCircle")
-    static let docCircle = SFSymbol(rawValue: "doc.circle")
+    static var docCircle: SFSymbol { .init(rawValue: "doc.circle") }
 
     /// 􀈺
     /// Single Localization, 3 Layersets
@@ -7276,7 +7276,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentCircleFill")
-    static let docCircleFill = SFSymbol(rawValue: "doc.circle.fill")
+    static var docCircleFill: SFSymbol { .init(rawValue: "doc.circle.fill") }
 
     /// 􀈸
     /// Single Localization, Single Layerset
@@ -7288,7 +7288,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentFill")
-    static let docFill = SFSymbol(rawValue: "doc.fill")
+    static var docFill: SFSymbol { .init(rawValue: "doc.fill") }
 
     /// 􀉃
     /// Single Localization, 3 Layersets
@@ -7302,7 +7302,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentOnClipboard")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentOnClipboard")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentOnClipboard")
-    static let docOnClipboard = SFSymbol(rawValue: "doc.on.clipboard")
+    static var docOnClipboard: SFSymbol { .init(rawValue: "doc.on.clipboard") }
 
     /// 􀉄
     /// Single Localization, 2 Layersets
@@ -7315,7 +7315,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentOnClipboardFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentOnClipboardFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentOnClipboardFill")
-    static let docOnClipboardFill = SFSymbol(rawValue: "doc.on.clipboard.fill")
+    static var docOnClipboardFill: SFSymbol { .init(rawValue: "doc.on.clipboard.fill") }
 
     /// 􀉁
     /// Single Localization, 3 Layersets
@@ -7329,7 +7329,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentOnDocument")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentOnDocument")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentOnDocument")
-    static let docOnDoc = SFSymbol(rawValue: "doc.on.doc")
+    static var docOnDoc: SFSymbol { .init(rawValue: "doc.on.doc") }
 
     /// 􀉂
     /// Single Localization, 2 Layersets
@@ -7342,7 +7342,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "documentOnDocumentFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "documentOnDocumentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentOnDocumentFill")
-    static let docOnDocFill = SFSymbol(rawValue: "doc.on.doc.fill")
+    static var docOnDocFill: SFSymbol { .init(rawValue: "doc.on.doc.fill") }
 
     /// 􀉆
     /// Single Localization, Single Layerset
@@ -7354,7 +7354,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textPage")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textPage")
-    static let docPlaintext = SFSymbol(rawValue: "doc.plaintext")
+    static var docPlaintext: SFSymbol { .init(rawValue: "doc.plaintext") }
 
     /// 􀉅
     /// 8 Localizations, Single Layerset
@@ -7376,7 +7376,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "richtextPage")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "richtextPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "richtextPage")
-    static let docRichtext = SymbolWith7Localizations<Ar_v2, He_v2, Hi_v3, Ja_v3, Ko_v3, Th_v3, Zh_v3>(rawValue: "doc.richtext")
+    static var docRichtext: SymbolWith7Localizations<Ar_v2, He_v2, Hi_v3, Ja_v3, Ko_v3, Th_v3, Zh_v3> { .init(rawValue: "doc.richtext") }
 
     /// 􀈿
     /// Single Localization, 2 Layersets
@@ -7389,7 +7389,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textDocument")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textDocument")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textDocument")
-    static let docText = SFSymbol(rawValue: "doc.text")
+    static var docText: SFSymbol { .init(rawValue: "doc.text") }
 
     /// 􀉀
     /// Single Localization, 2 Layersets
@@ -7402,7 +7402,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textDocumentFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textDocumentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textDocumentFill")
-    static let docTextFill = SFSymbol(rawValue: "doc.text.fill")
+    static var docTextFill: SFSymbol { .init(rawValue: "doc.text.fill") }
 
     /// 􀕹
     /// Single Localization, 2 Layersets
@@ -7415,7 +7415,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textPageBadgeMagnifyingglass")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textPageBadgeMagnifyingglass")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textPageBadgeMagnifyingglass")
-    static let docTextMagnifyingglass = SFSymbol(rawValue: "doc.text.magnifyingglass")
+    static var docTextMagnifyingglass: SFSymbol { .init(rawValue: "doc.text.magnifyingglass") }
 
     /// 􀎾
     /// Single Localization, Single Layerset
@@ -7427,7 +7427,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "docViewfinder")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "docViewfinder")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "docViewfinder")
-    static let docTextViewfinder = SFSymbol(rawValue: "doc.text.viewfinder")
+    static var docTextViewfinder: SFSymbol { .init(rawValue: "doc.text.viewfinder") }
 
     /// 􀖗
     /// Single Localization, 2 Layersets
@@ -7435,7 +7435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dollarsignCircle = SFSymbol(rawValue: "dollarsign.circle")
+    static var dollarsignCircle: SFSymbol { .init(rawValue: "dollarsign.circle") }
 
     /// 􀖘
     /// Single Localization, 3 Layersets
@@ -7444,7 +7444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dollarsignCircleFill = SFSymbol(rawValue: "dollarsign.circle.fill")
+    static var dollarsignCircleFill: SFSymbol { .init(rawValue: "dollarsign.circle.fill") }
 
     /// 􀗗
     /// Single Localization, 2 Layersets
@@ -7452,7 +7452,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dollarsignSquare = SFSymbol(rawValue: "dollarsign.square")
+    static var dollarsignSquare: SFSymbol { .init(rawValue: "dollarsign.square") }
 
     /// 􀗘
     /// Single Localization, 3 Layersets
@@ -7461,7 +7461,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dollarsignSquareFill = SFSymbol(rawValue: "dollarsign.square.fill")
+    static var dollarsignSquareFill: SFSymbol { .init(rawValue: "dollarsign.square.fill") }
 
     /// 􀖩
     /// Single Localization, 2 Layersets
@@ -7469,7 +7469,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dongsignCircle = SFSymbol(rawValue: "dongsign.circle")
+    static var dongsignCircle: SFSymbol { .init(rawValue: "dongsign.circle") }
 
     /// 􀖪
     /// Single Localization, 3 Layersets
@@ -7478,7 +7478,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dongsignCircleFill = SFSymbol(rawValue: "dongsign.circle.fill")
+    static var dongsignCircleFill: SFSymbol { .init(rawValue: "dongsign.circle.fill") }
 
     /// 􀗩
     /// Single Localization, 2 Layersets
@@ -7486,7 +7486,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dongsignSquare = SFSymbol(rawValue: "dongsign.square")
+    static var dongsignSquare: SFSymbol { .init(rawValue: "dongsign.square") }
 
     /// 􀗪
     /// Single Localization, 3 Layersets
@@ -7495,7 +7495,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dongsignSquareFill = SFSymbol(rawValue: "dongsign.square.fill")
+    static var dongsignSquareFill: SFSymbol { .init(rawValue: "dongsign.square.fill") }
 
     /// 􀌙
     /// Single Localization, 3 Layersets
@@ -7504,7 +7504,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotRadiowavesLeftAndRight = SFSymbol(rawValue: "dot.radiowaves.left.and.right")
+    static var dotRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "dot.radiowaves.left.and.right") }
 
     /// 􀖒
     /// Single Localization, 3 Layersets
@@ -7513,7 +7513,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotRadiowavesRight = SFSymbol(rawValue: "dot.radiowaves.right")
+    static var dotRadiowavesRight: SFSymbol { .init(rawValue: "dot.radiowaves.right") }
 
     /// 􀕴
     /// Single Localization, 2 Layersets
@@ -7521,7 +7521,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dotSquare = SFSymbol(rawValue: "dot.square")
+    static var dotSquare: SFSymbol { .init(rawValue: "dot.square") }
 
     /// 􀕵
     /// Single Localization, 3 Layersets
@@ -7530,7 +7530,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotSquareFill = SFSymbol(rawValue: "dot.square.fill")
+    static var dotSquareFill: SFSymbol { .init(rawValue: "dot.square.fill") }
 
     /// 􀈀
     /// Single Localization, 2 Layersets
@@ -7538,7 +7538,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dropTriangle = SFSymbol(rawValue: "drop.triangle")
+    static var dropTriangle: SFSymbol { .init(rawValue: "drop.triangle") }
 
     /// 􀈁
     /// Single Localization, 3 Layersets
@@ -7547,7 +7547,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dropTriangleFill = SFSymbol(rawValue: "drop.triangle.fill")
+    static var dropTriangleFill: SFSymbol { .init(rawValue: "drop.triangle.fill") }
 
     /// 􀀌
     /// Single Localization, 2 Layersets
@@ -7555,7 +7555,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eCircle = SFSymbol(rawValue: "e.circle")
+    static var eCircle: SFSymbol { .init(rawValue: "e.circle") }
 
     /// 􀀍
     /// Single Localization, 3 Layersets
@@ -7564,7 +7564,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eCircleFill = SFSymbol(rawValue: "e.circle.fill")
+    static var eCircleFill: SFSymbol { .init(rawValue: "e.circle.fill") }
 
     /// 􀂜
     /// Single Localization, 2 Layersets
@@ -7572,7 +7572,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eSquare = SFSymbol(rawValue: "e.square")
+    static var eSquare: SFSymbol { .init(rawValue: "e.square") }
 
     /// 􀂝
     /// Single Localization, 3 Layersets
@@ -7581,7 +7581,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eSquareFill = SFSymbol(rawValue: "e.square.fill")
+    static var eSquareFill: SFSymbol { .init(rawValue: "e.square.fill") }
 
     /// 􀜣
     /// Single Localization, 2 Layersets
@@ -7589,21 +7589,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ear = SFSymbol(rawValue: "ear")
+    static var ear: SFSymbol { .init(rawValue: "ear") }
 
     /// 􀆥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eject = SFSymbol(rawValue: "eject")
+    static var eject: SFSymbol { .init(rawValue: "eject") }
 
     /// 􀆦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ejectFill = SFSymbol(rawValue: "eject.fill")
+    static var ejectFill: SFSymbol { .init(rawValue: "eject.fill") }
 
     /// 􀕺
     /// Single Localization, 3 Layersets
@@ -7617,7 +7617,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "ellipsisBubble")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "ellipsisBubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ellipsisBubble")
-    static let ellipsesBubble = SFSymbol(rawValue: "ellipses.bubble")
+    static var ellipsesBubble: SFSymbol { .init(rawValue: "ellipses.bubble") }
 
     /// 􀕻
     /// Single Localization, 3 Layersets
@@ -7631,7 +7631,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "ellipsisBubbleFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "ellipsisBubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ellipsisBubbleFill")
-    static let ellipsesBubbleFill = SFSymbol(rawValue: "ellipses.bubble.fill")
+    static var ellipsesBubbleFill: SFSymbol { .init(rawValue: "ellipses.bubble.fill") }
 
     /// 􀍠
     /// Single Localization, 3 Layersets
@@ -7640,7 +7640,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsis = SFSymbol(rawValue: "ellipsis")
+    static var ellipsis: SFSymbol { .init(rawValue: "ellipsis") }
 
     /// 􀍡
     /// Single Localization, 3 Layersets
@@ -7649,7 +7649,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisCircle = SFSymbol(rawValue: "ellipsis.circle")
+    static var ellipsisCircle: SFSymbol { .init(rawValue: "ellipsis.circle") }
 
     /// 􀍢
     /// Single Localization, 3 Layersets
@@ -7658,14 +7658,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ellipsisCircleFill = SFSymbol(rawValue: "ellipsis.circle.fill")
+    static var ellipsisCircleFill: SFSymbol { .init(rawValue: "ellipsis.circle.fill") }
 
     /// 􀍕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelope = SFSymbol(rawValue: "envelope")
+    static var envelope: SFSymbol { .init(rawValue: "envelope") }
 
     /// 􀍛
     /// Single Localization, 3 Layersets
@@ -7674,7 +7674,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let envelopeBadge = SFSymbol(rawValue: "envelope.badge")
+    static var envelopeBadge: SFSymbol { .init(rawValue: "envelope.badge") }
 
     /// 􀍜
     /// Single Localization, 2 Layersets
@@ -7682,7 +7682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let envelopeBadgeFill = SFSymbol(rawValue: "envelope.badge.fill")
+    static var envelopeBadgeFill: SFSymbol { .init(rawValue: "envelope.badge.fill") }
 
     /// 􀍗
     /// Single Localization, 2 Layersets
@@ -7690,7 +7690,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let envelopeCircle = SFSymbol(rawValue: "envelope.circle")
+    static var envelopeCircle: SFSymbol { .init(rawValue: "envelope.circle") }
 
     /// 􀍘
     /// Single Localization, 3 Layersets
@@ -7699,35 +7699,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let envelopeCircleFill = SFSymbol(rawValue: "envelope.circle.fill")
+    static var envelopeCircleFill: SFSymbol { .init(rawValue: "envelope.circle.fill") }
 
     /// 􀍖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeFill = SFSymbol(rawValue: "envelope.fill")
+    static var envelopeFill: SFSymbol { .init(rawValue: "envelope.fill") }
 
     /// 􀍙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeOpen = SFSymbol(rawValue: "envelope.open")
+    static var envelopeOpen: SFSymbol { .init(rawValue: "envelope.open") }
 
     /// 􀍚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeOpenFill = SFSymbol(rawValue: "envelope.open.fill")
+    static var envelopeOpenFill: SFSymbol { .init(rawValue: "envelope.open.fill") }
 
     /// 􀆀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let equal = SFSymbol(rawValue: "equal")
+    static var equal: SFSymbol { .init(rawValue: "equal") }
 
     /// 􀁔
     /// Single Localization, 2 Layersets
@@ -7735,7 +7735,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let equalCircle = SFSymbol(rawValue: "equal.circle")
+    static var equalCircle: SFSymbol { .init(rawValue: "equal.circle") }
 
     /// 􀁕
     /// Single Localization, 3 Layersets
@@ -7744,7 +7744,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let equalCircleFill = SFSymbol(rawValue: "equal.circle.fill")
+    static var equalCircleFill: SFSymbol { .init(rawValue: "equal.circle.fill") }
 
     /// 􀃤
     /// Single Localization, 2 Layersets
@@ -7752,7 +7752,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let equalSquare = SFSymbol(rawValue: "equal.square")
+    static var equalSquare: SFSymbol { .init(rawValue: "equal.square") }
 
     /// 􀃥
     /// Single Localization, 3 Layersets
@@ -7761,7 +7761,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let equalSquareFill = SFSymbol(rawValue: "equal.square.fill")
+    static var equalSquareFill: SFSymbol { .init(rawValue: "equal.square.fill") }
 
     /// 􀆧
     /// Single Localization, 2 Layersets
@@ -7769,7 +7769,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let escape = SFSymbol(rawValue: "escape")
+    static var escape: SFSymbol { .init(rawValue: "escape") }
 
     /// 􀖧
     /// Single Localization, 2 Layersets
@@ -7777,7 +7777,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eurosignCircle = SFSymbol(rawValue: "eurosign.circle")
+    static var eurosignCircle: SFSymbol { .init(rawValue: "eurosign.circle") }
 
     /// 􀖨
     /// Single Localization, 3 Layersets
@@ -7786,7 +7786,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eurosignCircleFill = SFSymbol(rawValue: "eurosign.circle.fill")
+    static var eurosignCircleFill: SFSymbol { .init(rawValue: "eurosign.circle.fill") }
 
     /// 􀗧
     /// Single Localization, 2 Layersets
@@ -7794,7 +7794,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eurosignSquare = SFSymbol(rawValue: "eurosign.square")
+    static var eurosignSquare: SFSymbol { .init(rawValue: "eurosign.square") }
 
     /// 􀗨
     /// Single Localization, 3 Layersets
@@ -7803,7 +7803,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eurosignSquareFill = SFSymbol(rawValue: "eurosign.square.fill")
+    static var eurosignSquareFill: SFSymbol { .init(rawValue: "eurosign.square.fill") }
 
     /// 􀅎
     /// Single Localization, 2 Layersets
@@ -7811,7 +7811,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmark = SFSymbol(rawValue: "exclamationmark")
+    static var exclamationmark: SFSymbol { .init(rawValue: "exclamationmark") }
 
     /// 􀌬
     /// Single Localization, 2 Layersets
@@ -7819,7 +7819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkBubble = SFSymbol(rawValue: "exclamationmark.bubble")
+    static var exclamationmarkBubble: SFSymbol { .init(rawValue: "exclamationmark.bubble") }
 
     /// 􀌭
     /// Single Localization, 3 Layersets
@@ -7828,7 +7828,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let exclamationmarkBubbleFill = SFSymbol(rawValue: "exclamationmark.bubble.fill")
+    static var exclamationmarkBubbleFill: SFSymbol { .init(rawValue: "exclamationmark.bubble.fill") }
 
     /// 􀁞
     /// Single Localization, 3 Layersets
@@ -7837,7 +7837,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkCircle = SFSymbol(rawValue: "exclamationmark.circle")
+    static var exclamationmarkCircle: SFSymbol { .init(rawValue: "exclamationmark.circle") }
 
     /// 􀁟
     /// Single Localization, 3 Layersets
@@ -7846,7 +7846,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkCircleFill = SFSymbol(rawValue: "exclamationmark.circle.fill")
+    static var exclamationmarkCircleFill: SFSymbol { .init(rawValue: "exclamationmark.circle.fill") }
 
     /// 􀌑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7856,7 +7856,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let exclamationmarkIcloud = SFSymbol(rawValue: "exclamationmark.icloud")
+    static var exclamationmarkIcloud: SFSymbol { .init(rawValue: "exclamationmark.icloud") }
 
     /// 􀌒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7867,7 +7867,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let exclamationmarkIcloudFill = SFSymbol(rawValue: "exclamationmark.icloud.fill")
+    static var exclamationmarkIcloudFill: SFSymbol { .init(rawValue: "exclamationmark.icloud.fill") }
 
     /// 􀘯
     /// Single Localization, 3 Layersets
@@ -7876,7 +7876,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkOctagon = SFSymbol(rawValue: "exclamationmark.octagon")
+    static var exclamationmarkOctagon: SFSymbol { .init(rawValue: "exclamationmark.octagon") }
 
     /// 􀘰
     /// Single Localization, 3 Layersets
@@ -7885,7 +7885,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkOctagonFill = SFSymbol(rawValue: "exclamationmark.octagon.fill")
+    static var exclamationmarkOctagonFill: SFSymbol { .init(rawValue: "exclamationmark.octagon.fill") }
 
     /// 􀞟
     /// Single Localization, 2 Layersets
@@ -7893,7 +7893,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkShield = SFSymbol(rawValue: "exclamationmark.shield")
+    static var exclamationmarkShield: SFSymbol { .init(rawValue: "exclamationmark.shield") }
 
     /// 􀞠
     /// Single Localization, 3 Layersets
@@ -7902,7 +7902,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let exclamationmarkShieldFill = SFSymbol(rawValue: "exclamationmark.shield.fill")
+    static var exclamationmarkShieldFill: SFSymbol { .init(rawValue: "exclamationmark.shield.fill") }
 
     /// 􀃮
     /// Single Localization, 3 Layersets
@@ -7911,7 +7911,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkSquare = SFSymbol(rawValue: "exclamationmark.square")
+    static var exclamationmarkSquare: SFSymbol { .init(rawValue: "exclamationmark.square") }
 
     /// 􀃯
     /// Single Localization, 3 Layersets
@@ -7920,7 +7920,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkSquareFill = SFSymbol(rawValue: "exclamationmark.square.fill")
+    static var exclamationmarkSquareFill: SFSymbol { .init(rawValue: "exclamationmark.square.fill") }
 
     /// 􀇾
     /// Single Localization, 3 Layersets
@@ -7929,7 +7929,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let exclamationmarkTriangle = SFSymbol(rawValue: "exclamationmark.triangle")
+    static var exclamationmarkTriangle: SFSymbol { .init(rawValue: "exclamationmark.triangle") }
 
     /// 􀇿
     /// Single Localization, 3 Layersets
@@ -7938,21 +7938,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmarkTriangleFill = SFSymbol(rawValue: "exclamationmark.triangle.fill")
+    static var exclamationmarkTriangleFill: SFSymbol { .init(rawValue: "exclamationmark.triangle.fill") }
 
     /// 􀋭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eye = SFSymbol(rawValue: "eye")
+    static var eye: SFSymbol { .init(rawValue: "eye") }
 
     /// 􀋮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyeFill = SFSymbol(rawValue: "eye.fill")
+    static var eyeFill: SFSymbol { .init(rawValue: "eye.fill") }
 
     /// 􀋯
     /// Single Localization, 2 Layersets
@@ -7960,7 +7960,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eyeSlash = SFSymbol(rawValue: "eye.slash")
+    static var eyeSlash: SFSymbol { .init(rawValue: "eye.slash") }
 
     /// 􀋰
     /// Single Localization, 2 Layersets
@@ -7968,35 +7968,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eyeSlashFill = SFSymbol(rawValue: "eye.slash.fill")
+    static var eyeSlashFill: SFSymbol { .init(rawValue: "eye.slash.fill") }
 
     /// 􀎗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyedropper = SFSymbol(rawValue: "eyedropper")
+    static var eyedropper: SFSymbol { .init(rawValue: "eyedropper") }
 
     /// 􀎙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyedropperFull = SFSymbol(rawValue: "eyedropper.full")
+    static var eyedropperFull: SFSymbol { .init(rawValue: "eyedropper.full") }
 
     /// 􀎘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyedropperHalffull = SFSymbol(rawValue: "eyedropper.halffull")
+    static var eyedropperHalffull: SFSymbol { .init(rawValue: "eyedropper.halffull") }
 
     /// 􀖆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyeglasses = SFSymbol(rawValue: "eyeglasses")
+    static var eyeglasses: SFSymbol { .init(rawValue: "eyeglasses") }
 
     /// 􀀎
     /// Single Localization, 2 Layersets
@@ -8004,7 +8004,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fCircle = SFSymbol(rawValue: "f.circle")
+    static var fCircle: SFSymbol { .init(rawValue: "f.circle") }
 
     /// 􀀏
     /// Single Localization, 3 Layersets
@@ -8013,14 +8013,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fCircleFill = SFSymbol(rawValue: "f.circle.fill")
+    static var fCircleFill: SFSymbol { .init(rawValue: "f.circle.fill") }
 
     /// 􀅭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fCursive = SFSymbol(rawValue: "f.cursive")
+    static var fCursive: SFSymbol { .init(rawValue: "f.cursive") }
 
     /// 􀝧
     /// Single Localization, 2 Layersets
@@ -8028,7 +8028,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fCursiveCircle = SFSymbol(rawValue: "f.cursive.circle")
+    static var fCursiveCircle: SFSymbol { .init(rawValue: "f.cursive.circle") }
 
     /// 􀝨
     /// Single Localization, 3 Layersets
@@ -8037,7 +8037,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fCursiveCircleFill = SFSymbol(rawValue: "f.cursive.circle.fill")
+    static var fCursiveCircleFill: SFSymbol { .init(rawValue: "f.cursive.circle.fill") }
 
     /// 􀂞
     /// Single Localization, 2 Layersets
@@ -8045,7 +8045,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fSquare = SFSymbol(rawValue: "f.square")
+    static var fSquare: SFSymbol { .init(rawValue: "f.square") }
 
     /// 􀂟
     /// Single Localization, 3 Layersets
@@ -8054,7 +8054,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let fSquareFill = SFSymbol(rawValue: "f.square.fill")
+    static var fSquareFill: SFSymbol { .init(rawValue: "f.square.fill") }
 
     /// 􀎽
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8065,21 +8065,21 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Face ID feature.
-    static let faceid = SFSymbol(rawValue: "faceid")
+    static var faceid: SFSymbol { .init(rawValue: "faceid") }
 
     /// 􀎶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let film = SFSymbol(rawValue: "film")
+    static var film: SFSymbol { .init(rawValue: "film") }
 
     /// 􀎷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let filmFill = SFSymbol(rawValue: "film.fill")
+    static var filmFill: SFSymbol { .init(rawValue: "film.fill") }
 
     /// 􀋉
     /// Single Localization, 2 Layersets
@@ -8087,7 +8087,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let flag = SFSymbol(rawValue: "flag")
+    static var flag: SFSymbol { .init(rawValue: "flag") }
 
     /// 􀋋
     /// Single Localization, 3 Layersets
@@ -8096,7 +8096,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let flagCircle = SFSymbol(rawValue: "flag.circle")
+    static var flagCircle: SFSymbol { .init(rawValue: "flag.circle") }
 
     /// 􀋌
     /// Single Localization, 3 Layersets
@@ -8105,7 +8105,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let flagCircleFill = SFSymbol(rawValue: "flag.circle.fill")
+    static var flagCircleFill: SFSymbol { .init(rawValue: "flag.circle.fill") }
 
     /// 􀋊
     /// Single Localization, 2 Layersets
@@ -8113,7 +8113,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let flagFill = SFSymbol(rawValue: "flag.fill")
+    static var flagFill: SFSymbol { .init(rawValue: "flag.fill") }
 
     /// 􀋍
     /// Single Localization, 3 Layersets
@@ -8122,7 +8122,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let flagSlash = SFSymbol(rawValue: "flag.slash")
+    static var flagSlash: SFSymbol { .init(rawValue: "flag.slash") }
 
     /// 􀋎
     /// Single Localization, 3 Layersets
@@ -8131,21 +8131,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let flagSlashFill = SFSymbol(rawValue: "flag.slash.fill")
+    static var flagSlashFill: SFSymbol { .init(rawValue: "flag.slash.fill") }
 
     /// 􀙬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flame = SFSymbol(rawValue: "flame")
+    static var flame: SFSymbol { .init(rawValue: "flame") }
 
     /// 􀙭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flameFill = SFSymbol(rawValue: "flame.fill")
+    static var flameFill: SFSymbol { .init(rawValue: "flame.fill") }
 
     /// 􀖡
     /// Single Localization, 2 Layersets
@@ -8153,7 +8153,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let florinsignCircle = SFSymbol(rawValue: "florinsign.circle")
+    static var florinsignCircle: SFSymbol { .init(rawValue: "florinsign.circle") }
 
     /// 􀖢
     /// Single Localization, 3 Layersets
@@ -8162,7 +8162,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let florinsignCircleFill = SFSymbol(rawValue: "florinsign.circle.fill")
+    static var florinsignCircleFill: SFSymbol { .init(rawValue: "florinsign.circle.fill") }
 
     /// 􀗡
     /// Single Localization, 2 Layersets
@@ -8170,7 +8170,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let florinsignSquare = SFSymbol(rawValue: "florinsign.square")
+    static var florinsignSquare: SFSymbol { .init(rawValue: "florinsign.square") }
 
     /// 􀗢
     /// Single Localization, 3 Layersets
@@ -8179,21 +8179,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let florinsignSquareFill = SFSymbol(rawValue: "florinsign.square.fill")
+    static var florinsignSquareFill: SFSymbol { .init(rawValue: "florinsign.square.fill") }
 
     /// 􀐕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flowchart = SFSymbol(rawValue: "flowchart")
+    static var flowchart: SFSymbol { .init(rawValue: "flowchart") }
 
     /// 􀐖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flowchartFill = SFSymbol(rawValue: "flowchart.fill")
+    static var flowchartFill: SFSymbol { .init(rawValue: "flowchart.fill") }
 
     /// 􀈕
     /// Single Localization, 2 Layersets
@@ -8201,7 +8201,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folder = SFSymbol(rawValue: "folder")
+    static var folder: SFSymbol { .init(rawValue: "folder") }
 
     /// 􀈛
     /// Single Localization, 3 Layersets
@@ -8210,7 +8210,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderBadgeMinus = SFSymbol(rawValue: "folder.badge.minus")
+    static var folderBadgeMinus: SFSymbol { .init(rawValue: "folder.badge.minus") }
 
     /// 􀈝
     /// Single Localization, 3 Layersets
@@ -8219,7 +8219,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let folderBadgePersonCrop = SFSymbol(rawValue: "folder.badge.person.crop")
+    static var folderBadgePersonCrop: SFSymbol { .init(rawValue: "folder.badge.person.crop") }
 
     /// 􀈙
     /// Single Localization, 3 Layersets
@@ -8228,7 +8228,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderBadgePlus = SFSymbol(rawValue: "folder.badge.plus")
+    static var folderBadgePlus: SFSymbol { .init(rawValue: "folder.badge.plus") }
 
     /// 􀈗
     /// Single Localization, 3 Layersets
@@ -8237,7 +8237,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderCircle = SFSymbol(rawValue: "folder.circle")
+    static var folderCircle: SFSymbol { .init(rawValue: "folder.circle") }
 
     /// 􀈘
     /// Single Localization, 3 Layersets
@@ -8246,7 +8246,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderCircleFill = SFSymbol(rawValue: "folder.circle.fill")
+    static var folderCircleFill: SFSymbol { .init(rawValue: "folder.circle.fill") }
 
     /// 􀈖
     /// Single Localization, 2 Layersets
@@ -8254,7 +8254,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderFill = SFSymbol(rawValue: "folder.fill")
+    static var folderFill: SFSymbol { .init(rawValue: "folder.fill") }
 
     /// 􀈜
     /// Single Localization, 3 Layersets
@@ -8263,7 +8263,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderFillBadgeMinus = SFSymbol(rawValue: "folder.fill.badge.minus")
+    static var folderFillBadgeMinus: SFSymbol { .init(rawValue: "folder.fill.badge.minus") }
 
     /// 􀈞
     /// Single Localization, 3 Layersets
@@ -8272,7 +8272,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let folderFillBadgePersonCrop = SFSymbol(rawValue: "folder.fill.badge.person.crop")
+    static var folderFillBadgePersonCrop: SFSymbol { .init(rawValue: "folder.fill.badge.person.crop") }
 
     /// 􀈚
     /// Single Localization, 3 Layersets
@@ -8281,49 +8281,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderFillBadgePlus = SFSymbol(rawValue: "folder.fill.badge.plus")
+    static var folderFillBadgePlus: SFSymbol { .init(rawValue: "folder.fill.badge.plus") }
 
     /// 􀊋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forward = SFSymbol(rawValue: "forward")
+    static var forward: SFSymbol { .init(rawValue: "forward") }
 
     /// 􀊏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardEnd = SFSymbol(rawValue: "forward.end")
+    static var forwardEnd: SFSymbol { .init(rawValue: "forward.end") }
 
     /// 􀊓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardEndAlt = SFSymbol(rawValue: "forward.end.alt")
+    static var forwardEndAlt: SFSymbol { .init(rawValue: "forward.end.alt") }
 
     /// 􀊔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardEndAltFill = SFSymbol(rawValue: "forward.end.alt.fill")
+    static var forwardEndAltFill: SFSymbol { .init(rawValue: "forward.end.alt.fill") }
 
     /// 􀊐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardEndFill = SFSymbol(rawValue: "forward.end.fill")
+    static var forwardEndFill: SFSymbol { .init(rawValue: "forward.end.fill") }
 
     /// 􀊌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardFill = SFSymbol(rawValue: "forward.fill")
+    static var forwardFill: SFSymbol { .init(rawValue: "forward.fill") }
 
     /// 􀖟
     /// Single Localization, 2 Layersets
@@ -8331,7 +8331,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let francsignCircle = SFSymbol(rawValue: "francsign.circle")
+    static var francsignCircle: SFSymbol { .init(rawValue: "francsign.circle") }
 
     /// 􀖠
     /// Single Localization, 3 Layersets
@@ -8340,7 +8340,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let francsignCircleFill = SFSymbol(rawValue: "francsign.circle.fill")
+    static var francsignCircleFill: SFSymbol { .init(rawValue: "francsign.circle.fill") }
 
     /// 􀗟
     /// Single Localization, 2 Layersets
@@ -8348,7 +8348,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let francsignSquare = SFSymbol(rawValue: "francsign.square")
+    static var francsignSquare: SFSymbol { .init(rawValue: "francsign.square") }
 
     /// 􀗠
     /// Single Localization, 3 Layersets
@@ -8357,7 +8357,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let francsignSquareFill = SFSymbol(rawValue: "francsign.square.fill")
+    static var francsignSquareFill: SFSymbol { .init(rawValue: "francsign.square.fill") }
 
     /// 􀅮
     /// 2 Localizations, Single Layerset
@@ -8368,14 +8368,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let function = SymbolWith1Localization<Ar_v6_3>(rawValue: "function")
+    static var function: SymbolWith1Localization<Ar_v6_3> { .init(rawValue: "function") }
 
     /// 􀅬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fx = SFSymbol(rawValue: "fx")
+    static var fx: SFSymbol { .init(rawValue: "fx") }
 
     /// 􀀐
     /// Single Localization, 2 Layersets
@@ -8383,7 +8383,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gCircle = SFSymbol(rawValue: "g.circle")
+    static var gCircle: SFSymbol { .init(rawValue: "g.circle") }
 
     /// 􀀑
     /// Single Localization, 3 Layersets
@@ -8392,7 +8392,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gCircleFill = SFSymbol(rawValue: "g.circle.fill")
+    static var gCircleFill: SFSymbol { .init(rawValue: "g.circle.fill") }
 
     /// 􀂠
     /// Single Localization, 2 Layersets
@@ -8400,7 +8400,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gSquare = SFSymbol(rawValue: "g.square")
+    static var gSquare: SFSymbol { .init(rawValue: "g.square") }
 
     /// 􀂡
     /// Single Localization, 3 Layersets
@@ -8409,7 +8409,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gSquareFill = SFSymbol(rawValue: "g.square.fill")
+    static var gSquareFill: SFSymbol { .init(rawValue: "g.square.fill") }
 
     /// 􀛸
     /// Single Localization, 2 Layersets
@@ -8417,14 +8417,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gamecontroller = SFSymbol(rawValue: "gamecontroller")
+    static var gamecontroller: SFSymbol { .init(rawValue: "gamecontroller") }
 
     /// 􀛹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gamecontrollerFill = SFSymbol(rawValue: "gamecontroller.fill")
+    static var gamecontrollerFill: SFSymbol { .init(rawValue: "gamecontroller.fill") }
 
     /// 􀍽
     /// Single Localization, Single Layerset
@@ -8436,7 +8436,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "gaugeMedium")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "gaugeMedium")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeMedium")
-    static let gauge = SFSymbol(rawValue: "gauge")
+    static var gauge: SFSymbol { .init(rawValue: "gauge") }
 
     /// 􀓧
     /// Single Localization, Single Layerset
@@ -8448,7 +8448,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "gaugeMediumBadgeMinus")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "gaugeMediumBadgeMinus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeMediumBadgeMinus")
-    static let gaugeBadgeMinus = SFSymbol(rawValue: "gauge.badge.minus")
+    static var gaugeBadgeMinus: SFSymbol { .init(rawValue: "gauge.badge.minus") }
 
     /// 􀓓
     /// Single Localization, Single Layerset
@@ -8460,7 +8460,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "gaugeMediumBadgePlus")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "gaugeMediumBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeMediumBadgePlus")
-    static let gaugeBadgePlus = SFSymbol(rawValue: "gauge.badge.plus")
+    static var gaugeBadgePlus: SFSymbol { .init(rawValue: "gauge.badge.plus") }
 
     /// 􀍟
     /// Single Localization, 2 Layersets
@@ -8468,7 +8468,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gear = SFSymbol(rawValue: "gear")
+    static var gear: SFSymbol { .init(rawValue: "gear") }
 
     /// 􀑉
     /// Single Localization, 2 Layersets
@@ -8476,7 +8476,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let gift = SFSymbol(rawValue: "gift")
+    static var gift: SFSymbol { .init(rawValue: "gift") }
 
     /// 􀑊
     /// Single Localization, 2 Layersets
@@ -8484,14 +8484,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let giftFill = SFSymbol(rawValue: "gift.fill")
+    static var giftFill: SFSymbol { .init(rawValue: "gift.fill") }
 
     /// 􀆪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globe = SFSymbol(rawValue: "globe")
+    static var globe: SFSymbol { .init(rawValue: "globe") }
 
     /// 􀎀
     /// Single Localization, Single Layerset
@@ -8503,7 +8503,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadCounterclockwise")
-    static let gobackward = SFSymbol(rawValue: "gobackward")
+    static var gobackward: SFSymbol { .init(rawValue: "gobackward") }
 
     /// 􀎂
     /// 3 Localizations, 2 Layersets
@@ -8521,7 +8521,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_10ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_10ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_10ArrowTriangleheadCounterclockwise")
-    static let gobackward10 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.10")
+    static var gobackward10: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.10") }
 
     /// 􀎄
     /// 3 Localizations, 2 Layersets
@@ -8539,7 +8539,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_15ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_15ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_15ArrowTriangleheadCounterclockwise")
-    static let gobackward15 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.15")
+    static var gobackward15: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.15") }
 
     /// 􀎆
     /// 3 Localizations, 2 Layersets
@@ -8557,7 +8557,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_30ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_30ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_30ArrowTriangleheadCounterclockwise")
-    static let gobackward30 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.30")
+    static var gobackward30: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.30") }
 
     /// 􀎈
     /// 3 Localizations, 2 Layersets
@@ -8575,7 +8575,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_45ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_45ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_45ArrowTriangleheadCounterclockwise")
-    static let gobackward45 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.45")
+    static var gobackward45: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.45") }
 
     /// 􀎊
     /// 3 Localizations, 2 Layersets
@@ -8593,7 +8593,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_60ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_60ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_60ArrowTriangleheadCounterclockwise")
-    static let gobackward60 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.60")
+    static var gobackward60: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.60") }
 
     /// 􀘥
     /// 3 Localizations, 2 Layersets
@@ -8611,7 +8611,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_75ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_75ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_75ArrowTriangleheadCounterclockwise")
-    static let gobackward75 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.75")
+    static var gobackward75: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.75") }
 
     /// 􀘧
     /// 3 Localizations, 2 Layersets
@@ -8629,7 +8629,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_90ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_90ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_90ArrowTriangleheadCounterclockwise")
-    static let gobackward90 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.90")
+    static var gobackward90: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.90") }
 
     /// 􀘩
     /// Single Localization, 2 Layersets
@@ -8642,7 +8642,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "minusArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "minusArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "minusArrowTriangleheadCounterclockwise")
-    static let gobackwardMinus = SFSymbol(rawValue: "gobackward.minus")
+    static var gobackwardMinus: SFSymbol { .init(rawValue: "gobackward.minus") }
 
     /// 􀍿
     /// Single Localization, Single Layerset
@@ -8654,7 +8654,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "arrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "arrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadClockwise")
-    static let goforward = SFSymbol(rawValue: "goforward")
+    static var goforward: SFSymbol { .init(rawValue: "goforward") }
 
     /// 􀎁
     /// 3 Localizations, 2 Layersets
@@ -8672,7 +8672,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_10ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_10ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_10ArrowTriangleheadClockwise")
-    static let goforward10 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.10")
+    static var goforward10: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.10") }
 
     /// 􀎃
     /// 3 Localizations, 2 Layersets
@@ -8690,7 +8690,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_15ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_15ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_15ArrowTriangleheadClockwise")
-    static let goforward15 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.15")
+    static var goforward15: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.15") }
 
     /// 􀎅
     /// 3 Localizations, 2 Layersets
@@ -8708,7 +8708,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_30ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_30ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_30ArrowTriangleheadClockwise")
-    static let goforward30 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.30")
+    static var goforward30: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.30") }
 
     /// 􀎇
     /// 3 Localizations, 2 Layersets
@@ -8726,7 +8726,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_45ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_45ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_45ArrowTriangleheadClockwise")
-    static let goforward45 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.45")
+    static var goforward45: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.45") }
 
     /// 􀎉
     /// 3 Localizations, 2 Layersets
@@ -8744,7 +8744,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_60ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_60ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_60ArrowTriangleheadClockwise")
-    static let goforward60 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.60")
+    static var goforward60: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.60") }
 
     /// 􀘤
     /// 3 Localizations, 2 Layersets
@@ -8762,7 +8762,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_75ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_75ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_75ArrowTriangleheadClockwise")
-    static let goforward75 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.75")
+    static var goforward75: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.75") }
 
     /// 􀘦
     /// 3 Localizations, 2 Layersets
@@ -8780,7 +8780,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "_90ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "_90ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_90ArrowTriangleheadClockwise")
-    static let goforward90 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.90")
+    static var goforward90: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.90") }
 
     /// 􀘨
     /// Single Localization, 2 Layersets
@@ -8793,14 +8793,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "plusArrowTriangleheadClockwise")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "plusArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "plusArrowTriangleheadClockwise")
-    static let goforwardPlus = SFSymbol(rawValue: "goforward.plus")
+    static var goforwardPlus: SFSymbol { .init(rawValue: "goforward.plus") }
 
     /// 􀆂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let greaterthan = SFSymbol(rawValue: "greaterthan")
+    static var greaterthan: SFSymbol { .init(rawValue: "greaterthan") }
 
     /// 􀁖
     /// Single Localization, 2 Layersets
@@ -8808,7 +8808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let greaterthanCircle = SFSymbol(rawValue: "greaterthan.circle")
+    static var greaterthanCircle: SFSymbol { .init(rawValue: "greaterthan.circle") }
 
     /// 􀁗
     /// Single Localization, 3 Layersets
@@ -8817,7 +8817,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let greaterthanCircleFill = SFSymbol(rawValue: "greaterthan.circle.fill")
+    static var greaterthanCircleFill: SFSymbol { .init(rawValue: "greaterthan.circle.fill") }
 
     /// 􀃨
     /// Single Localization, 2 Layersets
@@ -8825,7 +8825,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let greaterthanSquare = SFSymbol(rawValue: "greaterthan.square")
+    static var greaterthanSquare: SFSymbol { .init(rawValue: "greaterthan.square") }
 
     /// 􀃩
     /// Single Localization, 3 Layersets
@@ -8834,14 +8834,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let greaterthanSquareFill = SFSymbol(rawValue: "greaterthan.square.fill")
+    static var greaterthanSquareFill: SFSymbol { .init(rawValue: "greaterthan.square.fill") }
 
     /// 􀓗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let grid = SFSymbol(rawValue: "grid")
+    static var grid: SFSymbol { .init(rawValue: "grid") }
 
     /// 􀓘
     /// Single Localization, 2 Layersets
@@ -8849,7 +8849,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gridCircle = SFSymbol(rawValue: "grid.circle")
+    static var gridCircle: SFSymbol { .init(rawValue: "grid.circle") }
 
     /// 􀘟
     /// Single Localization, 3 Layersets
@@ -8858,7 +8858,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let gridCircleFill = SFSymbol(rawValue: "grid.circle.fill")
+    static var gridCircleFill: SFSymbol { .init(rawValue: "grid.circle.fill") }
 
     /// 􀖿
     /// Single Localization, 2 Layersets
@@ -8866,7 +8866,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let guaranisignCircle = SFSymbol(rawValue: "guaranisign.circle")
+    static var guaranisignCircle: SFSymbol { .init(rawValue: "guaranisign.circle") }
 
     /// 􀗀
     /// Single Localization, 3 Layersets
@@ -8875,7 +8875,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let guaranisignCircleFill = SFSymbol(rawValue: "guaranisign.circle.fill")
+    static var guaranisignCircleFill: SFSymbol { .init(rawValue: "guaranisign.circle.fill") }
 
     /// 􀗿
     /// Single Localization, 2 Layersets
@@ -8883,7 +8883,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let guaranisignSquare = SFSymbol(rawValue: "guaranisign.square")
+    static var guaranisignSquare: SFSymbol { .init(rawValue: "guaranisign.square") }
 
     /// 􀘀
     /// Single Localization, 3 Layersets
@@ -8892,7 +8892,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let guaranisignSquareFill = SFSymbol(rawValue: "guaranisign.square.fill")
+    static var guaranisignSquareFill: SFSymbol { .init(rawValue: "guaranisign.square.fill") }
 
     /// 􀑭
     /// Single Localization, 2 Layersets
@@ -8900,7 +8900,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let guitars = SFSymbol(rawValue: "guitars")
+    static var guitars: SFSymbol { .init(rawValue: "guitars") }
 
     /// 􀀒
     /// Single Localization, 2 Layersets
@@ -8908,7 +8908,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hCircle = SFSymbol(rawValue: "h.circle")
+    static var hCircle: SFSymbol { .init(rawValue: "h.circle") }
 
     /// 􀀓
     /// Single Localization, 3 Layersets
@@ -8917,7 +8917,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hCircleFill = SFSymbol(rawValue: "h.circle.fill")
+    static var hCircleFill: SFSymbol { .init(rawValue: "h.circle.fill") }
 
     /// 􀂢
     /// Single Localization, 2 Layersets
@@ -8925,7 +8925,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hSquare = SFSymbol(rawValue: "h.square")
+    static var hSquare: SFSymbol { .init(rawValue: "h.square") }
 
     /// 􀂣
     /// Single Localization, 3 Layersets
@@ -8934,21 +8934,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hSquareFill = SFSymbol(rawValue: "h.square.fill")
+    static var hSquareFill: SFSymbol { .init(rawValue: "h.square.fill") }
 
     /// 􀙄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hammer = SFSymbol(rawValue: "hammer")
+    static var hammer: SFSymbol { .init(rawValue: "hammer") }
 
     /// 􀙅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hammerFill = SFSymbol(rawValue: "hammer.fill")
+    static var hammerFill: SFSymbol { .init(rawValue: "hammer.fill") }
 
     /// 􀖓
     /// Single Localization, 2 Layersets
@@ -8956,7 +8956,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handDraw = SFSymbol(rawValue: "hand.draw")
+    static var handDraw: SFSymbol { .init(rawValue: "hand.draw") }
 
     /// 􀖔
     /// Single Localization, 2 Layersets
@@ -8964,35 +8964,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handDrawFill = SFSymbol(rawValue: "hand.draw.fill")
+    static var handDrawFill: SFSymbol { .init(rawValue: "hand.draw.fill") }
 
     /// 􀙽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointLeft = SFSymbol(rawValue: "hand.point.left")
+    static var handPointLeft: SFSymbol { .init(rawValue: "hand.point.left") }
 
     /// 􀙾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointLeftFill = SFSymbol(rawValue: "hand.point.left.fill")
+    static var handPointLeftFill: SFSymbol { .init(rawValue: "hand.point.left.fill") }
 
     /// 􀙿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointRight = SFSymbol(rawValue: "hand.point.right")
+    static var handPointRight: SFSymbol { .init(rawValue: "hand.point.right") }
 
     /// 􀚀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointRightFill = SFSymbol(rawValue: "hand.point.right.fill")
+    static var handPointRightFill: SFSymbol { .init(rawValue: "hand.point.right.fill") }
 
     /// 􀉻
     /// Single Localization, 2 Layersets
@@ -9000,7 +9000,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handRaised = SFSymbol(rawValue: "hand.raised")
+    static var handRaised: SFSymbol { .init(rawValue: "hand.raised") }
 
     /// 􀉼
     /// Single Localization, 2 Layersets
@@ -9008,7 +9008,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handRaisedFill = SFSymbol(rawValue: "hand.raised.fill")
+    static var handRaisedFill: SFSymbol { .init(rawValue: "hand.raised.fill") }
 
     /// 􀉽
     /// Single Localization, 3 Layersets
@@ -9017,7 +9017,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let handRaisedSlash = SFSymbol(rawValue: "hand.raised.slash")
+    static var handRaisedSlash: SFSymbol { .init(rawValue: "hand.raised.slash") }
 
     /// 􀉾
     /// Single Localization, 2 Layersets
@@ -9025,56 +9025,56 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handRaisedSlashFill = SFSymbol(rawValue: "hand.raised.slash.fill")
+    static var handRaisedSlashFill: SFSymbol { .init(rawValue: "hand.raised.slash.fill") }
 
     /// 􀊁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdown = SFSymbol(rawValue: "hand.thumbsdown")
+    static var handThumbsdown: SFSymbol { .init(rawValue: "hand.thumbsdown") }
 
     /// 􀊂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdownFill = SFSymbol(rawValue: "hand.thumbsdown.fill")
+    static var handThumbsdownFill: SFSymbol { .init(rawValue: "hand.thumbsdown.fill") }
 
     /// 􀉿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsup = SFSymbol(rawValue: "hand.thumbsup")
+    static var handThumbsup: SFSymbol { .init(rawValue: "hand.thumbsup") }
 
     /// 􀊀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsupFill = SFSymbol(rawValue: "hand.thumbsup.fill")
+    static var handThumbsupFill: SFSymbol { .init(rawValue: "hand.thumbsup.fill") }
 
     /// 􀓎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hare = SFSymbol(rawValue: "hare")
+    static var hare: SFSymbol { .init(rawValue: "hare") }
 
     /// 􀓏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hareFill = SFSymbol(rawValue: "hare.fill")
+    static var hareFill: SFSymbol { .init(rawValue: "hare.fill") }
 
     /// 􀑈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let headphones = SFSymbol(rawValue: "headphones")
+    static var headphones: SFSymbol { .init(rawValue: "headphones") }
 
     /// 􀊴
     /// Single Localization, 2 Layersets
@@ -9082,7 +9082,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heart = SFSymbol(rawValue: "heart")
+    static var heart: SFSymbol { .init(rawValue: "heart") }
 
     /// 􀊸
     /// Single Localization, 3 Layersets
@@ -9091,7 +9091,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heartCircle = SFSymbol(rawValue: "heart.circle")
+    static var heartCircle: SFSymbol { .init(rawValue: "heart.circle") }
 
     /// 􀊹
     /// Single Localization, 3 Layersets
@@ -9100,7 +9100,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heartCircleFill = SFSymbol(rawValue: "heart.circle.fill")
+    static var heartCircleFill: SFSymbol { .init(rawValue: "heart.circle.fill") }
 
     /// 􀊵
     /// Single Localization, 2 Layersets
@@ -9108,7 +9108,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heartFill = SFSymbol(rawValue: "heart.fill")
+    static var heartFill: SFSymbol { .init(rawValue: "heart.fill") }
 
     /// 􀊶
     /// Single Localization, 3 Layersets
@@ -9117,7 +9117,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let heartSlash = SFSymbol(rawValue: "heart.slash")
+    static var heartSlash: SFSymbol { .init(rawValue: "heart.slash") }
 
     /// 􀊺
     /// Single Localization, 3 Layersets
@@ -9126,7 +9126,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let heartSlashCircle = SFSymbol(rawValue: "heart.slash.circle")
+    static var heartSlashCircle: SFSymbol { .init(rawValue: "heart.slash.circle") }
 
     /// 􀊻
     /// Single Localization, 3 Layersets
@@ -9135,7 +9135,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heartSlashCircleFill = SFSymbol(rawValue: "heart.slash.circle.fill")
+    static var heartSlashCircleFill: SFSymbol { .init(rawValue: "heart.slash.circle.fill") }
 
     /// 􀊷
     /// Single Localization, 3 Layersets
@@ -9144,35 +9144,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let heartSlashFill = SFSymbol(rawValue: "heart.slash.fill")
+    static var heartSlashFill: SFSymbol { .init(rawValue: "heart.slash.fill") }
 
     /// 􀐪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let helm = SFSymbol(rawValue: "helm")
+    static var helm: SFSymbol { .init(rawValue: "helm") }
 
     /// 􀝝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagon = SFSymbol(rawValue: "hexagon")
+    static var hexagon: SFSymbol { .init(rawValue: "hexagon") }
 
     /// 􀝞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagonFill = SFSymbol(rawValue: "hexagon.fill")
+    static var hexagonFill: SFSymbol { .init(rawValue: "hexagon.fill") }
 
     /// 􀝎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hifispeaker = SFSymbol(rawValue: "hifispeaker")
+    static var hifispeaker: SFSymbol { .init(rawValue: "hifispeaker") }
 
     /// 􀝏
     /// Single Localization, 2 Layersets
@@ -9180,7 +9180,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hifispeakerFill = SFSymbol(rawValue: "hifispeaker.fill")
+    static var hifispeakerFill: SFSymbol { .init(rawValue: "hifispeaker.fill") }
 
     /// 􀖇
     /// Single Localization, 3 Layersets
@@ -9189,7 +9189,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hourglass = SFSymbol(rawValue: "hourglass")
+    static var hourglass: SFSymbol { .init(rawValue: "hourglass") }
 
     /// 􀖈
     /// Single Localization, 3 Layersets
@@ -9203,7 +9203,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "hourglassBottomhalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "hourglassBottomhalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "hourglassBottomhalfFilled")
-    static let hourglassBottomhalfFill = SFSymbol(rawValue: "hourglass.bottomhalf.fill")
+    static var hourglassBottomhalfFill: SFSymbol { .init(rawValue: "hourglass.bottomhalf.fill") }
 
     /// 􀖉
     /// Single Localization, 3 Layersets
@@ -9217,7 +9217,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "hourglassTophalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "hourglassTophalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "hourglassTophalfFilled")
-    static let hourglassTophalfFill = SFSymbol(rawValue: "hourglass.tophalf.fill")
+    static var hourglassTophalfFill: SFSymbol { .init(rawValue: "hourglass.tophalf.fill") }
 
     /// 􀎞
     /// Single Localization, 2 Layersets
@@ -9225,7 +9225,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let house = SFSymbol(rawValue: "house")
+    static var house: SFSymbol { .init(rawValue: "house") }
 
     /// 􀎟
     /// Single Localization, 2 Layersets
@@ -9233,7 +9233,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let houseFill = SFSymbol(rawValue: "house.fill")
+    static var houseFill: SFSymbol { .init(rawValue: "house.fill") }
 
     /// 􀖻
     /// Single Localization, 2 Layersets
@@ -9241,7 +9241,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hryvniasignCircle = SFSymbol(rawValue: "hryvniasign.circle")
+    static var hryvniasignCircle: SFSymbol { .init(rawValue: "hryvniasign.circle") }
 
     /// 􀖼
     /// Single Localization, 3 Layersets
@@ -9250,7 +9250,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hryvniasignCircleFill = SFSymbol(rawValue: "hryvniasign.circle.fill")
+    static var hryvniasignCircleFill: SFSymbol { .init(rawValue: "hryvniasign.circle.fill") }
 
     /// 􀗻
     /// Single Localization, 2 Layersets
@@ -9258,7 +9258,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hryvniasignSquare = SFSymbol(rawValue: "hryvniasign.square")
+    static var hryvniasignSquare: SFSymbol { .init(rawValue: "hryvniasign.square") }
 
     /// 􀗼
     /// Single Localization, 3 Layersets
@@ -9267,7 +9267,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hryvniasignSquareFill = SFSymbol(rawValue: "hryvniasign.square.fill")
+    static var hryvniasignSquareFill: SFSymbol { .init(rawValue: "hryvniasign.square.fill") }
 
     /// 􀇩
     /// Single Localization, 2 Layersets
@@ -9275,7 +9275,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let hurricane = SFSymbol(rawValue: "hurricane")
+    static var hurricane: SFSymbol { .init(rawValue: "hurricane") }
 
     /// 􀀔
     /// Single Localization, 2 Layersets
@@ -9283,7 +9283,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let iCircle = SFSymbol(rawValue: "i.circle")
+    static var iCircle: SFSymbol { .init(rawValue: "i.circle") }
 
     /// 􀀕
     /// Single Localization, 3 Layersets
@@ -9292,7 +9292,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let iCircleFill = SFSymbol(rawValue: "i.circle.fill")
+    static var iCircleFill: SFSymbol { .init(rawValue: "i.circle.fill") }
 
     /// 􀂤
     /// Single Localization, 2 Layersets
@@ -9300,7 +9300,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let iSquare = SFSymbol(rawValue: "i.square")
+    static var iSquare: SFSymbol { .init(rawValue: "i.square") }
 
     /// 􀂥
     /// Single Localization, 3 Layersets
@@ -9309,7 +9309,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let iSquareFill = SFSymbol(rawValue: "i.square.fill")
+    static var iSquareFill: SFSymbol { .init(rawValue: "i.square.fill") }
 
     /// 􀌋
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9319,7 +9319,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.1, macOS 13.0, tvOS 16.1, watchOS 9.1)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloud = SFSymbol(rawValue: "icloud")
+    static var icloud: SFSymbol { .init(rawValue: "icloud") }
 
     /// 􀌕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9329,7 +9329,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudAndArrowDown = SFSymbol(rawValue: "icloud.and.arrow.down")
+    static var icloudAndArrowDown: SFSymbol { .init(rawValue: "icloud.and.arrow.down") }
 
     /// 􀌖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9339,7 +9339,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudAndArrowDownFill = SFSymbol(rawValue: "icloud.and.arrow.down.fill")
+    static var icloudAndArrowDownFill: SFSymbol { .init(rawValue: "icloud.and.arrow.down.fill") }
 
     /// 􀌗
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9349,7 +9349,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudAndArrowUp = SFSymbol(rawValue: "icloud.and.arrow.up")
+    static var icloudAndArrowUp: SFSymbol { .init(rawValue: "icloud.and.arrow.up") }
 
     /// 􀌘
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9359,7 +9359,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudAndArrowUpFill = SFSymbol(rawValue: "icloud.and.arrow.up.fill")
+    static var icloudAndArrowUpFill: SFSymbol { .init(rawValue: "icloud.and.arrow.up.fill") }
 
     /// 􀌍
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9370,7 +9370,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudCircle = SFSymbol(rawValue: "icloud.circle")
+    static var icloudCircle: SFSymbol { .init(rawValue: "icloud.circle") }
 
     /// 􀌎
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9381,7 +9381,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudCircleFill = SFSymbol(rawValue: "icloud.circle.fill")
+    static var icloudCircleFill: SFSymbol { .init(rawValue: "icloud.circle.fill") }
 
     /// 􀌌
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9391,7 +9391,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudFill = SFSymbol(rawValue: "icloud.fill")
+    static var icloudFill: SFSymbol { .init(rawValue: "icloud.fill") }
 
     /// 􀌏
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9402,7 +9402,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudSlash = SFSymbol(rawValue: "icloud.slash")
+    static var icloudSlash: SFSymbol { .init(rawValue: "icloud.slash") }
 
     /// 􀌐
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9413,7 +9413,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudSlashFill = SFSymbol(rawValue: "icloud.slash.fill")
+    static var icloudSlashFill: SFSymbol { .init(rawValue: "icloud.slash.fill") }
 
     /// 􀋵
     /// Single Localization, 3 Layersets
@@ -9422,7 +9422,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let increaseIndent = SFSymbol(rawValue: "increase.indent")
+    static var increaseIndent: SFSymbol { .init(rawValue: "increase.indent") }
 
     /// 􀞀
     /// Single Localization, 3 Layersets
@@ -9431,7 +9431,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let increaseQuotelevel = SFSymbol(rawValue: "increase.quotelevel")
+    static var increaseQuotelevel: SFSymbol { .init(rawValue: "increase.quotelevel") }
 
     /// 􀖫
     /// Single Localization, 2 Layersets
@@ -9439,7 +9439,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let indianrupeesignCircle = SFSymbol(rawValue: "indianrupeesign.circle")
+    static var indianrupeesignCircle: SFSymbol { .init(rawValue: "indianrupeesign.circle") }
 
     /// 􀖬
     /// Single Localization, 3 Layersets
@@ -9448,7 +9448,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let indianrupeesignCircleFill = SFSymbol(rawValue: "indianrupeesign.circle.fill")
+    static var indianrupeesignCircleFill: SFSymbol { .init(rawValue: "indianrupeesign.circle.fill") }
 
     /// 􀗫
     /// Single Localization, 2 Layersets
@@ -9456,7 +9456,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let indianrupeesignSquare = SFSymbol(rawValue: "indianrupeesign.square")
+    static var indianrupeesignSquare: SFSymbol { .init(rawValue: "indianrupeesign.square") }
 
     /// 􀗬
     /// Single Localization, 3 Layersets
@@ -9465,7 +9465,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let indianrupeesignSquareFill = SFSymbol(rawValue: "indianrupeesign.square.fill")
+    static var indianrupeesignSquareFill: SFSymbol { .init(rawValue: "indianrupeesign.square.fill") }
 
     /// 􀅳
     /// Single Localization, 2 Layersets
@@ -9473,7 +9473,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let info = SFSymbol(rawValue: "info")
+    static var info: SFSymbol { .init(rawValue: "info") }
 
     /// 􀅴
     /// Single Localization, 3 Layersets
@@ -9482,7 +9482,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let infoCircle = SFSymbol(rawValue: "info.circle")
+    static var infoCircle: SFSymbol { .init(rawValue: "info.circle") }
 
     /// 􀅵
     /// Single Localization, 3 Layersets
@@ -9491,7 +9491,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let infoCircleFill = SFSymbol(rawValue: "info.circle.fill")
+    static var infoCircleFill: SFSymbol { .init(rawValue: "info.circle.fill") }
 
     /// 􀅔
     /// Single Localization, 2 Layersets
@@ -9499,7 +9499,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let italic = SFSymbol(rawValue: "italic")
+    static var italic: SFSymbol { .init(rawValue: "italic") }
 
     /// 􀀖
     /// Single Localization, 2 Layersets
@@ -9507,7 +9507,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let jCircle = SFSymbol(rawValue: "j.circle")
+    static var jCircle: SFSymbol { .init(rawValue: "j.circle") }
 
     /// 􀀗
     /// Single Localization, 3 Layersets
@@ -9516,7 +9516,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let jCircleFill = SFSymbol(rawValue: "j.circle.fill")
+    static var jCircleFill: SFSymbol { .init(rawValue: "j.circle.fill") }
 
     /// 􀂦
     /// Single Localization, 2 Layersets
@@ -9524,7 +9524,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let jSquare = SFSymbol(rawValue: "j.square")
+    static var jSquare: SFSymbol { .init(rawValue: "j.square") }
 
     /// 􀂧
     /// Single Localization, 3 Layersets
@@ -9533,7 +9533,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let jSquareFill = SFSymbol(rawValue: "j.square.fill")
+    static var jSquareFill: SFSymbol { .init(rawValue: "j.square.fill") }
 
     /// 􀀘
     /// Single Localization, 2 Layersets
@@ -9541,7 +9541,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kCircle = SFSymbol(rawValue: "k.circle")
+    static var kCircle: SFSymbol { .init(rawValue: "k.circle") }
 
     /// 􀀙
     /// Single Localization, 3 Layersets
@@ -9550,7 +9550,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kCircleFill = SFSymbol(rawValue: "k.circle.fill")
+    static var kCircleFill: SFSymbol { .init(rawValue: "k.circle.fill") }
 
     /// 􀂨
     /// Single Localization, 2 Layersets
@@ -9558,7 +9558,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kSquare = SFSymbol(rawValue: "k.square")
+    static var kSquare: SFSymbol { .init(rawValue: "k.square") }
 
     /// 􀂩
     /// Single Localization, 3 Layersets
@@ -9567,21 +9567,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kSquareFill = SFSymbol(rawValue: "k.square.fill")
+    static var kSquareFill: SFSymbol { .init(rawValue: "k.square.fill") }
 
     /// 􀇳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboard = SFSymbol(rawValue: "keyboard")
+    static var keyboard: SFSymbol { .init(rawValue: "keyboard") }
 
     /// 􀓖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardChevronCompactDown = SFSymbol(rawValue: "keyboard.chevron.compact.down")
+    static var keyboardChevronCompactDown: SFSymbol { .init(rawValue: "keyboard.chevron.compact.down") }
 
     /// 􀖳
     /// Single Localization, 2 Layersets
@@ -9589,7 +9589,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kipsignCircle = SFSymbol(rawValue: "kipsign.circle")
+    static var kipsignCircle: SFSymbol { .init(rawValue: "kipsign.circle") }
 
     /// 􀖴
     /// Single Localization, 3 Layersets
@@ -9598,7 +9598,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kipsignCircleFill = SFSymbol(rawValue: "kipsign.circle.fill")
+    static var kipsignCircleFill: SFSymbol { .init(rawValue: "kipsign.circle.fill") }
 
     /// 􀗳
     /// Single Localization, 2 Layersets
@@ -9606,7 +9606,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kipsignSquare = SFSymbol(rawValue: "kipsign.square")
+    static var kipsignSquare: SFSymbol { .init(rawValue: "kipsign.square") }
 
     /// 􀗴
     /// Single Localization, 3 Layersets
@@ -9615,7 +9615,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let kipsignSquareFill = SFSymbol(rawValue: "kipsign.square.fill")
+    static var kipsignSquareFill: SFSymbol { .init(rawValue: "kipsign.square.fill") }
 
     /// 􀀚
     /// Single Localization, 2 Layersets
@@ -9623,7 +9623,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lCircle = SFSymbol(rawValue: "l.circle")
+    static var lCircle: SFSymbol { .init(rawValue: "l.circle") }
 
     /// 􀀛
     /// Single Localization, 3 Layersets
@@ -9632,7 +9632,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lCircleFill = SFSymbol(rawValue: "l.circle.fill")
+    static var lCircleFill: SFSymbol { .init(rawValue: "l.circle.fill") }
 
     /// 􀂪
     /// Single Localization, 2 Layersets
@@ -9640,7 +9640,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lSquare = SFSymbol(rawValue: "l.square")
+    static var lSquare: SFSymbol { .init(rawValue: "l.square") }
 
     /// 􀂫
     /// Single Localization, 3 Layersets
@@ -9649,7 +9649,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lSquareFill = SFSymbol(rawValue: "l.square.fill")
+    static var lSquareFill: SFSymbol { .init(rawValue: "l.square.fill") }
 
     /// 􀝜
     /// Single Localization, Single Layerset
@@ -9661,7 +9661,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "circleInsetFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "circleInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleInsetFilled")
-    static let largecircleFillCircle = SFSymbol(rawValue: "largecircle.fill.circle")
+    static var largecircleFillCircle: SFSymbol { .init(rawValue: "largecircle.fill.circle") }
 
     /// 􀗓
     /// Single Localization, 2 Layersets
@@ -9669,7 +9669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let larisignCircle = SFSymbol(rawValue: "larisign.circle")
+    static var larisignCircle: SFSymbol { .init(rawValue: "larisign.circle") }
 
     /// 􀗔
     /// Single Localization, 3 Layersets
@@ -9678,7 +9678,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let larisignCircleFill = SFSymbol(rawValue: "larisign.circle.fill")
+    static var larisignCircleFill: SFSymbol { .init(rawValue: "larisign.circle.fill") }
 
     /// 􀘓
     /// Single Localization, 2 Layersets
@@ -9686,7 +9686,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let larisignSquare = SFSymbol(rawValue: "larisign.square")
+    static var larisignSquare: SFSymbol { .init(rawValue: "larisign.square") }
 
     /// 􀘔
     /// Single Localization, 3 Layersets
@@ -9695,14 +9695,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let larisignSquareFill = SFSymbol(rawValue: "larisign.square.fill")
+    static var larisignSquareFill: SFSymbol { .init(rawValue: "larisign.square.fill") }
 
     /// 􀓩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lasso = SFSymbol(rawValue: "lasso")
+    static var lasso: SFSymbol { .init(rawValue: "lasso") }
 
     /// 􀙜
     /// Single Localization, Single Layerset
@@ -9714,14 +9714,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "leafArrowTriangleCirclepath")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "leafArrowTriangleCirclepath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "leafArrowTriangleCirclepath")
-    static let leafArrowCirclepath = SFSymbol(rawValue: "leaf.arrow.circlepath")
+    static var leafArrowCirclepath: SFSymbol { .init(rawValue: "leaf.arrow.circlepath") }
 
     /// 􀆁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lessthan = SFSymbol(rawValue: "lessthan")
+    static var lessthan: SFSymbol { .init(rawValue: "lessthan") }
 
     /// 􀁘
     /// Single Localization, 2 Layersets
@@ -9729,7 +9729,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lessthanCircle = SFSymbol(rawValue: "lessthan.circle")
+    static var lessthanCircle: SFSymbol { .init(rawValue: "lessthan.circle") }
 
     /// 􀁙
     /// Single Localization, 3 Layersets
@@ -9738,7 +9738,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lessthanCircleFill = SFSymbol(rawValue: "lessthan.circle.fill")
+    static var lessthanCircleFill: SFSymbol { .init(rawValue: "lessthan.circle.fill") }
 
     /// 􀃦
     /// Single Localization, 2 Layersets
@@ -9746,7 +9746,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lessthanSquare = SFSymbol(rawValue: "lessthan.square")
+    static var lessthanSquare: SFSymbol { .init(rawValue: "lessthan.square") }
 
     /// 􀃧
     /// Single Localization, 3 Layersets
@@ -9755,7 +9755,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lessthanSquareFill = SFSymbol(rawValue: "lessthan.square.fill")
+    static var lessthanSquareFill: SFSymbol { .init(rawValue: "lessthan.square.fill") }
 
     /// 􀇮
     /// Single Localization, 2 Layersets
@@ -9763,7 +9763,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lightMax = SFSymbol(rawValue: "light.max")
+    static var lightMax: SFSymbol { .init(rawValue: "light.max") }
 
     /// 􀇭
     /// Single Localization, 2 Layersets
@@ -9771,14 +9771,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lightMin = SFSymbol(rawValue: "light.min")
+    static var lightMin: SFSymbol { .init(rawValue: "light.min") }
 
     /// 􀛭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightbulb = SFSymbol(rawValue: "lightbulb")
+    static var lightbulb: SFSymbol { .init(rawValue: "lightbulb") }
 
     /// 􀛮
     /// Single Localization, 3 Layersets
@@ -9787,7 +9787,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lightbulbFill = SFSymbol(rawValue: "lightbulb.fill")
+    static var lightbulbFill: SFSymbol { .init(rawValue: "lightbulb.fill") }
 
     /// 􀞃
     /// Single Localization, 2 Layersets
@@ -9795,7 +9795,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lightbulbSlash = SFSymbol(rawValue: "lightbulb.slash")
+    static var lightbulbSlash: SFSymbol { .init(rawValue: "lightbulb.slash") }
 
     /// 􀞄
     /// Single Localization, 2 Layersets
@@ -9803,7 +9803,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lightbulbSlashFill = SFSymbol(rawValue: "lightbulb.slash.fill")
+    static var lightbulbSlashFill: SFSymbol { .init(rawValue: "lightbulb.slash.fill") }
 
     /// 􀌇
     /// Single Localization, Single Layerset
@@ -9815,7 +9815,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "line3Horizontal")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "line3Horizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3Horizontal")
-    static let lineHorizontal3 = SFSymbol(rawValue: "line.horizontal.3")
+    static var lineHorizontal3: SFSymbol { .init(rawValue: "line.horizontal.3") }
 
     /// 􀜓
     /// Single Localization, Single Layerset
@@ -9827,7 +9827,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "line3HorizontalDecrease")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "line3HorizontalDecrease")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3HorizontalDecrease")
-    static let lineHorizontal3Decrease = SFSymbol(rawValue: "line.horizontal.3.decrease")
+    static var lineHorizontal3Decrease: SFSymbol { .init(rawValue: "line.horizontal.3.decrease") }
 
     /// 􀌈
     /// Single Localization, 2 Layersets
@@ -9840,7 +9840,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "line3HorizontalDecreaseCircle")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "line3HorizontalDecreaseCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3HorizontalDecreaseCircle")
-    static let lineHorizontal3DecreaseCircle = SFSymbol(rawValue: "line.horizontal.3.decrease.circle")
+    static var lineHorizontal3DecreaseCircle: SFSymbol { .init(rawValue: "line.horizontal.3.decrease.circle") }
 
     /// 􀌉
     /// Single Localization, 3 Layersets
@@ -9854,7 +9854,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "line3HorizontalDecreaseCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "line3HorizontalDecreaseCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3HorizontalDecreaseCircleFill")
-    static let lineHorizontal3DecreaseCircleFill = SFSymbol(rawValue: "line.horizontal.3.decrease.circle.fill")
+    static var lineHorizontal3DecreaseCircleFill: SFSymbol { .init(rawValue: "line.horizontal.3.decrease.circle.fill") }
 
     /// 􀉣
     /// Single Localization, 2 Layersets
@@ -9862,7 +9862,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let link = SFSymbol(rawValue: "link")
+    static var link: SFSymbol { .init(rawValue: "link") }
 
     /// 􀒠
     /// Single Localization, 3 Layersets
@@ -9871,7 +9871,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let linkCircle = SFSymbol(rawValue: "link.circle")
+    static var linkCircle: SFSymbol { .init(rawValue: "link.circle") }
 
     /// 􀒡
     /// Single Localization, 3 Layersets
@@ -9880,7 +9880,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let linkCircleFill = SFSymbol(rawValue: "link.circle.fill")
+    static var linkCircleFill: SFSymbol { .init(rawValue: "link.circle.fill") }
 
     /// 􀒞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -9890,7 +9890,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let linkIcloud = SFSymbol(rawValue: "link.icloud")
+    static var linkIcloud: SFSymbol { .init(rawValue: "link.icloud") }
 
     /// 􀒟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9901,7 +9901,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let linkIcloudFill = SFSymbol(rawValue: "link.icloud.fill")
+    static var linkIcloudFill: SFSymbol { .init(rawValue: "link.icloud.fill") }
 
     /// 􀖷
     /// Single Localization, 2 Layersets
@@ -9909,7 +9909,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lirasignCircle = SFSymbol(rawValue: "lirasign.circle")
+    static var lirasignCircle: SFSymbol { .init(rawValue: "lirasign.circle") }
 
     /// 􀖸
     /// Single Localization, 3 Layersets
@@ -9918,7 +9918,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lirasignCircleFill = SFSymbol(rawValue: "lirasign.circle.fill")
+    static var lirasignCircleFill: SFSymbol { .init(rawValue: "lirasign.circle.fill") }
 
     /// 􀗷
     /// Single Localization, 2 Layersets
@@ -9926,7 +9926,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lirasignSquare = SFSymbol(rawValue: "lirasign.square")
+    static var lirasignSquare: SFSymbol { .init(rawValue: "lirasign.square") }
 
     /// 􀗸
     /// Single Localization, 3 Layersets
@@ -9935,7 +9935,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lirasignSquareFill = SFSymbol(rawValue: "lirasign.square.fill")
+    static var lirasignSquareFill: SFSymbol { .init(rawValue: "lirasign.square.fill") }
 
     /// 􀋲
     /// Single Localization, 3 Layersets
@@ -9944,14 +9944,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listBullet = SFSymbol(rawValue: "list.bullet")
+    static var listBullet: SFSymbol { .init(rawValue: "list.bullet") }
 
     /// 􀋷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let listBulletBelowRectangle = SFSymbol(rawValue: "list.bullet.below.rectangle")
+    static var listBulletBelowRectangle: SFSymbol { .init(rawValue: "list.bullet.below.rectangle") }
 
     /// 􀋳
     /// Single Localization, 3 Layersets
@@ -9960,7 +9960,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listBulletIndent = SFSymbol(rawValue: "list.bullet.indent")
+    static var listBulletIndent: SFSymbol { .init(rawValue: "list.bullet.indent") }
 
     /// 􀋱
     /// Single Localization, 3 Layersets
@@ -9969,7 +9969,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listDash = SFSymbol(rawValue: "list.dash")
+    static var listDash: SFSymbol { .init(rawValue: "list.dash") }
 
     /// 􀋴
     /// 4 Localizations, 3 Layersets
@@ -9984,7 +9984,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listNumber = SymbolWith3Localizations<Ar_v2, Hi_v3, Rtl>(rawValue: "list.number")
+    static var listNumber: SymbolWith3Localizations<Ar_v2, Hi_v3, Rtl> { .init(rawValue: "list.number") }
 
     /// 􀐡
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9995,7 +9995,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Live Photos feature.
-    static let livephoto = SFSymbol(rawValue: "livephoto")
+    static var livephoto: SFSymbol { .init(rawValue: "livephoto") }
 
     /// 􀐣
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -10004,7 +10004,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Live Photos feature.
-    static let livephotoPlay = SFSymbol(rawValue: "livephoto.play")
+    static var livephotoPlay: SFSymbol { .init(rawValue: "livephoto.play") }
 
     /// 􀐢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10014,7 +10014,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Live Photos feature.
-    static let livephotoSlash = SFSymbol(rawValue: "livephoto.slash")
+    static var livephotoSlash: SFSymbol { .init(rawValue: "livephoto.slash") }
 
     /// 􀋑
     /// Single Localization, 2 Layersets
@@ -10022,7 +10022,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let location = SFSymbol(rawValue: "location")
+    static var location: SFSymbol { .init(rawValue: "location") }
 
     /// 􀋕
     /// Single Localization, 3 Layersets
@@ -10031,7 +10031,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationCircle = SFSymbol(rawValue: "location.circle")
+    static var locationCircle: SFSymbol { .init(rawValue: "location.circle") }
 
     /// 􀋖
     /// Single Localization, 3 Layersets
@@ -10040,7 +10040,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationCircleFill = SFSymbol(rawValue: "location.circle.fill")
+    static var locationCircleFill: SFSymbol { .init(rawValue: "location.circle.fill") }
 
     /// 􀋒
     /// Single Localization, 2 Layersets
@@ -10048,7 +10048,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationFill = SFSymbol(rawValue: "location.fill")
+    static var locationFill: SFSymbol { .init(rawValue: "location.fill") }
 
     /// 􀋓
     /// Single Localization, 2 Layersets
@@ -10056,7 +10056,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationNorth = SFSymbol(rawValue: "location.north")
+    static var locationNorth: SFSymbol { .init(rawValue: "location.north") }
 
     /// 􀋔
     /// Single Localization, 2 Layersets
@@ -10064,7 +10064,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationNorthFill = SFSymbol(rawValue: "location.north.fill")
+    static var locationNorthFill: SFSymbol { .init(rawValue: "location.north.fill") }
 
     /// 􀋗
     /// Single Localization, 2 Layersets
@@ -10072,7 +10072,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationNorthLine = SFSymbol(rawValue: "location.north.line")
+    static var locationNorthLine: SFSymbol { .init(rawValue: "location.north.line") }
 
     /// 􀋘
     /// Single Localization, 2 Layersets
@@ -10080,7 +10080,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationNorthLineFill = SFSymbol(rawValue: "location.north.line.fill")
+    static var locationNorthLineFill: SFSymbol { .init(rawValue: "location.north.line.fill") }
 
     /// 􀘬
     /// Single Localization, 3 Layersets
@@ -10089,7 +10089,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let locationSlash = SFSymbol(rawValue: "location.slash")
+    static var locationSlash: SFSymbol { .init(rawValue: "location.slash") }
 
     /// 􀘭
     /// Single Localization, 3 Layersets
@@ -10098,7 +10098,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let locationSlashFill = SFSymbol(rawValue: "location.slash.fill")
+    static var locationSlashFill: SFSymbol { .init(rawValue: "location.slash.fill") }
 
     /// 􀎠
     /// Single Localization, 2 Layersets
@@ -10106,7 +10106,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lock = SFSymbol(rawValue: "lock")
+    static var lock: SFSymbol { .init(rawValue: "lock") }
 
     /// 􀒲
     /// Single Localization, 3 Layersets
@@ -10115,7 +10115,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockCircle = SFSymbol(rawValue: "lock.circle")
+    static var lockCircle: SFSymbol { .init(rawValue: "lock.circle") }
 
     /// 􀒳
     /// Single Localization, 3 Layersets
@@ -10124,7 +10124,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockCircleFill = SFSymbol(rawValue: "lock.circle.fill")
+    static var lockCircleFill: SFSymbol { .init(rawValue: "lock.circle.fill") }
 
     /// 􀎡
     /// Single Localization, 2 Layersets
@@ -10132,7 +10132,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockFill = SFSymbol(rawValue: "lock.fill")
+    static var lockFill: SFSymbol { .init(rawValue: "lock.fill") }
 
     /// 􀙵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10142,7 +10142,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let lockIcloud = SFSymbol(rawValue: "lock.icloud")
+    static var lockIcloud: SFSymbol { .init(rawValue: "lock.icloud") }
 
     /// 􀙶
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -10153,21 +10153,21 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let lockIcloudFill = SFSymbol(rawValue: "lock.icloud.fill")
+    static var lockIcloudFill: SFSymbol { .init(rawValue: "lock.icloud.fill") }
 
     /// 􀎤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lockOpen = SFSymbol(rawValue: "lock.open")
+    static var lockOpen: SFSymbol { .init(rawValue: "lock.open") }
 
     /// 􀎥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lockOpenFill = SFSymbol(rawValue: "lock.open.fill")
+    static var lockOpenFill: SFSymbol { .init(rawValue: "lock.open.fill") }
 
     /// 􀑙
     /// Single Localization, 2 Layersets
@@ -10175,7 +10175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockRotation = SFSymbol(rawValue: "lock.rotation")
+    static var lockRotation: SFSymbol { .init(rawValue: "lock.rotation") }
 
     /// 􀑚
     /// Single Localization, 2 Layersets
@@ -10188,7 +10188,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.1, renamed: "lockOpenRotation")
     @available(watchOS, introduced: 6.0, deprecated: 9.1, renamed: "lockOpenRotation")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lockOpenRotation")
-    static let lockRotationOpen = SFSymbol(rawValue: "lock.rotation.open")
+    static var lockRotationOpen: SFSymbol { .init(rawValue: "lock.rotation.open") }
 
     /// 􀞙
     /// Single Localization, 2 Layersets
@@ -10196,7 +10196,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockShield = SFSymbol(rawValue: "lock.shield")
+    static var lockShield: SFSymbol { .init(rawValue: "lock.shield") }
 
     /// 􀞚
     /// Single Localization, 3 Layersets
@@ -10205,7 +10205,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockShieldFill = SFSymbol(rawValue: "lock.shield.fill")
+    static var lockShieldFill: SFSymbol { .init(rawValue: "lock.shield.fill") }
 
     /// 􀎢
     /// Single Localization, 3 Layersets
@@ -10214,7 +10214,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let lockSlash = SFSymbol(rawValue: "lock.slash")
+    static var lockSlash: SFSymbol { .init(rawValue: "lock.slash") }
 
     /// 􀎣
     /// Single Localization, 3 Layersets
@@ -10223,7 +10223,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let lockSlashFill = SFSymbol(rawValue: "lock.slash.fill")
+    static var lockSlashFill: SFSymbol { .init(rawValue: "lock.slash.fill") }
 
     /// 􀀜
     /// Single Localization, 2 Layersets
@@ -10231,7 +10231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mCircle = SFSymbol(rawValue: "m.circle")
+    static var mCircle: SFSymbol { .init(rawValue: "m.circle") }
 
     /// 􀀝
     /// Single Localization, 3 Layersets
@@ -10240,7 +10240,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mCircleFill = SFSymbol(rawValue: "m.circle.fill")
+    static var mCircleFill: SFSymbol { .init(rawValue: "m.circle.fill") }
 
     /// 􀂬
     /// Single Localization, 2 Layersets
@@ -10248,7 +10248,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mSquare = SFSymbol(rawValue: "m.square")
+    static var mSquare: SFSymbol { .init(rawValue: "m.square") }
 
     /// 􀂭
     /// Single Localization, 3 Layersets
@@ -10257,7 +10257,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mSquareFill = SFSymbol(rawValue: "m.square.fill")
+    static var mSquareFill: SFSymbol { .init(rawValue: "m.square.fill") }
 
     /// 􀏜
     /// Single Localization, 3 Layersets
@@ -10266,14 +10266,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let macwindow = SFSymbol(rawValue: "macwindow")
+    static var macwindow: SFSymbol { .init(rawValue: "macwindow") }
 
     /// 􀊫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let magnifyingglass = SFSymbol(rawValue: "magnifyingglass")
+    static var magnifyingglass: SFSymbol { .init(rawValue: "magnifyingglass") }
 
     /// 􀒒
     /// Single Localization, 2 Layersets
@@ -10281,7 +10281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let magnifyingglassCircle = SFSymbol(rawValue: "magnifyingglass.circle")
+    static var magnifyingglassCircle: SFSymbol { .init(rawValue: "magnifyingglass.circle") }
 
     /// 􀒓
     /// Single Localization, 3 Layersets
@@ -10290,7 +10290,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let magnifyingglassCircleFill = SFSymbol(rawValue: "magnifyingglass.circle.fill")
+    static var magnifyingglassCircleFill: SFSymbol { .init(rawValue: "magnifyingglass.circle.fill") }
 
     /// 􀗍
     /// Single Localization, 2 Layersets
@@ -10298,7 +10298,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let manatsignCircle = SFSymbol(rawValue: "manatsign.circle")
+    static var manatsignCircle: SFSymbol { .init(rawValue: "manatsign.circle") }
 
     /// 􀗎
     /// Single Localization, 3 Layersets
@@ -10307,7 +10307,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let manatsignCircleFill = SFSymbol(rawValue: "manatsign.circle.fill")
+    static var manatsignCircleFill: SFSymbol { .init(rawValue: "manatsign.circle.fill") }
 
     /// 􀘍
     /// Single Localization, 2 Layersets
@@ -10315,7 +10315,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let manatsignSquare = SFSymbol(rawValue: "manatsign.square")
+    static var manatsignSquare: SFSymbol { .init(rawValue: "manatsign.square") }
 
     /// 􀘎
     /// Single Localization, 3 Layersets
@@ -10324,21 +10324,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let manatsignSquareFill = SFSymbol(rawValue: "manatsign.square.fill")
+    static var manatsignSquareFill: SFSymbol { .init(rawValue: "manatsign.square.fill") }
 
     /// 􀙊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let map = SFSymbol(rawValue: "map")
+    static var map: SFSymbol { .init(rawValue: "map") }
 
     /// 􀙋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mapFill = SFSymbol(rawValue: "map.fill")
+    static var mapFill: SFSymbol { .init(rawValue: "map.fill") }
 
     /// 􀎪
     /// Single Localization, 3 Layersets
@@ -10347,7 +10347,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let mappin = SFSymbol(rawValue: "mappin")
+    static var mappin: SFSymbol { .init(rawValue: "mappin") }
 
     /// 􀎫
     /// Single Localization, 3 Layersets
@@ -10356,7 +10356,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mappinAndEllipse = SFSymbol(rawValue: "mappin.and.ellipse")
+    static var mappinAndEllipse: SFSymbol { .init(rawValue: "mappin.and.ellipse") }
 
     /// 􀙉
     /// Single Localization, 3 Layersets
@@ -10365,14 +10365,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let mappinSlash = SFSymbol(rawValue: "mappin.slash")
+    static var mappinSlash: SFSymbol { .init(rawValue: "mappin.slash") }
 
     /// 􀑖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let memories = SFSymbol(rawValue: "memories")
+    static var memories: SFSymbol { .init(rawValue: "memories") }
 
     /// 􀑘
     /// Single Localization, 3 Layersets
@@ -10381,7 +10381,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let memoriesBadgeMinus = SFSymbol(rawValue: "memories.badge.minus")
+    static var memoriesBadgeMinus: SFSymbol { .init(rawValue: "memories.badge.minus") }
 
     /// 􀑗
     /// Single Localization, 3 Layersets
@@ -10390,7 +10390,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let memoriesBadgePlus = SFSymbol(rawValue: "memories.badge.plus")
+    static var memoriesBadgePlus: SFSymbol { .init(rawValue: "memories.badge.plus") }
 
     /// 􀌤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10400,7 +10400,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let message = SFSymbol(rawValue: "message")
+    static var message: SFSymbol { .init(rawValue: "message") }
 
     /// 􀌦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -10411,7 +10411,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageCircle = SFSymbol(rawValue: "message.circle")
+    static var messageCircle: SFSymbol { .init(rawValue: "message.circle") }
 
     /// 􀌧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -10422,7 +10422,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageCircleFill = SFSymbol(rawValue: "message.circle.fill")
+    static var messageCircleFill: SFSymbol { .init(rawValue: "message.circle.fill") }
 
     /// 􀌥
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10432,14 +10432,14 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageFill = SFSymbol(rawValue: "message.fill")
+    static var messageFill: SFSymbol { .init(rawValue: "message.fill") }
 
     /// 􀎌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let metronome = SFSymbol(rawValue: "metronome")
+    static var metronome: SFSymbol { .init(rawValue: "metronome") }
 
     /// 􀊰
     /// Single Localization, 2 Layersets
@@ -10452,7 +10452,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphone")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphone")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphone")
-    static let mic = SFSymbol(rawValue: "mic")
+    static var mic: SFSymbol { .init(rawValue: "mic") }
 
     /// 􀒩
     /// Single Localization, 3 Layersets
@@ -10466,7 +10466,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphoneCircle")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphoneCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneCircle")
-    static let micCircle = SFSymbol(rawValue: "mic.circle")
+    static var micCircle: SFSymbol { .init(rawValue: "mic.circle") }
 
     /// 􀒪
     /// Single Localization, 3 Layersets
@@ -10480,7 +10480,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphoneCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphoneCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneCircleFill")
-    static let micCircleFill = SFSymbol(rawValue: "mic.circle.fill")
+    static var micCircleFill: SFSymbol { .init(rawValue: "mic.circle.fill") }
 
     /// 􀊱
     /// Single Localization, 2 Layersets
@@ -10493,7 +10493,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphoneFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphoneFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneFill")
-    static let micFill = SFSymbol(rawValue: "mic.fill")
+    static var micFill: SFSymbol { .init(rawValue: "mic.fill") }
 
     /// 􀊲
     /// Single Localization, 3 Layersets
@@ -10507,7 +10507,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphoneSlash")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphoneSlash")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSlash")
-    static let micSlash = SFSymbol(rawValue: "mic.slash")
+    static var micSlash: SFSymbol { .init(rawValue: "mic.slash") }
 
     /// 􀊳
     /// Single Localization, 3 Layersets
@@ -10521,7 +10521,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "microphoneSlashFill")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "microphoneSlashFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSlashFill")
-    static let micSlashFill = SFSymbol(rawValue: "mic.slash.fill")
+    static var micSlashFill: SFSymbol { .init(rawValue: "mic.slash.fill") }
 
     /// 􀗉
     /// Single Localization, 2 Layersets
@@ -10529,7 +10529,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let millsignCircle = SFSymbol(rawValue: "millsign.circle")
+    static var millsignCircle: SFSymbol { .init(rawValue: "millsign.circle") }
 
     /// 􀗊
     /// Single Localization, 3 Layersets
@@ -10538,7 +10538,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let millsignCircleFill = SFSymbol(rawValue: "millsign.circle.fill")
+    static var millsignCircleFill: SFSymbol { .init(rawValue: "millsign.circle.fill") }
 
     /// 􀘉
     /// Single Localization, 2 Layersets
@@ -10546,7 +10546,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let millsignSquare = SFSymbol(rawValue: "millsign.square")
+    static var millsignSquare: SFSymbol { .init(rawValue: "millsign.square") }
 
     /// 􀘊
     /// Single Localization, 3 Layersets
@@ -10555,7 +10555,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let millsignSquareFill = SFSymbol(rawValue: "millsign.square.fill")
+    static var millsignSquareFill: SFSymbol { .init(rawValue: "millsign.square.fill") }
 
     /// 􀅽
     /// Single Localization, 2 Layersets
@@ -10563,7 +10563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minus = SFSymbol(rawValue: "minus")
+    static var minus: SFSymbol { .init(rawValue: "minus") }
 
     /// 􀁎
     /// Single Localization, 3 Layersets
@@ -10572,7 +10572,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusCircle = SFSymbol(rawValue: "minus.circle")
+    static var minusCircle: SFSymbol { .init(rawValue: "minus.circle") }
 
     /// 􀁏
     /// Single Localization, 3 Layersets
@@ -10581,7 +10581,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusCircleFill = SFSymbol(rawValue: "minus.circle.fill")
+    static var minusCircleFill: SFSymbol { .init(rawValue: "minus.circle.fill") }
 
     /// 􀊭
     /// Single Localization, 2 Layersets
@@ -10589,7 +10589,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let minusMagnifyingglass = SFSymbol(rawValue: "minus.magnifyingglass")
+    static var minusMagnifyingglass: SFSymbol { .init(rawValue: "minus.magnifyingglass") }
 
     /// 􀏉
     /// Single Localization, 3 Layersets
@@ -10598,7 +10598,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusRectangle = SFSymbol(rawValue: "minus.rectangle")
+    static var minusRectangle: SFSymbol { .init(rawValue: "minus.rectangle") }
 
     /// 􀏊
     /// Single Localization, 3 Layersets
@@ -10607,7 +10607,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusRectangleFill = SFSymbol(rawValue: "minus.rectangle.fill")
+    static var minusRectangleFill: SFSymbol { .init(rawValue: "minus.rectangle.fill") }
 
     /// 􀅻
     /// Single Localization, Single Layerset
@@ -10619,7 +10619,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "minusForwardslashPlus")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "minusForwardslashPlus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "minusForwardslashPlus")
-    static let minusSlashPlus = SFSymbol(rawValue: "minus.slash.plus")
+    static var minusSlashPlus: SFSymbol { .init(rawValue: "minus.slash.plus") }
 
     /// 􀃞
     /// Single Localization, 3 Layersets
@@ -10628,7 +10628,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusSquare = SFSymbol(rawValue: "minus.square")
+    static var minusSquare: SFSymbol { .init(rawValue: "minus.square") }
 
     /// 􀃟
     /// Single Localization, 3 Layersets
@@ -10637,14 +10637,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusSquareFill = SFSymbol(rawValue: "minus.square.fill")
+    static var minusSquareFill: SFSymbol { .init(rawValue: "minus.square.fill") }
 
     /// 􀆹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let moon = SFSymbol(rawValue: "moon")
+    static var moon: SFSymbol { .init(rawValue: "moon") }
 
     /// 􀆻
     /// Single Localization, 2 Layersets
@@ -10652,7 +10652,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let moonCircle = SFSymbol(rawValue: "moon.circle")
+    static var moonCircle: SFSymbol { .init(rawValue: "moon.circle") }
 
     /// 􀆼
     /// Single Localization, 3 Layersets
@@ -10661,7 +10661,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let moonCircleFill = SFSymbol(rawValue: "moon.circle.fill")
+    static var moonCircleFill: SFSymbol { .init(rawValue: "moon.circle.fill") }
 
     /// 􀆺
     /// Single Localization, 2 Layersets
@@ -10669,7 +10669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let moonFill = SFSymbol(rawValue: "moon.fill")
+    static var moonFill: SFSymbol { .init(rawValue: "moon.fill") }
 
     /// 􀇀
     /// Single Localization, 2 Layersets
@@ -10677,7 +10677,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let moonStars = SFSymbol(rawValue: "moon.stars")
+    static var moonStars: SFSymbol { .init(rawValue: "moon.stars") }
 
     /// 􀇁
     /// Single Localization, 3 Layersets
@@ -10686,7 +10686,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let moonStarsFill = SFSymbol(rawValue: "moon.stars.fill")
+    static var moonStarsFill: SFSymbol { .init(rawValue: "moon.stars.fill") }
 
     /// 􀆽
     /// Single Localization, 2 Layersets
@@ -10694,7 +10694,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let moonZzz = SFSymbol(rawValue: "moon.zzz")
+    static var moonZzz: SFSymbol { .init(rawValue: "moon.zzz") }
 
     /// 􀆾
     /// Single Localization, 3 Layersets
@@ -10703,14 +10703,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let moonZzzFill = SFSymbol(rawValue: "moon.zzz.fill")
+    static var moonZzzFill: SFSymbol { .init(rawValue: "moon.zzz.fill") }
 
     /// 􀅾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let multiply = SFSymbol(rawValue: "multiply")
+    static var multiply: SFSymbol { .init(rawValue: "multiply") }
 
     /// 􀁐
     /// Single Localization, 2 Layersets
@@ -10718,7 +10718,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let multiplyCircle = SFSymbol(rawValue: "multiply.circle")
+    static var multiplyCircle: SFSymbol { .init(rawValue: "multiply.circle") }
 
     /// 􀁑
     /// Single Localization, 3 Layersets
@@ -10727,7 +10727,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let multiplyCircleFill = SFSymbol(rawValue: "multiply.circle.fill")
+    static var multiplyCircleFill: SFSymbol { .init(rawValue: "multiply.circle.fill") }
 
     /// 􀃠
     /// Single Localization, 2 Layersets
@@ -10735,7 +10735,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let multiplySquare = SFSymbol(rawValue: "multiply.square")
+    static var multiplySquare: SFSymbol { .init(rawValue: "multiply.square") }
 
     /// 􀃡
     /// Single Localization, 3 Layersets
@@ -10744,7 +10744,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let multiplySquareFill = SFSymbol(rawValue: "multiply.square.fill")
+    static var multiplySquareFill: SFSymbol { .init(rawValue: "multiply.square.fill") }
 
     /// 􀒼
     /// Single Localization, 2 Layersets
@@ -10757,7 +10757,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "musicNoteHouse")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "musicNoteHouse")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "musicNoteHouse")
-    static let musicHouse = SFSymbol(rawValue: "music.house")
+    static var musicHouse: SFSymbol { .init(rawValue: "music.house") }
 
     /// 􀒽
     /// Single Localization, 3 Layersets
@@ -10771,7 +10771,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "musicNoteHouseFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "musicNoteHouseFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "musicNoteHouseFill")
-    static let musicHouseFill = SFSymbol(rawValue: "music.house.fill")
+    static var musicHouseFill: SFSymbol { .init(rawValue: "music.house.fill") }
 
     /// 􀑫
     /// Single Localization, Single Layerset
@@ -10783,14 +10783,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "musicMicrophone")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "musicMicrophone")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "musicMicrophone")
-    static let musicMic = SFSymbol(rawValue: "music.mic")
+    static var musicMic: SFSymbol { .init(rawValue: "music.mic") }
 
     /// 􀑪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let musicNote = SFSymbol(rawValue: "music.note")
+    static var musicNote: SFSymbol { .init(rawValue: "music.note") }
 
     /// 􀑬
     /// Single Localization, 2 Layersets
@@ -10798,7 +10798,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let musicNoteList = SFSymbol(rawValue: "music.note.list")
+    static var musicNoteList: SFSymbol { .init(rawValue: "music.note.list") }
 
     /// 􀀞
     /// Single Localization, 2 Layersets
@@ -10806,7 +10806,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nCircle = SFSymbol(rawValue: "n.circle")
+    static var nCircle: SFSymbol { .init(rawValue: "n.circle") }
 
     /// 􀀟
     /// Single Localization, 3 Layersets
@@ -10815,7 +10815,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nCircleFill = SFSymbol(rawValue: "n.circle.fill")
+    static var nCircleFill: SFSymbol { .init(rawValue: "n.circle.fill") }
 
     /// 􀂮
     /// Single Localization, 2 Layersets
@@ -10823,7 +10823,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nSquare = SFSymbol(rawValue: "n.square")
+    static var nSquare: SFSymbol { .init(rawValue: "n.square") }
 
     /// 􀂯
     /// Single Localization, 3 Layersets
@@ -10832,7 +10832,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nSquareFill = SFSymbol(rawValue: "n.square.fill")
+    static var nSquareFill: SFSymbol { .init(rawValue: "n.square.fill") }
 
     /// 􀖽
     /// Single Localization, 2 Layersets
@@ -10840,7 +10840,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nairasignCircle = SFSymbol(rawValue: "nairasign.circle")
+    static var nairasignCircle: SFSymbol { .init(rawValue: "nairasign.circle") }
 
     /// 􀖾
     /// Single Localization, 3 Layersets
@@ -10849,7 +10849,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nairasignCircleFill = SFSymbol(rawValue: "nairasign.circle.fill")
+    static var nairasignCircleFill: SFSymbol { .init(rawValue: "nairasign.circle.fill") }
 
     /// 􀗽
     /// Single Localization, 2 Layersets
@@ -10857,7 +10857,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nairasignSquare = SFSymbol(rawValue: "nairasign.square")
+    static var nairasignSquare: SFSymbol { .init(rawValue: "nairasign.square") }
 
     /// 􀗾
     /// Single Localization, 3 Layersets
@@ -10866,21 +10866,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let nairasignSquareFill = SFSymbol(rawValue: "nairasign.square.fill")
+    static var nairasignSquareFill: SFSymbol { .init(rawValue: "nairasign.square.fill") }
 
     /// 􀍼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let nosign = SFSymbol(rawValue: "nosign")
+    static var nosign: SFSymbol { .init(rawValue: "nosign") }
 
     /// 􀆃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let number = SFSymbol(rawValue: "number")
+    static var number: SFSymbol { .init(rawValue: "number") }
 
     /// 􀁚
     /// Single Localization, 2 Layersets
@@ -10888,7 +10888,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let numberCircle = SFSymbol(rawValue: "number.circle")
+    static var numberCircle: SFSymbol { .init(rawValue: "number.circle") }
 
     /// 􀁛
     /// Single Localization, 3 Layersets
@@ -10897,7 +10897,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let numberCircleFill = SFSymbol(rawValue: "number.circle.fill")
+    static var numberCircleFill: SFSymbol { .init(rawValue: "number.circle.fill") }
 
     /// 􀃪
     /// Single Localization, 2 Layersets
@@ -10905,7 +10905,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let numberSquare = SFSymbol(rawValue: "number.square")
+    static var numberSquare: SFSymbol { .init(rawValue: "number.square") }
 
     /// 􀃫
     /// Single Localization, 3 Layersets
@@ -10914,7 +10914,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let numberSquareFill = SFSymbol(rawValue: "number.square.fill")
+    static var numberSquareFill: SFSymbol { .init(rawValue: "number.square.fill") }
 
     /// 􀀠
     /// Single Localization, 2 Layersets
@@ -10922,7 +10922,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let oCircle = SFSymbol(rawValue: "o.circle")
+    static var oCircle: SFSymbol { .init(rawValue: "o.circle") }
 
     /// 􀀡
     /// Single Localization, 3 Layersets
@@ -10931,7 +10931,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let oCircleFill = SFSymbol(rawValue: "o.circle.fill")
+    static var oCircleFill: SFSymbol { .init(rawValue: "o.circle.fill") }
 
     /// 􀂰
     /// Single Localization, 2 Layersets
@@ -10939,7 +10939,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let oSquare = SFSymbol(rawValue: "o.square")
+    static var oSquare: SFSymbol { .init(rawValue: "o.square") }
 
     /// 􀂱
     /// Single Localization, 3 Layersets
@@ -10948,14 +10948,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let oSquareFill = SFSymbol(rawValue: "o.square.fill")
+    static var oSquareFill: SFSymbol { .init(rawValue: "o.square.fill") }
 
     /// 􀆕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let option = SFSymbol(rawValue: "option")
+    static var option: SFSymbol { .init(rawValue: "option") }
 
     /// 􀀢
     /// Single Localization, 2 Layersets
@@ -10963,7 +10963,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pCircle = SFSymbol(rawValue: "p.circle")
+    static var pCircle: SFSymbol { .init(rawValue: "p.circle") }
 
     /// 􀀣
     /// Single Localization, 3 Layersets
@@ -10972,7 +10972,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pCircleFill = SFSymbol(rawValue: "p.circle.fill")
+    static var pCircleFill: SFSymbol { .init(rawValue: "p.circle.fill") }
 
     /// 􀂲
     /// Single Localization, 2 Layersets
@@ -10980,7 +10980,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pSquare = SFSymbol(rawValue: "p.square")
+    static var pSquare: SFSymbol { .init(rawValue: "p.square") }
 
     /// 􀂳
     /// Single Localization, 3 Layersets
@@ -10989,35 +10989,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pSquareFill = SFSymbol(rawValue: "p.square.fill")
+    static var pSquareFill: SFSymbol { .init(rawValue: "p.square.fill") }
 
     /// 􀎑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paintbrush = SFSymbol(rawValue: "paintbrush")
+    static var paintbrush: SFSymbol { .init(rawValue: "paintbrush") }
 
     /// 􀎒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paintbrushFill = SFSymbol(rawValue: "paintbrush.fill")
+    static var paintbrushFill: SFSymbol { .init(rawValue: "paintbrush.fill") }
 
     /// 􀐏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pano = SFSymbol(rawValue: "pano")
+    static var pano: SFSymbol { .init(rawValue: "pano") }
 
     /// 􀐐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let panoFill = SFSymbol(rawValue: "pano.fill")
+    static var panoFill: SFSymbol { .init(rawValue: "pano.fill") }
 
     /// 􀉢
     /// Single Localization, 2 Layersets
@@ -11025,21 +11025,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let paperclip = SFSymbol(rawValue: "paperclip")
+    static var paperclip: SFSymbol { .init(rawValue: "paperclip") }
 
     /// 􀈟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paperplane = SFSymbol(rawValue: "paperplane")
+    static var paperplane: SFSymbol { .init(rawValue: "paperplane") }
 
     /// 􀈠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paperplaneFill = SFSymbol(rawValue: "paperplane.fill")
+    static var paperplaneFill: SFSymbol { .init(rawValue: "paperplane.fill") }
 
     /// 􀒆
     /// Single Localization, Single Layerset
@@ -11051,14 +11051,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "paragraphsign")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "paragraphsign")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "paragraphsign")
-    static let paragraph = SFSymbol(rawValue: "paragraph")
+    static var paragraph: SFSymbol { .init(rawValue: "paragraph") }
 
     /// 􀊅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pause = SFSymbol(rawValue: "pause")
+    static var pause: SFSymbol { .init(rawValue: "pause") }
 
     /// 􀊗
     /// Single Localization, 2 Layersets
@@ -11066,7 +11066,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pauseCircle = SFSymbol(rawValue: "pause.circle")
+    static var pauseCircle: SFSymbol { .init(rawValue: "pause.circle") }
 
     /// 􀊘
     /// Single Localization, 3 Layersets
@@ -11075,14 +11075,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pauseCircleFill = SFSymbol(rawValue: "pause.circle.fill")
+    static var pauseCircleFill: SFSymbol { .init(rawValue: "pause.circle.fill") }
 
     /// 􀊆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pauseFill = SFSymbol(rawValue: "pause.fill")
+    static var pauseFill: SFSymbol { .init(rawValue: "pause.fill") }
 
     /// 􀊛
     /// Single Localization, 2 Layersets
@@ -11090,7 +11090,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pauseRectangle = SFSymbol(rawValue: "pause.rectangle")
+    static var pauseRectangle: SFSymbol { .init(rawValue: "pause.rectangle") }
 
     /// 􀊜
     /// Single Localization, 3 Layersets
@@ -11099,14 +11099,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pauseRectangleFill = SFSymbol(rawValue: "pause.rectangle.fill")
+    static var pauseRectangleFill: SFSymbol { .init(rawValue: "pause.rectangle.fill") }
 
     /// 􀈊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pencil = SFSymbol(rawValue: "pencil")
+    static var pencil: SFSymbol { .init(rawValue: "pencil") }
 
     /// 􀈏
     /// Single Localization, 3 Layersets
@@ -11120,7 +11120,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "rectangleAndPencilAndEllipsis")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "rectangleAndPencilAndEllipsis")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleAndPencilAndEllipsis")
-    static let pencilAndEllipsisRectangle = SFSymbol(rawValue: "pencil.and.ellipsis.rectangle")
+    static var pencilAndEllipsisRectangle: SFSymbol { .init(rawValue: "pencil.and.ellipsis.rectangle") }
 
     /// 􀈐
     /// Single Localization, 2 Layersets
@@ -11128,7 +11128,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pencilAndOutline = SFSymbol(rawValue: "pencil.and.outline")
+    static var pencilAndOutline: SFSymbol { .init(rawValue: "pencil.and.outline") }
 
     /// 􀈋
     /// Single Localization, 2 Layersets
@@ -11136,7 +11136,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pencilCircle = SFSymbol(rawValue: "pencil.circle")
+    static var pencilCircle: SFSymbol { .init(rawValue: "pencil.circle") }
 
     /// 􀈌
     /// Single Localization, 3 Layersets
@@ -11145,7 +11145,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pencilCircleFill = SFSymbol(rawValue: "pencil.circle.fill")
+    static var pencilCircleFill: SFSymbol { .init(rawValue: "pencil.circle.fill") }
 
     /// 􀈍
     /// Single Localization, 2 Layersets
@@ -11153,7 +11153,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pencilSlash = SFSymbol(rawValue: "pencil.slash")
+    static var pencilSlash: SFSymbol { .init(rawValue: "pencil.slash") }
 
     /// 􀒋
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -11162,7 +11162,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to drawing experiences that are based on PencilKit.
-    static let pencilTip = SFSymbol(rawValue: "pencil.tip")
+    static var pencilTip: SFSymbol { .init(rawValue: "pencil.tip") }
 
     /// 􀉥
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -11171,7 +11171,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircle = SFSymbol(rawValue: "pencil.tip.crop.circle")
+    static var pencilTipCropCircle: SFSymbol { .init(rawValue: "pencil.tip.crop.circle") }
 
     /// 􀉧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11182,7 +11182,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgeMinus = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.minus")
+    static var pencilTipCropCircleBadgeMinus: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.minus") }
 
     /// 􀉦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11193,7 +11193,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgePlus = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.plus")
+    static var pencilTipCropCircleBadgePlus: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.plus") }
 
     /// 􀘾
     /// 2 Localizations, Single Layerset
@@ -11204,14 +11204,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let percent = SymbolWith1Localization<Ar_v2>(rawValue: "percent")
+    static var percent: SymbolWith1Localization<Ar_v2> { .init(rawValue: "percent") }
 
     /// 􀉩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let person = SFSymbol(rawValue: "person")
+    static var person: SFSymbol { .init(rawValue: "person") }
 
     /// 􀉫
     /// Single Localization, 2 Layersets
@@ -11219,7 +11219,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person2 = SFSymbol(rawValue: "person.2")
+    static var person2: SFSymbol { .init(rawValue: "person.2") }
 
     /// 􀉬
     /// Single Localization, 2 Layersets
@@ -11227,7 +11227,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person2Fill = SFSymbol(rawValue: "person.2.fill")
+    static var person2Fill: SFSymbol { .init(rawValue: "person.2.fill") }
 
     /// 􀓥
     /// Single Localization, Single Layerset
@@ -11239,7 +11239,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "person2CropSquareStack")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "person2CropSquareStack")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "person2CropSquareStack")
-    static let person2SquareStack = SFSymbol(rawValue: "person.2.square.stack")
+    static var person2SquareStack: SFSymbol { .init(rawValue: "person.2.square.stack") }
 
     /// 􀓦
     /// Single Localization, 3 Layersets
@@ -11253,7 +11253,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "person2CropSquareStackFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "person2CropSquareStackFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "person2CropSquareStackFill")
-    static let person2SquareStackFill = SFSymbol(rawValue: "person.2.square.stack.fill")
+    static var person2SquareStackFill: SFSymbol { .init(rawValue: "person.2.square.stack.fill") }
 
     /// 􀝊
     /// Single Localization, 2 Layersets
@@ -11261,7 +11261,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person3 = SFSymbol(rawValue: "person.3")
+    static var person3: SFSymbol { .init(rawValue: "person.3") }
 
     /// 􀝋
     /// Single Localization, 2 Layersets
@@ -11269,7 +11269,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person3Fill = SFSymbol(rawValue: "person.3.fill")
+    static var person3Fill: SFSymbol { .init(rawValue: "person.3.fill") }
 
     /// 􀜗
     /// Single Localization, 3 Layersets
@@ -11278,7 +11278,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personBadgeMinus = SFSymbol(rawValue: "person.badge.minus")
+    static var personBadgeMinus: SFSymbol { .init(rawValue: "person.badge.minus") }
 
     /// 􀜘
     /// Single Localization, 3 Layersets
@@ -11292,7 +11292,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "personFillBadgeMinus")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "personFillBadgeMinus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personFillBadgeMinus")
-    static let personBadgeMinusFill = SFSymbol(rawValue: "person.badge.minus.fill")
+    static var personBadgeMinusFill: SFSymbol { .init(rawValue: "person.badge.minus.fill") }
 
     /// 􀜕
     /// Single Localization, 3 Layersets
@@ -11301,7 +11301,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personBadgePlus = SFSymbol(rawValue: "person.badge.plus")
+    static var personBadgePlus: SFSymbol { .init(rawValue: "person.badge.plus") }
 
     /// 􀜖
     /// Single Localization, 3 Layersets
@@ -11315,7 +11315,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "personFillBadgePlus")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "personFillBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personFillBadgePlus")
-    static let personBadgePlusFill = SFSymbol(rawValue: "person.badge.plus.fill")
+    static var personBadgePlusFill: SFSymbol { .init(rawValue: "person.badge.plus.fill") }
 
     /// 􀓣
     /// Single Localization, 2 Layersets
@@ -11323,7 +11323,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCircle = SFSymbol(rawValue: "person.circle")
+    static var personCircle: SFSymbol { .init(rawValue: "person.circle") }
 
     /// 􀓤
     /// Single Localization, 3 Layersets
@@ -11332,14 +11332,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCircleFill = SFSymbol(rawValue: "person.circle.fill")
+    static var personCircleFill: SFSymbol { .init(rawValue: "person.circle.fill") }
 
     /// 􀉭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personCropCircle = SFSymbol(rawValue: "person.crop.circle")
+    static var personCropCircle: SFSymbol { .init(rawValue: "person.crop.circle") }
 
     /// 􀉳
     /// Single Localization, 3 Layersets
@@ -11348,7 +11348,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgeCheckmark = SFSymbol(rawValue: "person.crop.circle.badge.checkmark")
+    static var personCropCircleBadgeCheckmark: SFSymbol { .init(rawValue: "person.crop.circle.badge.checkmark") }
 
     /// 􀉷
     /// Single Localization, 3 Layersets
@@ -11362,7 +11362,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "personCropCircleBadgeExclamationmark")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "personCropCircleBadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropCircleBadgeExclamationmark")
-    static let personCropCircleBadgeExclam = SFSymbol(rawValue: "person.crop.circle.badge.exclam")
+    static var personCropCircleBadgeExclam: SFSymbol { .init(rawValue: "person.crop.circle.badge.exclam") }
 
     /// 􀉱
     /// Single Localization, 3 Layersets
@@ -11371,7 +11371,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgeMinus = SFSymbol(rawValue: "person.crop.circle.badge.minus")
+    static var personCropCircleBadgeMinus: SFSymbol { .init(rawValue: "person.crop.circle.badge.minus") }
 
     /// 􀉯
     /// Single Localization, 3 Layersets
@@ -11380,7 +11380,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgePlus = SFSymbol(rawValue: "person.crop.circle.badge.plus")
+    static var personCropCircleBadgePlus: SFSymbol { .init(rawValue: "person.crop.circle.badge.plus") }
 
     /// 􀉵
     /// Single Localization, 3 Layersets
@@ -11389,7 +11389,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgeXmark = SFSymbol(rawValue: "person.crop.circle.badge.xmark")
+    static var personCropCircleBadgeXmark: SFSymbol { .init(rawValue: "person.crop.circle.badge.xmark") }
 
     /// 􀉮
     /// Single Localization, 3 Layersets
@@ -11398,7 +11398,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleFill = SFSymbol(rawValue: "person.crop.circle.fill")
+    static var personCropCircleFill: SFSymbol { .init(rawValue: "person.crop.circle.fill") }
 
     /// 􀉴
     /// Single Localization, 3 Layersets
@@ -11407,7 +11407,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleFillBadgeCheckmark = SFSymbol(rawValue: "person.crop.circle.fill.badge.checkmark")
+    static var personCropCircleFillBadgeCheckmark: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.checkmark") }
 
     /// 􀉸
     /// Single Localization, Single Layerset
@@ -11419,7 +11419,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "personCropCircleFillBadgeExclamationmark")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "personCropCircleFillBadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropCircleFillBadgeExclamationmark")
-    static let personCropCircleFillBadgeExclam = SFSymbol(rawValue: "person.crop.circle.fill.badge.exclam")
+    static var personCropCircleFillBadgeExclam: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.exclam") }
 
     /// 􀉲
     /// Single Localization, 3 Layersets
@@ -11428,7 +11428,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleFillBadgeMinus = SFSymbol(rawValue: "person.crop.circle.fill.badge.minus")
+    static var personCropCircleFillBadgeMinus: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.minus") }
 
     /// 􀉰
     /// Single Localization, 3 Layersets
@@ -11437,7 +11437,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleFillBadgePlus = SFSymbol(rawValue: "person.crop.circle.fill.badge.plus")
+    static var personCropCircleFillBadgePlus: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.plus") }
 
     /// 􀉶
     /// Single Localization, 3 Layersets
@@ -11446,14 +11446,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleFillBadgeXmark = SFSymbol(rawValue: "person.crop.circle.fill.badge.xmark")
+    static var personCropCircleFillBadgeXmark: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.xmark") }
 
     /// 􀏏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personCropRectangle = SFSymbol(rawValue: "person.crop.rectangle")
+    static var personCropRectangle: SFSymbol { .init(rawValue: "person.crop.rectangle") }
 
     /// 􀏐
     /// Single Localization, 3 Layersets
@@ -11462,14 +11462,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
     /// - Multicolor (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
-    static let personCropRectangleFill = SFSymbol(rawValue: "person.crop.rectangle.fill")
+    static var personCropRectangleFill: SFSymbol { .init(rawValue: "person.crop.rectangle.fill") }
 
     /// 􀉹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personCropSquare = SFSymbol(rawValue: "person.crop.square")
+    static var personCropSquare: SFSymbol { .init(rawValue: "person.crop.square") }
 
     /// 􀉺
     /// Single Localization, 3 Layersets
@@ -11478,14 +11478,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropSquareFill = SFSymbol(rawValue: "person.crop.square.fill")
+    static var personCropSquareFill: SFSymbol { .init(rawValue: "person.crop.square.fill") }
 
     /// 􀉪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personFill = SFSymbol(rawValue: "person.fill")
+    static var personFill: SFSymbol { .init(rawValue: "person.fill") }
 
     /// 􀙳
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -11494,7 +11494,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let personIcloud = SFSymbol(rawValue: "person.icloud")
+    static var personIcloud: SFSymbol { .init(rawValue: "person.icloud") }
 
     /// 􀙴
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11505,14 +11505,14 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let personIcloudFill = SFSymbol(rawValue: "person.icloud.fill")
+    static var personIcloudFill: SFSymbol { .init(rawValue: "person.icloud.fill") }
 
     /// 􀉤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personalhotspot = SFSymbol(rawValue: "personalhotspot")
+    static var personalhotspot: SFSymbol { .init(rawValue: "personalhotspot") }
 
     /// 􀒱
     /// Single Localization, 3 Layersets
@@ -11521,7 +11521,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let perspective = SFSymbol(rawValue: "perspective")
+    static var perspective: SFSymbol { .init(rawValue: "perspective") }
 
     /// 􀖯
     /// Single Localization, 2 Layersets
@@ -11529,7 +11529,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesetasignCircle = SFSymbol(rawValue: "pesetasign.circle")
+    static var pesetasignCircle: SFSymbol { .init(rawValue: "pesetasign.circle") }
 
     /// 􀖰
     /// Single Localization, 3 Layersets
@@ -11538,7 +11538,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesetasignCircleFill = SFSymbol(rawValue: "pesetasign.circle.fill")
+    static var pesetasignCircleFill: SFSymbol { .init(rawValue: "pesetasign.circle.fill") }
 
     /// 􀗯
     /// Single Localization, 2 Layersets
@@ -11546,7 +11546,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesetasignSquare = SFSymbol(rawValue: "pesetasign.square")
+    static var pesetasignSquare: SFSymbol { .init(rawValue: "pesetasign.square") }
 
     /// 􀗰
     /// Single Localization, 3 Layersets
@@ -11555,7 +11555,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesetasignSquareFill = SFSymbol(rawValue: "pesetasign.square.fill")
+    static var pesetasignSquareFill: SFSymbol { .init(rawValue: "pesetasign.square.fill") }
 
     /// 􀖱
     /// Single Localization, 2 Layersets
@@ -11563,7 +11563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesosignCircle = SFSymbol(rawValue: "pesosign.circle")
+    static var pesosignCircle: SFSymbol { .init(rawValue: "pesosign.circle") }
 
     /// 􀖲
     /// Single Localization, 3 Layersets
@@ -11572,7 +11572,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesosignCircleFill = SFSymbol(rawValue: "pesosign.circle.fill")
+    static var pesosignCircleFill: SFSymbol { .init(rawValue: "pesosign.circle.fill") }
 
     /// 􀗱
     /// Single Localization, 2 Layersets
@@ -11580,7 +11580,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesosignSquare = SFSymbol(rawValue: "pesosign.square")
+    static var pesosignSquare: SFSymbol { .init(rawValue: "pesosign.square") }
 
     /// 􀗲
     /// Single Localization, 3 Layersets
@@ -11589,7 +11589,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pesosignSquareFill = SFSymbol(rawValue: "pesosign.square.fill")
+    static var pesosignSquareFill: SFSymbol { .init(rawValue: "pesosign.square.fill") }
 
     /// 􀌾
     /// Single Localization, 2 Layersets
@@ -11597,7 +11597,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phone = SFSymbol(rawValue: "phone")
+    static var phone: SFSymbol { .init(rawValue: "phone") }
 
     /// 􀍂
     /// Single Localization, 2 Layersets
@@ -11605,7 +11605,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneArrowDownLeft = SFSymbol(rawValue: "phone.arrow.down.left")
+    static var phoneArrowDownLeft: SFSymbol { .init(rawValue: "phone.arrow.down.left") }
 
     /// 􀍄
     /// Single Localization, 2 Layersets
@@ -11613,7 +11613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneArrowRight = SFSymbol(rawValue: "phone.arrow.right")
+    static var phoneArrowRight: SFSymbol { .init(rawValue: "phone.arrow.right") }
 
     /// 􀍀
     /// Single Localization, 2 Layersets
@@ -11621,7 +11621,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneArrowUpRight = SFSymbol(rawValue: "phone.arrow.up.right")
+    static var phoneArrowUpRight: SFSymbol { .init(rawValue: "phone.arrow.up.right") }
 
     /// 􀖎
     /// Single Localization, 3 Layersets
@@ -11630,7 +11630,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneBadgePlus = SFSymbol(rawValue: "phone.badge.plus")
+    static var phoneBadgePlus: SFSymbol { .init(rawValue: "phone.badge.plus") }
 
     /// 􀒥
     /// Single Localization, 3 Layersets
@@ -11639,7 +11639,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneCircle = SFSymbol(rawValue: "phone.circle")
+    static var phoneCircle: SFSymbol { .init(rawValue: "phone.circle") }
 
     /// 􀒦
     /// Single Localization, 3 Layersets
@@ -11648,7 +11648,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneCircleFill = SFSymbol(rawValue: "phone.circle.fill")
+    static var phoneCircleFill: SFSymbol { .init(rawValue: "phone.circle.fill") }
 
     /// 􀍆
     /// Single Localization, 2 Layersets
@@ -11656,7 +11656,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneDown = SFSymbol(rawValue: "phone.down")
+    static var phoneDown: SFSymbol { .init(rawValue: "phone.down") }
 
     /// 􀒧
     /// Single Localization, 3 Layersets
@@ -11665,7 +11665,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneDownCircle = SFSymbol(rawValue: "phone.down.circle")
+    static var phoneDownCircle: SFSymbol { .init(rawValue: "phone.down.circle") }
 
     /// 􀒨
     /// Single Localization, 3 Layersets
@@ -11674,7 +11674,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneDownCircleFill = SFSymbol(rawValue: "phone.down.circle.fill")
+    static var phoneDownCircleFill: SFSymbol { .init(rawValue: "phone.down.circle.fill") }
 
     /// 􀍇
     /// Single Localization, 2 Layersets
@@ -11682,7 +11682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneDownFill = SFSymbol(rawValue: "phone.down.fill")
+    static var phoneDownFill: SFSymbol { .init(rawValue: "phone.down.fill") }
 
     /// 􀌿
     /// Single Localization, 2 Layersets
@@ -11690,7 +11690,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneFill = SFSymbol(rawValue: "phone.fill")
+    static var phoneFill: SFSymbol { .init(rawValue: "phone.fill") }
 
     /// 􀍃
     /// Single Localization, 2 Layersets
@@ -11703,7 +11703,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "phoneArrowDownLeftFill")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "phoneArrowDownLeftFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneArrowDownLeftFill")
-    static let phoneFillArrowDownLeft = SFSymbol(rawValue: "phone.fill.arrow.down.left")
+    static var phoneFillArrowDownLeft: SFSymbol { .init(rawValue: "phone.fill.arrow.down.left") }
 
     /// 􀍅
     /// Single Localization, 2 Layersets
@@ -11716,7 +11716,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "phoneArrowRightFill")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "phoneArrowRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneArrowRightFill")
-    static let phoneFillArrowRight = SFSymbol(rawValue: "phone.fill.arrow.right")
+    static var phoneFillArrowRight: SFSymbol { .init(rawValue: "phone.fill.arrow.right") }
 
     /// 􀍁
     /// Single Localization, 2 Layersets
@@ -11729,7 +11729,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "phoneArrowUpRightFill")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "phoneArrowUpRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneArrowUpRightFill")
-    static let phoneFillArrowUpRight = SFSymbol(rawValue: "phone.fill.arrow.up.right")
+    static var phoneFillArrowUpRight: SFSymbol { .init(rawValue: "phone.fill.arrow.up.right") }
 
     /// 􀖏
     /// Single Localization, 3 Layersets
@@ -11738,21 +11738,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneFillBadgePlus = SFSymbol(rawValue: "phone.fill.badge.plus")
+    static var phoneFillBadgePlus: SFSymbol { .init(rawValue: "phone.fill.badge.plus") }
 
     /// 􀏅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let photo = SFSymbol(rawValue: "photo")
+    static var photo: SFSymbol { .init(rawValue: "photo") }
 
     /// 􀏆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let photoFill = SFSymbol(rawValue: "photo.fill")
+    static var photoFill: SFSymbol { .init(rawValue: "photo.fill") }
 
     /// 􀏬
     /// Single Localization, 2 Layersets
@@ -11760,7 +11760,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let photoFillOnRectangleFill = SFSymbol(rawValue: "photo.fill.on.rectangle.fill")
+    static var photoFillOnRectangleFill: SFSymbol { .init(rawValue: "photo.fill.on.rectangle.fill") }
 
     /// 􀏫
     /// Single Localization, 3 Layersets
@@ -11769,7 +11769,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let photoOnRectangle = SFSymbol(rawValue: "photo.on.rectangle")
+    static var photoOnRectangle: SFSymbol { .init(rawValue: "photo.on.rectangle") }
 
     /// 􀎦
     /// Single Localization, 2 Layersets
@@ -11777,7 +11777,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pin = SFSymbol(rawValue: "pin")
+    static var pin: SFSymbol { .init(rawValue: "pin") }
 
     /// 􀎧
     /// Single Localization, 2 Layersets
@@ -11785,7 +11785,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pinFill = SFSymbol(rawValue: "pin.fill")
+    static var pinFill: SFSymbol { .init(rawValue: "pin.fill") }
 
     /// 􀎨
     /// Single Localization, 3 Layersets
@@ -11794,7 +11794,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let pinSlash = SFSymbol(rawValue: "pin.slash")
+    static var pinSlash: SFSymbol { .init(rawValue: "pin.slash") }
 
     /// 􀎩
     /// Single Localization, 3 Layersets
@@ -11803,14 +11803,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let pinSlashFill = SFSymbol(rawValue: "pin.slash.fill")
+    static var pinSlashFill: SFSymbol { .init(rawValue: "pin.slash.fill") }
 
     /// 􀊃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let play = SFSymbol(rawValue: "play")
+    static var play: SFSymbol { .init(rawValue: "play") }
 
     /// 􀊕
     /// Single Localization, 2 Layersets
@@ -11818,7 +11818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playCircle = SFSymbol(rawValue: "play.circle")
+    static var playCircle: SFSymbol { .init(rawValue: "play.circle") }
 
     /// 􀊖
     /// Single Localization, 3 Layersets
@@ -11827,14 +11827,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playCircleFill = SFSymbol(rawValue: "play.circle.fill")
+    static var playCircleFill: SFSymbol { .init(rawValue: "play.circle.fill") }
 
     /// 􀊄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let playFill = SFSymbol(rawValue: "play.fill")
+    static var playFill: SFSymbol { .init(rawValue: "play.fill") }
 
     /// 􀊙
     /// Single Localization, 2 Layersets
@@ -11842,7 +11842,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playRectangle = SFSymbol(rawValue: "play.rectangle")
+    static var playRectangle: SFSymbol { .init(rawValue: "play.rectangle") }
 
     /// 􀊚
     /// Single Localization, 3 Layersets
@@ -11851,21 +11851,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playRectangleFill = SFSymbol(rawValue: "play.rectangle.fill")
+    static var playRectangleFill: SFSymbol { .init(rawValue: "play.rectangle.fill") }
 
     /// 􀊇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let playpause = SFSymbol(rawValue: "playpause")
+    static var playpause: SFSymbol { .init(rawValue: "playpause") }
 
     /// 􀊈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let playpauseFill = SFSymbol(rawValue: "playpause.fill")
+    static var playpauseFill: SFSymbol { .init(rawValue: "playpause.fill") }
 
     /// 􀅼
     /// Single Localization, 2 Layersets
@@ -11873,7 +11873,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plus = SFSymbol(rawValue: "plus")
+    static var plus: SFSymbol { .init(rawValue: "plus") }
 
     /// 􀑍
     /// Single Localization, 2 Layersets
@@ -11881,7 +11881,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusApp = SFSymbol(rawValue: "plus.app")
+    static var plusApp: SFSymbol { .init(rawValue: "plus.app") }
 
     /// 􀑎
     /// Single Localization, 3 Layersets
@@ -11890,7 +11890,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusAppFill = SFSymbol(rawValue: "plus.app.fill")
+    static var plusAppFill: SFSymbol { .init(rawValue: "plus.app.fill") }
 
     /// 􀌶
     /// Single Localization, 2 Layersets
@@ -11898,7 +11898,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusBubble = SFSymbol(rawValue: "plus.bubble")
+    static var plusBubble: SFSymbol { .init(rawValue: "plus.bubble") }
 
     /// 􀌷
     /// Single Localization, 3 Layersets
@@ -11907,7 +11907,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusBubbleFill = SFSymbol(rawValue: "plus.bubble.fill")
+    static var plusBubbleFill: SFSymbol { .init(rawValue: "plus.bubble.fill") }
 
     /// 􀁌
     /// Single Localization, 3 Layersets
@@ -11916,7 +11916,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusCircle = SFSymbol(rawValue: "plus.circle")
+    static var plusCircle: SFSymbol { .init(rawValue: "plus.circle") }
 
     /// 􀁍
     /// Single Localization, 3 Layersets
@@ -11925,7 +11925,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusCircleFill = SFSymbol(rawValue: "plus.circle.fill")
+    static var plusCircleFill: SFSymbol { .init(rawValue: "plus.circle.fill") }
 
     /// 􀊬
     /// Single Localization, 2 Layersets
@@ -11933,7 +11933,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let plusMagnifyingglass = SFSymbol(rawValue: "plus.magnifyingglass")
+    static var plusMagnifyingglass: SFSymbol { .init(rawValue: "plus.magnifyingglass") }
 
     /// 􀏇
     /// Single Localization, 3 Layersets
@@ -11942,7 +11942,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusRectangle = SFSymbol(rawValue: "plus.rectangle")
+    static var plusRectangle: SFSymbol { .init(rawValue: "plus.rectangle") }
 
     /// 􀏈
     /// Single Localization, 3 Layersets
@@ -11951,7 +11951,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusRectangleFill = SFSymbol(rawValue: "plus.rectangle.fill")
+    static var plusRectangleFill: SFSymbol { .init(rawValue: "plus.rectangle.fill") }
 
     /// 􀏪
     /// Single Localization, 3 Layersets
@@ -11960,7 +11960,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusRectangleFillOnRectangleFill = SFSymbol(rawValue: "plus.rectangle.fill.on.rectangle.fill")
+    static var plusRectangleFillOnRectangleFill: SFSymbol { .init(rawValue: "plus.rectangle.fill.on.rectangle.fill") }
 
     /// 􀏩
     /// Single Localization, 3 Layersets
@@ -11969,7 +11969,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusRectangleOnRectangle = SFSymbol(rawValue: "plus.rectangle.on.rectangle")
+    static var plusRectangleOnRectangle: SFSymbol { .init(rawValue: "plus.rectangle.on.rectangle") }
 
     /// 􀅺
     /// Single Localization, Single Layerset
@@ -11981,7 +11981,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "plusForwardslashMinus")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "plusForwardslashMinus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "plusForwardslashMinus")
-    static let plusSlashMinus = SFSymbol(rawValue: "plus.slash.minus")
+    static var plusSlashMinus: SFSymbol { .init(rawValue: "plus.slash.minus") }
 
     /// 􀃜
     /// Single Localization, 3 Layersets
@@ -11990,7 +11990,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusSquare = SFSymbol(rawValue: "plus.square")
+    static var plusSquare: SFSymbol { .init(rawValue: "plus.square") }
 
     /// 􀃝
     /// Single Localization, 3 Layersets
@@ -11999,7 +11999,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusSquareFill = SFSymbol(rawValue: "plus.square.fill")
+    static var plusSquareFill: SFSymbol { .init(rawValue: "plus.square.fill") }
 
     /// 􀐈
     /// Single Localization, 3 Layersets
@@ -12008,7 +12008,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusSquareFillOnSquareFill = SFSymbol(rawValue: "plus.square.fill.on.square.fill")
+    static var plusSquareFillOnSquareFill: SFSymbol { .init(rawValue: "plus.square.fill.on.square.fill") }
 
     /// 􀐇
     /// Single Localization, 3 Layersets
@@ -12017,14 +12017,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusSquareOnSquare = SFSymbol(rawValue: "plus.square.on.square")
+    static var plusSquareOnSquare: SFSymbol { .init(rawValue: "plus.square.on.square") }
 
     /// 􀛺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let plusminus = SFSymbol(rawValue: "plusminus")
+    static var plusminus: SFSymbol { .init(rawValue: "plusminus") }
 
     /// 􀍶
     /// Single Localization, 2 Layersets
@@ -12032,7 +12032,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusminusCircle = SFSymbol(rawValue: "plusminus.circle")
+    static var plusminusCircle: SFSymbol { .init(rawValue: "plusminus.circle") }
 
     /// 􀘝
     /// Single Localization, 3 Layersets
@@ -12041,42 +12041,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusminusCircleFill = SFSymbol(rawValue: "plusminus.circle.fill")
+    static var plusminusCircleFill: SFSymbol { .init(rawValue: "plusminus.circle.fill") }
 
     /// 􀆨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let power = SFSymbol(rawValue: "power")
+    static var power: SFSymbol { .init(rawValue: "power") }
 
     /// 􀎚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printer = SFSymbol(rawValue: "printer")
+    static var printer: SFSymbol { .init(rawValue: "printer") }
 
     /// 􀎛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerFill = SFSymbol(rawValue: "printer.fill")
+    static var printerFill: SFSymbol { .init(rawValue: "printer.fill") }
 
     /// 􀆎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let projective = SFSymbol(rawValue: "projective")
+    static var projective: SFSymbol { .init(rawValue: "projective") }
 
     /// 􀚐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let purchased = SFSymbol(rawValue: "purchased")
+    static var purchased: SFSymbol { .init(rawValue: "purchased") }
 
     /// 􀚑
     /// Single Localization, 2 Layersets
@@ -12084,7 +12084,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let purchasedCircle = SFSymbol(rawValue: "purchased.circle")
+    static var purchasedCircle: SFSymbol { .init(rawValue: "purchased.circle") }
 
     /// 􀚒
     /// Single Localization, 3 Layersets
@@ -12093,7 +12093,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let purchasedCircleFill = SFSymbol(rawValue: "purchased.circle.fill")
+    static var purchasedCircleFill: SFSymbol { .init(rawValue: "purchased.circle.fill") }
 
     /// 􀀤
     /// Single Localization, 2 Layersets
@@ -12101,7 +12101,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let qCircle = SFSymbol(rawValue: "q.circle")
+    static var qCircle: SFSymbol { .init(rawValue: "q.circle") }
 
     /// 􀀥
     /// Single Localization, 3 Layersets
@@ -12110,7 +12110,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let qCircleFill = SFSymbol(rawValue: "q.circle.fill")
+    static var qCircleFill: SFSymbol { .init(rawValue: "q.circle.fill") }
 
     /// 􀂴
     /// Single Localization, 2 Layersets
@@ -12118,7 +12118,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let qSquare = SFSymbol(rawValue: "q.square")
+    static var qSquare: SFSymbol { .init(rawValue: "q.square") }
 
     /// 􀂵
     /// Single Localization, 3 Layersets
@@ -12127,14 +12127,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let qSquareFill = SFSymbol(rawValue: "q.square.fill")
+    static var qSquareFill: SFSymbol { .init(rawValue: "q.square.fill") }
 
     /// 􀖂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let qrcode = SFSymbol(rawValue: "qrcode")
+    static var qrcode: SFSymbol { .init(rawValue: "qrcode") }
 
     /// 􀎻
     /// Single Localization, 2 Layersets
@@ -12142,7 +12142,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let qrcodeViewfinder = SFSymbol(rawValue: "qrcode.viewfinder")
+    static var qrcodeViewfinder: SFSymbol { .init(rawValue: "qrcode.viewfinder") }
 
     /// 􀅍
     /// 2 Localizations, 2 Layersets
@@ -12154,7 +12154,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmark = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark")
+    static var questionmark: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark") }
 
     /// 􀁜
     /// 2 Localizations, 3 Layersets
@@ -12167,7 +12167,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkCircle = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.circle")
+    static var questionmarkCircle: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.circle") }
 
     /// 􀁝
     /// 2 Localizations, 3 Layersets
@@ -12180,7 +12180,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkCircleFill = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.circle.fill")
+    static var questionmarkCircleFill: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.circle.fill") }
 
     /// 􀄢
     /// 2 Localizations, 3 Layersets
@@ -12193,7 +12193,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkDiamond = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.diamond")
+    static var questionmarkDiamond: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.diamond") }
 
     /// 􀄣
     /// 2 Localizations, 3 Layersets
@@ -12206,7 +12206,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkDiamondFill = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.diamond.fill")
+    static var questionmarkDiamondFill: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.diamond.fill") }
 
     /// 􀃬
     /// 2 Localizations, 3 Layersets
@@ -12219,7 +12219,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkSquare = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.square")
+    static var questionmarkSquare: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.square") }
 
     /// 􀃭
     /// 2 Localizations, 3 Layersets
@@ -12232,7 +12232,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkSquareFill = SymbolWith1Localization<Ar_v2>(rawValue: "questionmark.square.fill")
+    static var questionmarkSquareFill: SymbolWith1Localization<Ar_v2> { .init(rawValue: "questionmark.square.fill") }
 
     /// 􀍓
     /// 3 Localizations, 2 Layersets, ⚠️ Restricted
@@ -12247,7 +12247,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let questionmarkVideo = SymbolWith2Localizations<Ar_v2, Rtl>(rawValue: "questionmark.video")
+    static var questionmarkVideo: SymbolWith2Localizations<Ar_v2, Rtl> { .init(rawValue: "questionmark.video") }
 
     /// 􀍔
     /// 3 Localizations, 3 Layersets, ⚠️ Restricted
@@ -12263,7 +12263,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let questionmarkVideoFill = SymbolWith2Localizations<Ar_v2, Rtl>(rawValue: "questionmark.video.fill")
+    static var questionmarkVideoFill: SymbolWith2Localizations<Ar_v2, Rtl> { .init(rawValue: "questionmark.video.fill") }
 
     /// 􀌮
     /// 2 Localizations, 2 Layersets
@@ -12275,7 +12275,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let quoteBubble = SymbolWith1Localization<Rtl_v2>(rawValue: "quote.bubble")
+    static var quoteBubble: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "quote.bubble") }
 
     /// 􀌯
     /// 2 Localizations, 3 Layersets
@@ -12288,7 +12288,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let quoteBubbleFill = SymbolWith1Localization<Rtl_v2>(rawValue: "quote.bubble.fill")
+    static var quoteBubbleFill: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "quote.bubble.fill") }
 
     /// 􀀦
     /// Single Localization, 2 Layersets
@@ -12296,7 +12296,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rCircle = SFSymbol(rawValue: "r.circle")
+    static var rCircle: SFSymbol { .init(rawValue: "r.circle") }
 
     /// 􀀧
     /// Single Localization, 3 Layersets
@@ -12305,7 +12305,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rCircleFill = SFSymbol(rawValue: "r.circle.fill")
+    static var rCircleFill: SFSymbol { .init(rawValue: "r.circle.fill") }
 
     /// 􀂶
     /// Single Localization, 2 Layersets
@@ -12313,7 +12313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rSquare = SFSymbol(rawValue: "r.square")
+    static var rSquare: SFSymbol { .init(rawValue: "r.square") }
 
     /// 􀂷
     /// Single Localization, 3 Layersets
@@ -12322,7 +12322,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rSquareFill = SFSymbol(rawValue: "r.square.fill")
+    static var rSquareFill: SFSymbol { .init(rawValue: "r.square.fill") }
 
     /// 􀙱
     /// Single Localization, 3 Layersets
@@ -12336,7 +12336,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "wave3Left")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "wave3Left")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "wave3Left")
-    static let radiowavesLeft = SFSymbol(rawValue: "radiowaves.left")
+    static var radiowavesLeft: SFSymbol { .init(rawValue: "radiowaves.left") }
 
     /// 􀙲
     /// Single Localization, 3 Layersets
@@ -12350,7 +12350,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "wave3Right")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "wave3Right")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "wave3Right")
-    static let radiowavesRight = SFSymbol(rawValue: "radiowaves.right")
+    static var radiowavesRight: SFSymbol { .init(rawValue: "radiowaves.right") }
 
     /// 􀇯
     /// Single Localization, 3 Layersets
@@ -12359,21 +12359,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rays = SFSymbol(rawValue: "rays")
+    static var rays: SFSymbol { .init(rawValue: "rays") }
 
     /// 􀕼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let recordingtape = SFSymbol(rawValue: "recordingtape")
+    static var recordingtape: SFSymbol { .init(rawValue: "recordingtape") }
 
     /// 􀏃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangle = SFSymbol(rawValue: "rectangle")
+    static var rectangle: SFSymbol { .init(rawValue: "rectangle") }
 
     /// 􀇴
     /// Single Localization, Single Layerset
@@ -12385,7 +12385,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "rectangle3Group")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "rectangle3Group")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3Group")
-    static let rectangle3Offgrid = SFSymbol(rawValue: "rectangle.3.offgrid")
+    static var rectangle3Offgrid: SFSymbol { .init(rawValue: "rectangle.3.offgrid") }
 
     /// 􀚅
     /// Single Localization, Single Layerset
@@ -12397,7 +12397,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "rectangle3GroupFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "rectangle3GroupFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3GroupFill")
-    static let rectangle3OffgridFill = SFSymbol(rawValue: "rectangle.3.offgrid.fill")
+    static var rectangle3OffgridFill: SFSymbol { .init(rawValue: "rectangle.3.offgrid.fill") }
 
     /// 􀙮
     /// Single Localization, 2 Layersets
@@ -12405,7 +12405,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleAndArrowUpRightAndArrowDownLeft = SFSymbol(rawValue: "rectangle.and.arrow.up.right.and.arrow.down.left")
+    static var rectangleAndArrowUpRightAndArrowDownLeft: SFSymbol { .init(rawValue: "rectangle.and.arrow.up.right.and.arrow.down.left") }
 
     /// 􀙯
     /// Single Localization, 2 Layersets
@@ -12413,7 +12413,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleAndArrowUpRightAndArrowDownLeftSlash = SFSymbol(rawValue: "rectangle.and.arrow.up.right.and.arrow.down.left.slash")
+    static var rectangleAndArrowUpRightAndArrowDownLeftSlash: SFSymbol { .init(rawValue: "rectangle.and.arrow.up.right.and.arrow.down.left.slash") }
 
     /// 􀒖
     /// Single Localization, 2 Layersets
@@ -12421,7 +12421,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleAndPaperclip = SFSymbol(rawValue: "rectangle.and.paperclip")
+    static var rectangleAndPaperclip: SFSymbol { .init(rawValue: "rectangle.and.paperclip") }
 
     /// 􀏕
     /// Single Localization, 3 Layersets
@@ -12430,7 +12430,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleBadgeCheckmark = SFSymbol(rawValue: "rectangle.badge.checkmark")
+    static var rectangleBadgeCheckmark: SFSymbol { .init(rawValue: "rectangle.badge.checkmark") }
 
     /// 􀏗
     /// Single Localization, 3 Layersets
@@ -12439,7 +12439,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleBadgeXmark = SFSymbol(rawValue: "rectangle.badge.xmark")
+    static var rectangleBadgeXmark: SFSymbol { .init(rawValue: "rectangle.badge.xmark") }
 
     /// 􀐷
     /// Single Localization, 2 Layersets
@@ -12447,7 +12447,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleCompressVertical = SFSymbol(rawValue: "rectangle.compress.vertical")
+    static var rectangleCompressVertical: SFSymbol { .init(rawValue: "rectangle.compress.vertical") }
 
     /// 􀏞
     /// Single Localization, 2 Layersets
@@ -12460,7 +12460,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "dockRectangle")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "dockRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dockRectangle")
-    static let rectangleDock = SFSymbol(rawValue: "rectangle.dock")
+    static var rectangleDock: SFSymbol { .init(rawValue: "rectangle.dock") }
 
     /// 􀐸
     /// Single Localization, 2 Layersets
@@ -12468,14 +12468,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleExpandVertical = SFSymbol(rawValue: "rectangle.expand.vertical")
+    static var rectangleExpandVertical: SFSymbol { .init(rawValue: "rectangle.expand.vertical") }
 
     /// 􀏄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleFill = SFSymbol(rawValue: "rectangle.fill")
+    static var rectangleFill: SFSymbol { .init(rawValue: "rectangle.fill") }
 
     /// 􀏖
     /// Single Localization, 3 Layersets
@@ -12484,7 +12484,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillBadgeCheckmark = SFSymbol(rawValue: "rectangle.fill.badge.checkmark")
+    static var rectangleFillBadgeCheckmark: SFSymbol { .init(rawValue: "rectangle.fill.badge.checkmark") }
 
     /// 􀏘
     /// Single Localization, 3 Layersets
@@ -12493,7 +12493,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillBadgeXmark = SFSymbol(rawValue: "rectangle.fill.badge.xmark")
+    static var rectangleFillBadgeXmark: SFSymbol { .init(rawValue: "rectangle.fill.badge.xmark") }
 
     /// 􀑰
     /// Single Localization, 2 Layersets
@@ -12501,7 +12501,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillOnRectangleAngledFill = SFSymbol(rawValue: "rectangle.fill.on.rectangle.angled.fill")
+    static var rectangleFillOnRectangleAngledFill: SFSymbol { .init(rawValue: "rectangle.fill.on.rectangle.angled.fill") }
 
     /// 􀏨
     /// Single Localization, 2 Layersets
@@ -12509,49 +12509,49 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillOnRectangleFill = SFSymbol(rawValue: "rectangle.fill.on.rectangle.fill")
+    static var rectangleFillOnRectangleFill: SFSymbol { .init(rawValue: "rectangle.fill.on.rectangle.fill") }
 
     /// 􀓛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid1x2 = SFSymbol(rawValue: "rectangle.grid.1x2")
+    static var rectangleGrid1x2: SFSymbol { .init(rawValue: "rectangle.grid.1x2") }
 
     /// 􀚉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid1x2Fill = SFSymbol(rawValue: "rectangle.grid.1x2.fill")
+    static var rectangleGrid1x2Fill: SFSymbol { .init(rawValue: "rectangle.grid.1x2.fill") }
 
     /// 􀛦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid2x2 = SFSymbol(rawValue: "rectangle.grid.2x2")
+    static var rectangleGrid2x2: SFSymbol { .init(rawValue: "rectangle.grid.2x2") }
 
     /// 􀛧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid2x2Fill = SFSymbol(rawValue: "rectangle.grid.2x2.fill")
+    static var rectangleGrid2x2Fill: SFSymbol { .init(rawValue: "rectangle.grid.2x2.fill") }
 
     /// 􀇶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x2 = SFSymbol(rawValue: "rectangle.grid.3x2")
+    static var rectangleGrid3x2: SFSymbol { .init(rawValue: "rectangle.grid.3x2") }
 
     /// 􀚆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x2Fill = SFSymbol(rawValue: "rectangle.grid.3x2.fill")
+    static var rectangleGrid3x2Fill: SFSymbol { .init(rawValue: "rectangle.grid.3x2.fill") }
 
     /// 􀏧
     /// Single Localization, 3 Layersets
@@ -12560,7 +12560,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleOnRectangle = SFSymbol(rawValue: "rectangle.on.rectangle")
+    static var rectangleOnRectangle: SFSymbol { .init(rawValue: "rectangle.on.rectangle") }
 
     /// 􀑯
     /// Single Localization, 3 Layersets
@@ -12569,42 +12569,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleOnRectangleAngled = SFSymbol(rawValue: "rectangle.on.rectangle.angled")
+    static var rectangleOnRectangleAngled: SFSymbol { .init(rawValue: "rectangle.on.rectangle.angled") }
 
     /// 􀏟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit3x1 = SFSymbol(rawValue: "rectangle.split.3x1")
+    static var rectangleSplit3x1: SFSymbol { .init(rawValue: "rectangle.split.3x1") }
 
     /// 􀕸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit3x1Fill = SFSymbol(rawValue: "rectangle.split.3x1.fill")
+    static var rectangleSplit3x1Fill: SFSymbol { .init(rawValue: "rectangle.split.3x1.fill") }
 
     /// 􀏢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit3x3 = SFSymbol(rawValue: "rectangle.split.3x3")
+    static var rectangleSplit3x3: SFSymbol { .init(rawValue: "rectangle.split.3x3") }
 
     /// 􀘮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit3x3Fill = SFSymbol(rawValue: "rectangle.split.3x3.fill")
+    static var rectangleSplit3x3Fill: SFSymbol { .init(rawValue: "rectangle.split.3x3.fill") }
 
     /// 􀏭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleStack = SFSymbol(rawValue: "rectangle.stack")
+    static var rectangleStack: SFSymbol { .init(rawValue: "rectangle.stack") }
 
     /// 􀏳
     /// Single Localization, 3 Layersets
@@ -12613,7 +12613,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleStackBadgeMinus = SFSymbol(rawValue: "rectangle.stack.badge.minus")
+    static var rectangleStackBadgeMinus: SFSymbol { .init(rawValue: "rectangle.stack.badge.minus") }
 
     /// 􀏹
     /// Single Localization, 3 Layersets
@@ -12622,7 +12622,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleStackBadgePersonCrop = SFSymbol(rawValue: "rectangle.stack.badge.person.crop")
+    static var rectangleStackBadgePersonCrop: SFSymbol { .init(rawValue: "rectangle.stack.badge.person.crop") }
 
     /// 􀏱
     /// Single Localization, 3 Layersets
@@ -12631,14 +12631,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleStackBadgePlus = SFSymbol(rawValue: "rectangle.stack.badge.plus")
+    static var rectangleStackBadgePlus: SFSymbol { .init(rawValue: "rectangle.stack.badge.plus") }
 
     /// 􀏮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleStackFill = SFSymbol(rawValue: "rectangle.stack.fill")
+    static var rectangleStackFill: SFSymbol { .init(rawValue: "rectangle.stack.fill") }
 
     /// 􀏴
     /// Single Localization, 3 Layersets
@@ -12647,7 +12647,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleStackFillBadgeMinus = SFSymbol(rawValue: "rectangle.stack.fill.badge.minus")
+    static var rectangleStackFillBadgeMinus: SFSymbol { .init(rawValue: "rectangle.stack.fill.badge.minus") }
 
     /// 􀏺
     /// Single Localization, 3 Layersets
@@ -12661,7 +12661,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "rectangleStackBadgePersonCropFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "rectangleStackBadgePersonCropFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleStackBadgePersonCropFill")
-    static let rectangleStackFillBadgePersonCrop = SFSymbol(rawValue: "rectangle.stack.fill.badge.person.crop")
+    static var rectangleStackFillBadgePersonCrop: SFSymbol { .init(rawValue: "rectangle.stack.fill.badge.person.crop") }
 
     /// 􀏲
     /// Single Localization, 3 Layersets
@@ -12670,7 +12670,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleStackFillBadgePlus = SFSymbol(rawValue: "rectangle.stack.fill.badge.plus")
+    static var rectangleStackFillBadgePlus: SFSymbol { .init(rawValue: "rectangle.stack.fill.badge.plus") }
 
     /// 􀏻
     /// Single Localization, Single Layerset
@@ -12682,7 +12682,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "personCropRectangleStack")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "personCropRectangleStack")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropRectangleStack")
-    static let rectangleStackPersonCrop = SFSymbol(rawValue: "rectangle.stack.person.crop")
+    static var rectangleStackPersonCrop: SFSymbol { .init(rawValue: "rectangle.stack.person.crop") }
 
     /// 􀏼
     /// Single Localization, 3 Layersets
@@ -12696,14 +12696,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "personCropRectangleStackFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "personCropRectangleStackFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropRectangleStackFill")
-    static let rectangleStackPersonCropFill = SFSymbol(rawValue: "rectangle.stack.person.crop.fill")
+    static var rectangleStackPersonCropFill: SFSymbol { .init(rawValue: "rectangle.stack.person.crop.fill") }
 
     /// 􀊞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let `repeat` = SFSymbol(rawValue: "repeat")
+    static var `repeat`: SFSymbol { .init(rawValue: "repeat") }
 
     /// 􀊟
     /// 3 Localizations, 2 Layersets
@@ -12716,35 +12716,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let repeat1 = SymbolWith2Localizations<Ar_v3, Hi_v3>(rawValue: "repeat.1")
+    static var repeat1: SymbolWith2Localizations<Ar_v3, Hi_v3> { .init(rawValue: "repeat.1") }
 
     /// 􀅇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let `return` = SFSymbol(rawValue: "return")
+    static var `return`: SFSymbol { .init(rawValue: "return") }
 
     /// 􀋀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rhombus = SFSymbol(rawValue: "rhombus")
+    static var rhombus: SFSymbol { .init(rawValue: "rhombus") }
 
     /// 􀋁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rhombusFill = SFSymbol(rawValue: "rhombus.fill")
+    static var rhombusFill: SFSymbol { .init(rawValue: "rhombus.fill") }
 
     /// 􀛯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rosette = SFSymbol(rawValue: "rosette")
+    static var rosette: SFSymbol { .init(rawValue: "rosette") }
 
     /// 􀎮
     /// Single Localization, 2 Layersets
@@ -12752,7 +12752,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rotateLeft = SFSymbol(rawValue: "rotate.left")
+    static var rotateLeft: SFSymbol { .init(rawValue: "rotate.left") }
 
     /// 􀎯
     /// Single Localization, 2 Layersets
@@ -12760,7 +12760,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rotateLeftFill = SFSymbol(rawValue: "rotate.left.fill")
+    static var rotateLeftFill: SFSymbol { .init(rawValue: "rotate.left.fill") }
 
     /// 􀎰
     /// Single Localization, 2 Layersets
@@ -12768,7 +12768,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rotateRight = SFSymbol(rawValue: "rotate.right")
+    static var rotateRight: SFSymbol { .init(rawValue: "rotate.right") }
 
     /// 􀎱
     /// Single Localization, 2 Layersets
@@ -12776,7 +12776,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rotateRightFill = SFSymbol(rawValue: "rotate.right.fill")
+    static var rotateRightFill: SFSymbol { .init(rawValue: "rotate.right.fill") }
 
     /// 􀖥
     /// Single Localization, 2 Layersets
@@ -12784,7 +12784,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rublesignCircle = SFSymbol(rawValue: "rublesign.circle")
+    static var rublesignCircle: SFSymbol { .init(rawValue: "rublesign.circle") }
 
     /// 􀖦
     /// Single Localization, 3 Layersets
@@ -12793,7 +12793,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rublesignCircleFill = SFSymbol(rawValue: "rublesign.circle.fill")
+    static var rublesignCircleFill: SFSymbol { .init(rawValue: "rublesign.circle.fill") }
 
     /// 􀗥
     /// Single Localization, 2 Layersets
@@ -12801,7 +12801,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rublesignSquare = SFSymbol(rawValue: "rublesign.square")
+    static var rublesignSquare: SFSymbol { .init(rawValue: "rublesign.square") }
 
     /// 􀗦
     /// Single Localization, 3 Layersets
@@ -12810,7 +12810,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rublesignSquareFill = SFSymbol(rawValue: "rublesign.square.fill")
+    static var rublesignSquareFill: SFSymbol { .init(rawValue: "rublesign.square.fill") }
 
     /// 􀗏
     /// Single Localization, 2 Layersets
@@ -12818,7 +12818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rupeesignCircle = SFSymbol(rawValue: "rupeesign.circle")
+    static var rupeesignCircle: SFSymbol { .init(rawValue: "rupeesign.circle") }
 
     /// 􀗐
     /// Single Localization, 3 Layersets
@@ -12827,7 +12827,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rupeesignCircleFill = SFSymbol(rawValue: "rupeesign.circle.fill")
+    static var rupeesignCircleFill: SFSymbol { .init(rawValue: "rupeesign.circle.fill") }
 
     /// 􀘏
     /// Single Localization, 2 Layersets
@@ -12835,7 +12835,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rupeesignSquare = SFSymbol(rawValue: "rupeesign.square")
+    static var rupeesignSquare: SFSymbol { .init(rawValue: "rupeesign.square") }
 
     /// 􀘐
     /// Single Localization, 3 Layersets
@@ -12844,7 +12844,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rupeesignSquareFill = SFSymbol(rawValue: "rupeesign.square.fill")
+    static var rupeesignSquareFill: SFSymbol { .init(rawValue: "rupeesign.square.fill") }
 
     /// 􀀨
     /// Single Localization, 2 Layersets
@@ -12852,7 +12852,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sCircle = SFSymbol(rawValue: "s.circle")
+    static var sCircle: SFSymbol { .init(rawValue: "s.circle") }
 
     /// 􀀩
     /// Single Localization, 3 Layersets
@@ -12861,7 +12861,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sCircleFill = SFSymbol(rawValue: "s.circle.fill")
+    static var sCircleFill: SFSymbol { .init(rawValue: "s.circle.fill") }
 
     /// 􀂸
     /// Single Localization, 2 Layersets
@@ -12869,7 +12869,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sSquare = SFSymbol(rawValue: "s.square")
+    static var sSquare: SFSymbol { .init(rawValue: "s.square") }
 
     /// 􀂹
     /// Single Localization, 3 Layersets
@@ -12878,7 +12878,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sSquareFill = SFSymbol(rawValue: "s.square.fill")
+    static var sSquareFill: SFSymbol { .init(rawValue: "s.square.fill") }
 
     /// 􀎬
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -12888,7 +12888,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Safari browser.
-    static let safari = SFSymbol(rawValue: "safari")
+    static var safari: SFSymbol { .init(rawValue: "safari") }
 
     /// 􀎭
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -12899,35 +12899,35 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Safari browser.
-    static let safariFill = SFSymbol(rawValue: "safari.fill")
+    static var safariFill: SFSymbol { .init(rawValue: "safari.fill") }
 
     /// 􀉈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scissors = SFSymbol(rawValue: "scissors")
+    static var scissors: SFSymbol { .init(rawValue: "scissors") }
 
     /// 􀐩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scope = SFSymbol(rawValue: "scope")
+    static var scope: SFSymbol { .init(rawValue: "scope") }
 
     /// 􀓨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scribble = SFSymbol(rawValue: "scribble")
+    static var scribble: SFSymbol { .init(rawValue: "scribble") }
 
     /// 􀑠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let selectionPinInOut = SFSymbol(rawValue: "selection.pin.in.out")
+    static var selectionPinInOut: SFSymbol { .init(rawValue: "selection.pin.in.out") }
 
     /// 􀗋
     /// Single Localization, 2 Layersets
@@ -12940,7 +12940,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shekelsignCircle")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shekelsignCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shekelsignCircle")
-    static let sheqelsignCircle = SFSymbol(rawValue: "sheqelsign.circle")
+    static var sheqelsignCircle: SFSymbol { .init(rawValue: "sheqelsign.circle") }
 
     /// 􀗌
     /// Single Localization, 3 Layersets
@@ -12954,7 +12954,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shekelsignCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shekelsignCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shekelsignCircleFill")
-    static let sheqelsignCircleFill = SFSymbol(rawValue: "sheqelsign.circle.fill")
+    static var sheqelsignCircleFill: SFSymbol { .init(rawValue: "sheqelsign.circle.fill") }
 
     /// 􀘋
     /// Single Localization, 2 Layersets
@@ -12967,7 +12967,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shekelsignSquare")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shekelsignSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shekelsignSquare")
-    static let sheqelsignSquare = SFSymbol(rawValue: "sheqelsign.square")
+    static var sheqelsignSquare: SFSymbol { .init(rawValue: "sheqelsign.square") }
 
     /// 􀘌
     /// Single Localization, 3 Layersets
@@ -12981,21 +12981,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "shekelsignSquareFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "shekelsignSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shekelsignSquareFill")
-    static let sheqelsignSquareFill = SFSymbol(rawValue: "sheqelsign.square.fill")
+    static var sheqelsignSquareFill: SFSymbol { .init(rawValue: "sheqelsign.square.fill") }
 
     /// 􀙦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shield = SFSymbol(rawValue: "shield")
+    static var shield: SFSymbol { .init(rawValue: "shield") }
 
     /// 􀙧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shieldFill = SFSymbol(rawValue: "shield.fill")
+    static var shieldFill: SFSymbol { .init(rawValue: "shield.fill") }
 
     /// 􀙨
     /// Single Localization, Single Layerset
@@ -13007,7 +13007,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "shieldLefthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "shieldLefthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shieldLefthalfFilled")
-    static let shieldLefthalfFill = SFSymbol(rawValue: "shield.lefthalf.fill")
+    static var shieldLefthalfFill: SFSymbol { .init(rawValue: "shield.lefthalf.fill") }
 
     /// 􀞡
     /// Single Localization, 2 Layersets
@@ -13015,7 +13015,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shieldSlash = SFSymbol(rawValue: "shield.slash")
+    static var shieldSlash: SFSymbol { .init(rawValue: "shield.slash") }
 
     /// 􀞢
     /// Single Localization, 2 Layersets
@@ -13023,42 +13023,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shieldSlashFill = SFSymbol(rawValue: "shield.slash.fill")
+    static var shieldSlashFill: SFSymbol { .init(rawValue: "shield.slash.fill") }
 
     /// 􀆝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shift = SFSymbol(rawValue: "shift")
+    static var shift: SFSymbol { .init(rawValue: "shift") }
 
     /// 􀆞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shiftFill = SFSymbol(rawValue: "shift.fill")
+    static var shiftFill: SFSymbol { .init(rawValue: "shift.fill") }
 
     /// 􀊝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shuffle = SFSymbol(rawValue: "shuffle")
+    static var shuffle: SFSymbol { .init(rawValue: "shuffle") }
 
     /// 􀏚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarLeft = SFSymbol(rawValue: "sidebar.left")
+    static var sidebarLeft: SFSymbol { .init(rawValue: "sidebar.left") }
 
     /// 􀏛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarRight = SFSymbol(rawValue: "sidebar.right")
+    static var sidebarRight: SFSymbol { .init(rawValue: "sidebar.right") }
 
     /// 􀙤
     /// 6 Localizations, 3 Layersets
@@ -13075,14 +13075,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let signature = SymbolWith5Localizations<Ar_v2, He_v2, Ja_v3, Th_v3, Zh_v3>(rawValue: "signature")
+    static var signature: SymbolWith5Localizations<Ar_v2, He_v2, Ja_v3, Th_v3, Zh_v3> { .init(rawValue: "signature") }
 
     /// 􀍵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let skew = SFSymbol(rawValue: "skew")
+    static var skew: SFSymbol { .init(rawValue: "skew") }
 
     /// 􀕧
     /// Single Localization, 2 Layersets
@@ -13090,7 +13090,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let slashCircle = SFSymbol(rawValue: "slash.circle")
+    static var slashCircle: SFSymbol { .init(rawValue: "slash.circle") }
 
     /// 􀕨
     /// Single Localization, 3 Layersets
@@ -13099,14 +13099,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let slashCircleFill = SFSymbol(rawValue: "slash.circle.fill")
+    static var slashCircleFill: SFSymbol { .init(rawValue: "slash.circle.fill") }
 
     /// 􀌆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sliderHorizontal3 = SFSymbol(rawValue: "slider.horizontal.3")
+    static var sliderHorizontal3: SFSymbol { .init(rawValue: "slider.horizontal.3") }
 
     /// 􀐗
     /// Single Localization, 2 Layersets
@@ -13114,7 +13114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sliderHorizontalBelowRectangle = SFSymbol(rawValue: "slider.horizontal.below.rectangle")
+    static var sliderHorizontalBelowRectangle: SFSymbol { .init(rawValue: "slider.horizontal.below.rectangle") }
 
     /// 􀇱
     /// Single Localization, 3 Layersets
@@ -13123,7 +13123,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let slowmo = SFSymbol(rawValue: "slowmo")
+    static var slowmo: SFSymbol { .init(rawValue: "slowmo") }
 
     /// 􀕪
     /// Single Localization, 2 Layersets
@@ -13131,7 +13131,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let smallcircleCircle = SFSymbol(rawValue: "smallcircle.circle")
+    static var smallcircleCircle: SFSymbol { .init(rawValue: "smallcircle.circle") }
 
     /// 􀕫
     /// Single Localization, 3 Layersets
@@ -13140,7 +13140,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let smallcircleCircleFill = SFSymbol(rawValue: "smallcircle.circle.fill")
+    static var smallcircleCircleFill: SFSymbol { .init(rawValue: "smallcircle.circle.fill") }
 
     /// 􀍷
     /// Single Localization, 2 Layersets
@@ -13153,7 +13153,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "smallcircleFilledCircle")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "smallcircleFilledCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "smallcircleFilledCircle")
-    static let smallcircleFillCircle = SFSymbol(rawValue: "smallcircle.fill.circle")
+    static var smallcircleFillCircle: SFSymbol { .init(rawValue: "smallcircle.fill.circle") }
 
     /// 􀕩
     /// Single Localization, 3 Layersets
@@ -13167,7 +13167,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "smallcircleFilledCircleFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "smallcircleFilledCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "smallcircleFilledCircleFill")
-    static let smallcircleFillCircleFill = SFSymbol(rawValue: "smallcircle.fill.circle.fill")
+    static var smallcircleFillCircleFill: SFSymbol { .init(rawValue: "smallcircle.fill.circle.fill") }
 
     /// 􀎸
     /// Single Localization, 2 Layersets
@@ -13180,7 +13180,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "faceSmiling")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "faceSmiling")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "faceSmiling")
-    static let smiley = SFSymbol(rawValue: "smiley")
+    static var smiley: SFSymbol { .init(rawValue: "smiley") }
 
     /// 􀙌
     /// Single Localization, Single Layerset
@@ -13192,14 +13192,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "faceSmilingFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "faceSmilingFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "faceSmilingFill")
-    static let smileyFill = SFSymbol(rawValue: "smiley.fill")
+    static var smileyFill: SFSymbol { .init(rawValue: "smiley.fill") }
 
     /// 􀇢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let smoke = SFSymbol(rawValue: "smoke")
+    static var smoke: SFSymbol { .init(rawValue: "smoke") }
 
     /// 􀇣
     /// Single Localization, 2 Layersets
@@ -13207,7 +13207,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let smokeFill = SFSymbol(rawValue: "smoke.fill")
+    static var smokeFill: SFSymbol { .init(rawValue: "smoke.fill") }
 
     /// 􀇥
     /// Single Localization, 2 Layersets
@@ -13220,7 +13220,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "snowflake")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "snowflake")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "snowflake")
-    static let snow = SFSymbol(rawValue: "snow")
+    static var snow: SFSymbol { .init(rawValue: "snow") }
 
     /// 􀆿
     /// Single Localization, 2 Layersets
@@ -13228,14 +13228,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let sparkles = SFSymbol(rawValue: "sparkles")
+    static var sparkles: SFSymbol { .init(rawValue: "sparkles") }
 
     /// 􀊠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let speaker = SFSymbol(rawValue: "speaker")
+    static var speaker: SFSymbol { .init(rawValue: "speaker") }
 
     /// 􀊤
     /// Single Localization, 3 Layersets
@@ -13249,7 +13249,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave1")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave1")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave1")
-    static let speaker1 = SFSymbol(rawValue: "speaker.1")
+    static var speaker1: SFSymbol { .init(rawValue: "speaker.1") }
 
     /// 􀊥
     /// Single Localization, 3 Layersets
@@ -13263,7 +13263,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave1Fill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave1Fill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave1Fill")
-    static let speaker1Fill = SFSymbol(rawValue: "speaker.1.fill")
+    static var speaker1Fill: SFSymbol { .init(rawValue: "speaker.1.fill") }
 
     /// 􀊦
     /// Single Localization, 3 Layersets
@@ -13277,7 +13277,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave2")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave2")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave2")
-    static let speaker2 = SFSymbol(rawValue: "speaker.2")
+    static var speaker2: SFSymbol { .init(rawValue: "speaker.2") }
 
     /// 􀊧
     /// Single Localization, 3 Layersets
@@ -13291,7 +13291,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave2Fill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave2Fill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave2Fill")
-    static let speaker2Fill = SFSymbol(rawValue: "speaker.2.fill")
+    static var speaker2Fill: SFSymbol { .init(rawValue: "speaker.2.fill") }
 
     /// 􀊨
     /// Single Localization, 3 Layersets
@@ -13305,7 +13305,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave3")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave3")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave3")
-    static let speaker3 = SFSymbol(rawValue: "speaker.3")
+    static var speaker3: SFSymbol { .init(rawValue: "speaker.3") }
 
     /// 􀊩
     /// Single Localization, 3 Layersets
@@ -13319,14 +13319,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "speakerWave3Fill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "speakerWave3Fill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave3Fill")
-    static let speaker3Fill = SFSymbol(rawValue: "speaker.3.fill")
+    static var speaker3Fill: SFSymbol { .init(rawValue: "speaker.3.fill") }
 
     /// 􀊡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let speakerFill = SFSymbol(rawValue: "speaker.fill")
+    static var speakerFill: SFSymbol { .init(rawValue: "speaker.fill") }
 
     /// 􀊢
     /// 2 Localizations, 2 Layersets
@@ -13338,7 +13338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerSlash = SymbolWith1Localization<Rtl>(rawValue: "speaker.slash")
+    static var speakerSlash: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.slash") }
 
     /// 􀊣
     /// 2 Localizations, 2 Layersets
@@ -13350,7 +13350,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerSlashFill = SymbolWith1Localization<Rtl>(rawValue: "speaker.slash.fill")
+    static var speakerSlashFill: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.slash.fill") }
 
     /// 􀌊
     /// 2 Localizations, 2 Layersets
@@ -13362,7 +13362,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerZzz = SymbolWith1Localization<Rtl>(rawValue: "speaker.zzz")
+    static var speakerZzz: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.zzz") }
 
     /// 􀑞
     /// 2 Localizations, 2 Layersets
@@ -13374,7 +13374,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerZzzFill = SymbolWith1Localization<Rtl>(rawValue: "speaker.zzz.fill")
+    static var speakerZzzFill: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.zzz.fill") }
 
     /// 􀍾
     /// Single Localization, 2 Layersets
@@ -13387,28 +13387,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedle67percent")
     @available(watchOS, introduced: 6.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedle67percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedle67percent")
-    static let speedometer = SFSymbol(rawValue: "speedometer")
+    static var speedometer: SFSymbol { .init(rawValue: "speedometer") }
 
     /// 􀝐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sportscourt = SFSymbol(rawValue: "sportscourt")
+    static var sportscourt: SFSymbol { .init(rawValue: "sportscourt") }
 
     /// 􀝑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sportscourtFill = SFSymbol(rawValue: "sportscourt.fill")
+    static var sportscourtFill: SFSymbol { .init(rawValue: "sportscourt.fill") }
 
     /// 􀂒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let square = SFSymbol(rawValue: "square")
+    static var square: SFSymbol { .init(rawValue: "square") }
 
     /// 􀈄
     /// Single Localization, 2 Layersets
@@ -13416,7 +13416,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndArrowDown = SFSymbol(rawValue: "square.and.arrow.down")
+    static var squareAndArrowDown: SFSymbol { .init(rawValue: "square.and.arrow.down") }
 
     /// 􀈅
     /// Single Localization, 2 Layersets
@@ -13424,7 +13424,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let squareAndArrowDownFill = SFSymbol(rawValue: "square.and.arrow.down.fill")
+    static var squareAndArrowDownFill: SFSymbol { .init(rawValue: "square.and.arrow.down.fill") }
 
     /// 􀈈
     /// Single Localization, 2 Layersets
@@ -13432,7 +13432,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndArrowDownOnSquare = SFSymbol(rawValue: "square.and.arrow.down.on.square")
+    static var squareAndArrowDownOnSquare: SFSymbol { .init(rawValue: "square.and.arrow.down.on.square") }
 
     /// 􀈉
     /// Single Localization, 2 Layersets
@@ -13440,7 +13440,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let squareAndArrowDownOnSquareFill = SFSymbol(rawValue: "square.and.arrow.down.on.square.fill")
+    static var squareAndArrowDownOnSquareFill: SFSymbol { .init(rawValue: "square.and.arrow.down.on.square.fill") }
 
     /// 􀈂
     /// Single Localization, 2 Layersets
@@ -13448,7 +13448,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndArrowUp = SFSymbol(rawValue: "square.and.arrow.up")
+    static var squareAndArrowUp: SFSymbol { .init(rawValue: "square.and.arrow.up") }
 
     /// 􀈃
     /// Single Localization, 2 Layersets
@@ -13456,7 +13456,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let squareAndArrowUpFill = SFSymbol(rawValue: "square.and.arrow.up.fill")
+    static var squareAndArrowUpFill: SFSymbol { .init(rawValue: "square.and.arrow.up.fill") }
 
     /// 􀈆
     /// Single Localization, 2 Layersets
@@ -13464,7 +13464,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndArrowUpOnSquare = SFSymbol(rawValue: "square.and.arrow.up.on.square")
+    static var squareAndArrowUpOnSquare: SFSymbol { .init(rawValue: "square.and.arrow.up.on.square") }
 
     /// 􀈇
     /// Single Localization, 2 Layersets
@@ -13472,14 +13472,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let squareAndArrowUpOnSquareFill = SFSymbol(rawValue: "square.and.arrow.up.on.square.fill")
+    static var squareAndArrowUpOnSquareFill: SFSymbol { .init(rawValue: "square.and.arrow.up.on.square.fill") }
 
     /// 􀐑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareAndLineVerticalAndSquare = SFSymbol(rawValue: "square.and.line.vertical.and.square")
+    static var squareAndLineVerticalAndSquare: SFSymbol { .init(rawValue: "square.and.line.vertical.and.square") }
 
     /// 􀐔
     /// Single Localization, 2 Layersets
@@ -13492,7 +13492,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "squareAndLineVerticalAndSquareFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "squareAndLineVerticalAndSquareFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareAndLineVerticalAndSquareFilled")
-    static let squareAndLineVerticalAndSquareFill = SFSymbol(rawValue: "square.and.line.vertical.and.square.fill")
+    static var squareAndLineVerticalAndSquareFill: SFSymbol { .init(rawValue: "square.and.line.vertical.and.square.fill") }
 
     /// 􀈎
     /// Single Localization, 2 Layersets
@@ -13500,14 +13500,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndPencil = SFSymbol(rawValue: "square.and.pencil")
+    static var squareAndPencil: SFSymbol { .init(rawValue: "square.and.pencil") }
 
     /// 􀂓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareFill = SFSymbol(rawValue: "square.fill")
+    static var squareFill: SFSymbol { .init(rawValue: "square.fill") }
 
     /// 􀐓
     /// Single Localization, 2 Layersets
@@ -13520,7 +13520,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "squareFilledAndLineVerticalAndSquare")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "squareFilledAndLineVerticalAndSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareFilledAndLineVerticalAndSquare")
-    static let squareFillAndLineVerticalAndSquare = SFSymbol(rawValue: "square.fill.and.line.vertical.and.square")
+    static var squareFillAndLineVerticalAndSquare: SFSymbol { .init(rawValue: "square.fill.and.line.vertical.and.square") }
 
     /// 􀐒
     /// Single Localization, Single Layerset
@@ -13532,7 +13532,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "squareFillAndLineVerticalAndSquareFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "squareFillAndLineVerticalAndSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareFillAndLineVerticalAndSquareFill")
-    static let squareFillAndLineVerticalSquareFill = SFSymbol(rawValue: "square.fill.and.line.vertical.square.fill")
+    static var squareFillAndLineVerticalSquareFill: SFSymbol { .init(rawValue: "square.fill.and.line.vertical.square.fill") }
 
     /// 􀐊
     /// Single Localization, 2 Layersets
@@ -13540,7 +13540,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareFillOnCircleFill = SFSymbol(rawValue: "square.fill.on.circle.fill")
+    static var squareFillOnCircleFill: SFSymbol { .init(rawValue: "square.fill.on.circle.fill") }
 
     /// 􀐆
     /// Single Localization, 2 Layersets
@@ -13548,42 +13548,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareFillOnSquareFill = SFSymbol(rawValue: "square.fill.on.square.fill")
+    static var squareFillOnSquareFill: SFSymbol { .init(rawValue: "square.fill.on.square.fill") }
 
     /// 􀇷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid2x2 = SFSymbol(rawValue: "square.grid.2x2")
+    static var squareGrid2x2: SFSymbol { .init(rawValue: "square.grid.2x2") }
 
     /// 􀚈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid2x2Fill = SFSymbol(rawValue: "square.grid.2x2.fill")
+    static var squareGrid2x2Fill: SFSymbol { .init(rawValue: "square.grid.2x2.fill") }
 
     /// 􀇵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x2 = SFSymbol(rawValue: "square.grid.3x2")
+    static var squareGrid3x2: SFSymbol { .init(rawValue: "square.grid.3x2") }
 
     /// 􀚇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x2Fill = SFSymbol(rawValue: "square.grid.3x2.fill")
+    static var squareGrid3x2Fill: SFSymbol { .init(rawValue: "square.grid.3x2.fill") }
 
     /// 􀓚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid4x3Fill = SFSymbol(rawValue: "square.grid.4x3.fill")
+    static var squareGrid4x3Fill: SFSymbol { .init(rawValue: "square.grid.4x3.fill") }
 
     /// 􀚓
     /// Single Localization, Single Layerset
@@ -13595,7 +13595,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "squareLefthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "squareLefthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareLefthalfFilled")
-    static let squareLefthalfFill = SFSymbol(rawValue: "square.lefthalf.fill")
+    static var squareLefthalfFill: SFSymbol { .init(rawValue: "square.lefthalf.fill") }
 
     /// 􀐉
     /// Single Localization, 3 Layersets
@@ -13604,7 +13604,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareOnCircle = SFSymbol(rawValue: "square.on.circle")
+    static var squareOnCircle: SFSymbol { .init(rawValue: "square.on.circle") }
 
     /// 􀐅
     /// Single Localization, 3 Layersets
@@ -13613,7 +13613,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareOnSquare = SFSymbol(rawValue: "square.on.square")
+    static var squareOnSquare: SFSymbol { .init(rawValue: "square.on.square") }
 
     /// 􀚔
     /// Single Localization, Single Layerset
@@ -13625,56 +13625,56 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "squareRighthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "squareRighthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareRighthalfFilled")
-    static let squareRighthalfFill = SFSymbol(rawValue: "square.righthalf.fill")
+    static var squareRighthalfFill: SFSymbol { .init(rawValue: "square.righthalf.fill") }
 
     /// 􀕰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit1x2 = SFSymbol(rawValue: "square.split.1x2")
+    static var squareSplit1x2: SFSymbol { .init(rawValue: "square.split.1x2") }
 
     /// 􀕱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit1x2Fill = SFSymbol(rawValue: "square.split.1x2.fill")
+    static var squareSplit1x2Fill: SFSymbol { .init(rawValue: "square.split.1x2.fill") }
 
     /// 􀏠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit2x1 = SFSymbol(rawValue: "square.split.2x1")
+    static var squareSplit2x1: SFSymbol { .init(rawValue: "square.split.2x1") }
 
     /// 􀘜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit2x1Fill = SFSymbol(rawValue: "square.split.2x1.fill")
+    static var squareSplit2x1Fill: SFSymbol { .init(rawValue: "square.split.2x1.fill") }
 
     /// 􀕮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit2x2 = SFSymbol(rawValue: "square.split.2x2")
+    static var squareSplit2x2: SFSymbol { .init(rawValue: "square.split.2x2") }
 
     /// 􀕯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplit2x2Fill = SFSymbol(rawValue: "square.split.2x2.fill")
+    static var squareSplit2x2Fill: SFSymbol { .init(rawValue: "square.split.2x2.fill") }
 
     /// 􀐋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareStack = SFSymbol(rawValue: "square.stack")
+    static var squareStack: SFSymbol { .init(rawValue: "square.stack") }
 
     /// 􀐠
     /// Single Localization, 3 Layersets
@@ -13688,7 +13688,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "squareStack3dForwardDottedline")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "squareStack3dForwardDottedline")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareStack3dForwardDottedline")
-    static let squareStack3dDownDottedline = SFSymbol(rawValue: "square.stack.3d.down.dottedline")
+    static var squareStack3dDownDottedline: SFSymbol { .init(rawValue: "square.stack.3d.down.dottedline") }
 
     /// 􀐜
     /// Single Localization, 3 Layersets
@@ -13697,7 +13697,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dDownRight = SFSymbol(rawValue: "square.stack.3d.down.right")
+    static var squareStack3dDownRight: SFSymbol { .init(rawValue: "square.stack.3d.down.right") }
 
     /// 􀐝
     /// Single Localization, 3 Layersets
@@ -13706,7 +13706,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dDownRightFill = SFSymbol(rawValue: "square.stack.3d.down.right.fill")
+    static var squareStack3dDownRightFill: SFSymbol { .init(rawValue: "square.stack.3d.down.right.fill") }
 
     /// 􀐞
     /// Single Localization, 3 Layersets
@@ -13715,7 +13715,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dUp = SFSymbol(rawValue: "square.stack.3d.up")
+    static var squareStack3dUp: SFSymbol { .init(rawValue: "square.stack.3d.up") }
 
     /// 􀐟
     /// Single Localization, 3 Layersets
@@ -13724,7 +13724,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dUpFill = SFSymbol(rawValue: "square.stack.3d.up.fill")
+    static var squareStack3dUpFill: SFSymbol { .init(rawValue: "square.stack.3d.up.fill") }
 
     /// 􀙒
     /// Single Localization, 2 Layersets
@@ -13732,7 +13732,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareStack3dUpSlash = SFSymbol(rawValue: "square.stack.3d.up.slash")
+    static var squareStack3dUpSlash: SFSymbol { .init(rawValue: "square.stack.3d.up.slash") }
 
     /// 􀙓
     /// Single Localization, 2 Layersets
@@ -13740,14 +13740,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareStack3dUpSlashFill = SFSymbol(rawValue: "square.stack.3d.up.slash.fill")
+    static var squareStack3dUpSlashFill: SFSymbol { .init(rawValue: "square.stack.3d.up.slash.fill") }
 
     /// 􀐌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareStackFill = SFSymbol(rawValue: "square.stack.fill")
+    static var squareStackFill: SFSymbol { .init(rawValue: "square.stack.fill") }
 
     /// 􀏡
     /// Single Localization, 2 Layersets
@@ -13755,7 +13755,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squaresBelowRectangle = SFSymbol(rawValue: "squares.below.rectangle")
+    static var squaresBelowRectangle: SFSymbol { .init(rawValue: "squares.below.rectangle") }
 
     /// 􀋂
     /// Single Localization, 2 Layersets
@@ -13763,7 +13763,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let star = SFSymbol(rawValue: "star")
+    static var star: SFSymbol { .init(rawValue: "star") }
 
     /// 􀋅
     /// Single Localization, 3 Layersets
@@ -13772,7 +13772,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let starCircle = SFSymbol(rawValue: "star.circle")
+    static var starCircle: SFSymbol { .init(rawValue: "star.circle") }
 
     /// 􀋆
     /// Single Localization, 3 Layersets
@@ -13781,7 +13781,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let starCircleFill = SFSymbol(rawValue: "star.circle.fill")
+    static var starCircleFill: SFSymbol { .init(rawValue: "star.circle.fill") }
 
     /// 􀋃
     /// Single Localization, 2 Layersets
@@ -13789,7 +13789,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let starFill = SFSymbol(rawValue: "star.fill")
+    static var starFill: SFSymbol { .init(rawValue: "star.fill") }
 
     /// 􀋄
     /// Single Localization, Single Layerset
@@ -13801,7 +13801,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "starLeadinghalfFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "starLeadinghalfFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "starLeadinghalfFill")
-    static let starLefthalfFill = SFSymbol(rawValue: "star.lefthalf.fill")
+    static var starLefthalfFill: SFSymbol { .init(rawValue: "star.lefthalf.fill") }
 
     /// 􀋇
     /// Single Localization, 3 Layersets
@@ -13810,7 +13810,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let starSlash = SFSymbol(rawValue: "star.slash")
+    static var starSlash: SFSymbol { .init(rawValue: "star.slash") }
 
     /// 􀋈
     /// Single Localization, 3 Layersets
@@ -13819,21 +13819,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let starSlashFill = SFSymbol(rawValue: "star.slash.fill")
+    static var starSlashFill: SFSymbol { .init(rawValue: "star.slash.fill") }
 
     /// 􀑆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let staroflife = SFSymbol(rawValue: "staroflife")
+    static var staroflife: SFSymbol { .init(rawValue: "staroflife") }
 
     /// 􀑇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let staroflifeFill = SFSymbol(rawValue: "staroflife.fill")
+    static var staroflifeFill: SFSymbol { .init(rawValue: "staroflife.fill") }
 
     /// 􀖝
     /// Single Localization, 2 Layersets
@@ -13841,7 +13841,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sterlingsignCircle = SFSymbol(rawValue: "sterlingsign.circle")
+    static var sterlingsignCircle: SFSymbol { .init(rawValue: "sterlingsign.circle") }
 
     /// 􀖞
     /// Single Localization, 3 Layersets
@@ -13850,7 +13850,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sterlingsignCircleFill = SFSymbol(rawValue: "sterlingsign.circle.fill")
+    static var sterlingsignCircleFill: SFSymbol { .init(rawValue: "sterlingsign.circle.fill") }
 
     /// 􀗝
     /// Single Localization, 2 Layersets
@@ -13858,7 +13858,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sterlingsignSquare = SFSymbol(rawValue: "sterlingsign.square")
+    static var sterlingsignSquare: SFSymbol { .init(rawValue: "sterlingsign.square") }
 
     /// 􀗞
     /// Single Localization, 3 Layersets
@@ -13867,14 +13867,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sterlingsignSquareFill = SFSymbol(rawValue: "sterlingsign.square.fill")
+    static var sterlingsignSquareFill: SFSymbol { .init(rawValue: "sterlingsign.square.fill") }
 
     /// 􀛶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stop = SFSymbol(rawValue: "stop")
+    static var stop: SFSymbol { .init(rawValue: "stop") }
 
     /// 􀜪
     /// Single Localization, 2 Layersets
@@ -13882,7 +13882,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let stopCircle = SFSymbol(rawValue: "stop.circle")
+    static var stopCircle: SFSymbol { .init(rawValue: "stop.circle") }
 
     /// 􀜫
     /// Single Localization, 3 Layersets
@@ -13891,14 +13891,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let stopCircleFill = SFSymbol(rawValue: "stop.circle.fill")
+    static var stopCircleFill: SFSymbol { .init(rawValue: "stop.circle.fill") }
 
     /// 􀛷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stopFill = SFSymbol(rawValue: "stop.fill")
+    static var stopFill: SFSymbol { .init(rawValue: "stop.fill") }
 
     /// 􀐯
     /// Single Localization, 3 Layersets
@@ -13907,7 +13907,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let stopwatch = SFSymbol(rawValue: "stopwatch")
+    static var stopwatch: SFSymbol { .init(rawValue: "stopwatch") }
 
     /// 􀐰
     /// Single Localization, 3 Layersets
@@ -13916,7 +13916,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     /// - Multicolor (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let stopwatchFill = SFSymbol(rawValue: "stopwatch.fill")
+    static var stopwatchFill: SFSymbol { .init(rawValue: "stopwatch.fill") }
 
     /// 􀅖
     /// Single Localization, 3 Layersets
@@ -13925,7 +13925,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let strikethrough = SFSymbol(rawValue: "strikethrough")
+    static var strikethrough: SFSymbol { .init(rawValue: "strikethrough") }
 
     /// 􀒃
     /// Single Localization, 2 Layersets
@@ -13933,7 +13933,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitClub = SFSymbol(rawValue: "suit.club")
+    static var suitClub: SFSymbol { .init(rawValue: "suit.club") }
 
     /// 􀊽
     /// Single Localization, 2 Layersets
@@ -13941,7 +13941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitClubFill = SFSymbol(rawValue: "suit.club.fill")
+    static var suitClubFill: SFSymbol { .init(rawValue: "suit.club.fill") }
 
     /// 􀒄
     /// Single Localization, 2 Layersets
@@ -13949,7 +13949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitDiamond = SFSymbol(rawValue: "suit.diamond")
+    static var suitDiamond: SFSymbol { .init(rawValue: "suit.diamond") }
 
     /// 􀊿
     /// Single Localization, 2 Layersets
@@ -13957,7 +13957,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitDiamondFill = SFSymbol(rawValue: "suit.diamond.fill")
+    static var suitDiamondFill: SFSymbol { .init(rawValue: "suit.diamond.fill") }
 
     /// 􀒂
     /// Single Localization, 2 Layersets
@@ -13965,7 +13965,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitHeart = SFSymbol(rawValue: "suit.heart")
+    static var suitHeart: SFSymbol { .init(rawValue: "suit.heart") }
 
     /// 􀊼
     /// Single Localization, 2 Layersets
@@ -13973,7 +13973,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitHeartFill = SFSymbol(rawValue: "suit.heart.fill")
+    static var suitHeartFill: SFSymbol { .init(rawValue: "suit.heart.fill") }
 
     /// 􀒅
     /// Single Localization, 2 Layersets
@@ -13981,7 +13981,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitSpade = SFSymbol(rawValue: "suit.spade")
+    static var suitSpade: SFSymbol { .init(rawValue: "suit.spade") }
 
     /// 􀊾
     /// Single Localization, 2 Layersets
@@ -13989,7 +13989,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let suitSpadeFill = SFSymbol(rawValue: "suit.spade.fill")
+    static var suitSpadeFill: SFSymbol { .init(rawValue: "suit.spade.fill") }
 
     /// 􀘽
     /// 2 Localizations, Single Layerset
@@ -14000,7 +14000,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let sum = SymbolWith1Localization<Ar_v2>(rawValue: "sum")
+    static var sum: SymbolWith1Localization<Ar_v2> { .init(rawValue: "sum") }
 
     /// 􀆵
     /// Single Localization, 3 Layersets
@@ -14009,7 +14009,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sunDust = SFSymbol(rawValue: "sun.dust")
+    static var sunDust: SFSymbol { .init(rawValue: "sun.dust") }
 
     /// 􀆶
     /// Single Localization, 3 Layersets
@@ -14018,7 +14018,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sunDustFill = SFSymbol(rawValue: "sun.dust.fill")
+    static var sunDustFill: SFSymbol { .init(rawValue: "sun.dust.fill") }
 
     /// 􀆷
     /// Single Localization, 3 Layersets
@@ -14027,7 +14027,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sunHaze = SFSymbol(rawValue: "sun.haze")
+    static var sunHaze: SFSymbol { .init(rawValue: "sun.haze") }
 
     /// 􀆸
     /// Single Localization, 3 Layersets
@@ -14036,14 +14036,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sunHazeFill = SFSymbol(rawValue: "sun.haze.fill")
+    static var sunHazeFill: SFSymbol { .init(rawValue: "sun.haze.fill") }
 
     /// 􀆭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunMax = SFSymbol(rawValue: "sun.max")
+    static var sunMax: SFSymbol { .init(rawValue: "sun.max") }
 
     /// 􀆮
     /// Single Localization, 2 Layersets
@@ -14051,21 +14051,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let sunMaxFill = SFSymbol(rawValue: "sun.max.fill")
+    static var sunMaxFill: SFSymbol { .init(rawValue: "sun.max.fill") }
 
     /// 􀆫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunMin = SFSymbol(rawValue: "sun.min")
+    static var sunMin: SFSymbol { .init(rawValue: "sun.min") }
 
     /// 􀆬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunMinFill = SFSymbol(rawValue: "sun.min.fill")
+    static var sunMinFill: SFSymbol { .init(rawValue: "sun.min.fill") }
 
     /// 􀆱
     /// Single Localization, 3 Layersets
@@ -14074,7 +14074,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sunrise = SFSymbol(rawValue: "sunrise")
+    static var sunrise: SFSymbol { .init(rawValue: "sunrise") }
 
     /// 􀆲
     /// Single Localization, 3 Layersets
@@ -14083,7 +14083,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sunriseFill = SFSymbol(rawValue: "sunrise.fill")
+    static var sunriseFill: SFSymbol { .init(rawValue: "sunrise.fill") }
 
     /// 􀆳
     /// Single Localization, 3 Layersets
@@ -14092,7 +14092,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sunset = SFSymbol(rawValue: "sunset")
+    static var sunset: SFSymbol { .init(rawValue: "sunset") }
 
     /// 􀆴
     /// Single Localization, 3 Layersets
@@ -14101,7 +14101,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sunsetFill = SFSymbol(rawValue: "sunset.fill")
+    static var sunsetFill: SFSymbol { .init(rawValue: "sunset.fill") }
 
     /// 􀌰
     /// 3 Localizations, 2 Layersets
@@ -14119,7 +14119,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.5, renamed: "characterBubble")
     @available(watchOS, introduced: 6.0, deprecated: 7.4, renamed: "characterBubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterBubble")
-    static let tBubble = SymbolWith2Localizations<Ar_v2, He_v2>(rawValue: "t.bubble")
+    static var tBubble: SymbolWith2Localizations<Ar_v2, He_v2> { .init(rawValue: "t.bubble") }
 
     /// 􀌱
     /// 3 Localizations, 3 Layersets
@@ -14138,7 +14138,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.5, renamed: "characterBubbleFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.4, renamed: "characterBubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterBubbleFill")
-    static let tBubbleFill = SymbolWith2Localizations<Ar_v2, He_v2>(rawValue: "t.bubble.fill")
+    static var tBubbleFill: SymbolWith2Localizations<Ar_v2, He_v2> { .init(rawValue: "t.bubble.fill") }
 
     /// 􀀪
     /// Single Localization, 2 Layersets
@@ -14146,7 +14146,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tCircle = SFSymbol(rawValue: "t.circle")
+    static var tCircle: SFSymbol { .init(rawValue: "t.circle") }
 
     /// 􀀫
     /// Single Localization, 3 Layersets
@@ -14155,7 +14155,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tCircleFill = SFSymbol(rawValue: "t.circle.fill")
+    static var tCircleFill: SFSymbol { .init(rawValue: "t.circle.fill") }
 
     /// 􀂺
     /// Single Localization, 2 Layersets
@@ -14163,7 +14163,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tSquare = SFSymbol(rawValue: "t.square")
+    static var tSquare: SFSymbol { .init(rawValue: "t.square") }
 
     /// 􀂻
     /// Single Localization, 3 Layersets
@@ -14172,7 +14172,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tSquareFill = SFSymbol(rawValue: "t.square.fill")
+    static var tSquareFill: SFSymbol { .init(rawValue: "t.square.fill") }
 
     /// 􀏣
     /// Single Localization, Single Layerset
@@ -14184,7 +14184,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "tablecells")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "tablecells")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tablecells")
-    static let table = SFSymbol(rawValue: "table")
+    static var table: SFSymbol { .init(rawValue: "table") }
 
     /// 􀏥
     /// Single Localization, 3 Layersets
@@ -14198,7 +14198,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "tablecellsBadgeEllipsis")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "tablecellsBadgeEllipsis")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tablecellsBadgeEllipsis")
-    static let tableBadgeMore = SFSymbol(rawValue: "table.badge.more")
+    static var tableBadgeMore: SFSymbol { .init(rawValue: "table.badge.more") }
 
     /// 􀏦
     /// Single Localization, Single Layerset
@@ -14210,7 +14210,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "tablecellsBadgeEllipsisFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "tablecellsBadgeEllipsisFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tablecellsBadgeEllipsisFill")
-    static let tableBadgeMoreFill = SFSymbol(rawValue: "table.badge.more.fill")
+    static var tableBadgeMoreFill: SFSymbol { .init(rawValue: "table.badge.more.fill") }
 
     /// 􀏤
     /// Single Localization, Single Layerset
@@ -14222,14 +14222,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "tablecellsFill")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "tablecellsFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tablecellsFill")
-    static let tableFill = SFSymbol(rawValue: "table.fill")
+    static var tableFill: SFSymbol { .init(rawValue: "table.fill") }
 
     /// 􀋡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tag = SFSymbol(rawValue: "tag")
+    static var tag: SFSymbol { .init(rawValue: "tag") }
 
     /// 􀋣
     /// Single Localization, 2 Layersets
@@ -14237,7 +14237,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tagCircle = SFSymbol(rawValue: "tag.circle")
+    static var tagCircle: SFSymbol { .init(rawValue: "tag.circle") }
 
     /// 􀋤
     /// Single Localization, 3 Layersets
@@ -14246,14 +14246,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tagCircleFill = SFSymbol(rawValue: "tag.circle.fill")
+    static var tagCircleFill: SFSymbol { .init(rawValue: "tag.circle.fill") }
 
     /// 􀋢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tagFill = SFSymbol(rawValue: "tag.fill")
+    static var tagFill: SFSymbol { .init(rawValue: "tag.fill") }
 
     /// 􀍈
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -14263,7 +14263,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletype = SFSymbol(rawValue: "teletype")
+    static var teletype: SFSymbol { .init(rawValue: "teletype") }
 
     /// 􀙰
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -14273,7 +14273,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletypeAnswer = SFSymbol(rawValue: "teletype.answer")
+    static var teletypeAnswer: SFSymbol { .init(rawValue: "teletype.answer") }
 
     /// 􀖭
     /// Single Localization, 2 Layersets
@@ -14281,7 +14281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tengesignCircle = SFSymbol(rawValue: "tengesign.circle")
+    static var tengesignCircle: SFSymbol { .init(rawValue: "tengesign.circle") }
 
     /// 􀖮
     /// Single Localization, 3 Layersets
@@ -14290,7 +14290,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tengesignCircleFill = SFSymbol(rawValue: "tengesign.circle.fill")
+    static var tengesignCircleFill: SFSymbol { .init(rawValue: "tengesign.circle.fill") }
 
     /// 􀗭
     /// Single Localization, 2 Layersets
@@ -14298,7 +14298,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tengesignSquare = SFSymbol(rawValue: "tengesign.square")
+    static var tengesignSquare: SFSymbol { .init(rawValue: "tengesign.square") }
 
     /// 􀗮
     /// Single Localization, 3 Layersets
@@ -14307,28 +14307,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tengesignSquareFill = SFSymbol(rawValue: "tengesign.square.fill")
+    static var tengesignSquareFill: SFSymbol { .init(rawValue: "tengesign.square.fill") }
 
     /// 􀌁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textAligncenter = SFSymbol(rawValue: "text.aligncenter")
+    static var textAligncenter: SFSymbol { .init(rawValue: "text.aligncenter") }
 
     /// 􀌀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textAlignleft = SFSymbol(rawValue: "text.alignleft")
+    static var textAlignleft: SFSymbol { .init(rawValue: "text.alignleft") }
 
     /// 􀌂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textAlignright = SFSymbol(rawValue: "text.alignright")
+    static var textAlignright: SFSymbol { .init(rawValue: "text.alignright") }
 
     /// 􀋾
     /// Single Localization, 2 Layersets
@@ -14336,7 +14336,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textAppend = SFSymbol(rawValue: "text.append")
+    static var textAppend: SFSymbol { .init(rawValue: "text.append") }
 
     /// 􀋺
     /// 2 Localizations, 3 Layersets
@@ -14349,7 +14349,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBadgeCheckmark = SymbolWith1Localization<Rtl_v2>(rawValue: "text.badge.checkmark")
+    static var textBadgeCheckmark: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "text.badge.checkmark") }
 
     /// 􀋹
     /// Single Localization, 3 Layersets
@@ -14358,7 +14358,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBadgeMinus = SFSymbol(rawValue: "text.badge.minus")
+    static var textBadgeMinus: SFSymbol { .init(rawValue: "text.badge.minus") }
 
     /// 􀋸
     /// Single Localization, 3 Layersets
@@ -14367,7 +14367,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBadgePlus = SFSymbol(rawValue: "text.badge.plus")
+    static var textBadgePlus: SFSymbol { .init(rawValue: "text.badge.plus") }
 
     /// 􀋼
     /// Single Localization, 3 Layersets
@@ -14376,7 +14376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBadgeStar = SFSymbol(rawValue: "text.badge.star")
+    static var textBadgeStar: SFSymbol { .init(rawValue: "text.badge.star") }
 
     /// 􀋻
     /// Single Localization, 3 Layersets
@@ -14385,7 +14385,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBadgeXmark = SFSymbol(rawValue: "text.badge.xmark")
+    static var textBadgeXmark: SFSymbol { .init(rawValue: "text.badge.xmark") }
 
     /// 􀌲
     /// 2 Localizations, 2 Layersets
@@ -14397,7 +14397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textBubble = SymbolWith1Localization<Rtl_v2>(rawValue: "text.bubble")
+    static var textBubble: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "text.bubble") }
 
     /// 􀌳
     /// 2 Localizations, 3 Layersets
@@ -14410,7 +14410,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let textBubbleFill = SymbolWith1Localization<Rtl_v2>(rawValue: "text.bubble.fill")
+    static var textBubbleFill: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "text.bubble.fill") }
 
     /// 􀅫
     /// 8 Localizations, 2 Layersets
@@ -14433,7 +14433,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.5, renamed: "characterCursorIbeam")
     @available(watchOS, introduced: 6.0, deprecated: 7.4, renamed: "characterCursorIbeam")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterCursorIbeam")
-    static let textCursor = SymbolWith7Localizations<Ar_v2, He_v2, Hi_v2, Ja_v2, Ko_v2, Th_v2, Zh_v2>(rawValue: "text.cursor")
+    static var textCursor: SymbolWith7Localizations<Ar_v2, He_v2, Hi_v2, Ja_v2, Ko_v2, Th_v2, Zh_v2> { .init(rawValue: "text.cursor") }
 
     /// 􀋽
     /// Single Localization, 2 Layersets
@@ -14441,14 +14441,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textInsert = SFSymbol(rawValue: "text.insert")
+    static var textInsert: SFSymbol { .init(rawValue: "text.insert") }
 
     /// 􀌃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textJustify = SFSymbol(rawValue: "text.justify")
+    static var textJustify: SFSymbol { .init(rawValue: "text.justify") }
 
     /// 􀌄
     /// Single Localization, Single Layerset
@@ -14460,7 +14460,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.1, renamed: "textJustifyLeft")
     @available(watchOS, introduced: 6.0, deprecated: 8.1, renamed: "textJustifyLeft")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "textJustifyLeft")
-    static let textJustifyleft = SFSymbol(rawValue: "text.justifyleft")
+    static var textJustifyleft: SFSymbol { .init(rawValue: "text.justifyleft") }
 
     /// 􀌅
     /// Single Localization, Single Layerset
@@ -14472,7 +14472,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.1, renamed: "textJustifyRight")
     @available(watchOS, introduced: 6.0, deprecated: 8.1, renamed: "textJustifyRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "textJustifyRight")
-    static let textJustifyright = SFSymbol(rawValue: "text.justifyright")
+    static var textJustifyright: SFSymbol { .init(rawValue: "text.justifyright") }
 
     /// 􀋿
     /// 2 Localizations, 2 Layersets
@@ -14484,7 +14484,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textQuote = SymbolWith1Localization<Rtl_v2>(rawValue: "text.quote")
+    static var textQuote: SymbolWith1Localization<Rtl_v2> { .init(rawValue: "text.quote") }
 
     /// 􀅶
     /// 8 Localizations, 2 Layersets
@@ -14507,7 +14507,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.5, renamed: "characterTextbox")
     @available(watchOS, introduced: 6.0, deprecated: 7.4, renamed: "characterTextbox")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterTextbox")
-    static let textbox = SymbolWith7Localizations<Ar_v2, He_v2, Hi_v2, Ja_v2, Ko_v2, Th_v2, Zh_v2>(rawValue: "textbox")
+    static var textbox: SymbolWith7Localizations<Ar_v2, He_v2, Hi_v2, Ja_v2, Ko_v2, Th_v2, Zh_v2> { .init(rawValue: "textbox") }
 
     /// 􀅒
     /// 21 Localizations, Single Layerset
@@ -14537,7 +14537,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformat = SymbolWith20Localizations<Ar_v6, Bn_v6_3, El_v6, Gu_v6_3, He_v6, Hi_v6, Ja_v6, Kn_v6_3, Ko_v6, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v6, Zh_v6>(rawValue: "textformat")
+    static var textformat: SymbolWith20Localizations<Ar_v6, Bn_v6_3, El_v6, Gu_v6_3, He_v6, Hi_v6, Ja_v6, Kn_v6_3, Ko_v6, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v6, Zh_v6> { .init(rawValue: "textformat") }
 
     /// 􀅱
     /// 3 Localizations, Single Layerset
@@ -14554,7 +14554,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "numbers")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "numbers")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "numbers")
-    static let textformat123 = SymbolWith2Localizations<Ar_v2, Hi_v3>(rawValue: "textformat.123")
+    static var textformat123: SymbolWith2Localizations<Ar_v2, Hi_v3> { .init(rawValue: "textformat.123") }
 
     /// 􀅯
     /// Single Localization, Single Layerset
@@ -14566,7 +14566,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textformatCharacters")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textformatCharacters")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textformatCharacters")
-    static let textformatAbc = SFSymbol(rawValue: "textformat.abc")
+    static var textformatAbc: SFSymbol { .init(rawValue: "textformat.abc") }
 
     /// 􀅰
     /// Single Localization, 3 Layersets
@@ -14580,7 +14580,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "textformatCharactersDottedunderline")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "textformatCharactersDottedunderline")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textformatCharactersDottedunderline")
-    static let textformatAbcDottedunderline = SFSymbol(rawValue: "textformat.abc.dottedunderline")
+    static var textformatAbcDottedunderline: SFSymbol { .init(rawValue: "textformat.abc.dottedunderline") }
 
     /// 􀅑
     /// 21 Localizations, Single Layerset
@@ -14610,7 +14610,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatAlt = SymbolWith20Localizations<Ar_v6, Bn_v6_3, El_v6, Gu_v6_3, He_v6, Hi_v6, Ja_v6, Kn_v6_3, Ko_v6, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v6, Zh_v6>(rawValue: "textformat.alt")
+    static var textformatAlt: SymbolWith20Localizations<Ar_v6, Bn_v6_3, El_v6, Gu_v6_3, He_v6, Hi_v6, Ja_v6, Kn_v6_3, Ko_v6, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v6, Zh_v6> { .init(rawValue: "textformat.alt") }
 
     /// 􀅐
     /// 19 Localizations, Single Layerset
@@ -14638,7 +14638,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatSize = SymbolWith18Localizations<Ar_v2_1, Bn_v6, Gu_v6, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6, Ko_v2_1, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th_v2_1, Zh_v2_1>(rawValue: "textformat.size")
+    static var textformatSize: SymbolWith18Localizations<Ar_v2_1, Bn_v6, Gu_v6, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6, Ko_v2_1, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th_v2_1, Zh_v2_1> { .init(rawValue: "textformat.size") }
 
     /// 􀓡
     /// 20 Localizations, 2 Layersets
@@ -14668,7 +14668,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textformatSubscript = SymbolWith19Localizations<Ar_v2_1, Bn_v6_3, Gu_v6_3, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6_3, Ko_v2_1, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v2_1, Zh_v2_1>(rawValue: "textformat.subscript")
+    static var textformatSubscript: SymbolWith19Localizations<Ar_v2_1, Bn_v6_3, Gu_v6_3, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6_3, Ko_v2_1, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v2_1, Zh_v2_1> { .init(rawValue: "textformat.subscript") }
 
     /// 􀓢
     /// 20 Localizations, 2 Layersets
@@ -14698,7 +14698,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textformatSuperscript = SymbolWith19Localizations<Ar_v2_1, Bn_v6_3, Gu_v6_3, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6_3, Ko_v2_1, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v2_1, Zh_v2_1>(rawValue: "textformat.superscript")
+    static var textformatSuperscript: SymbolWith19Localizations<Ar_v2_1, Bn_v6_3, Gu_v6_3, He_v2_1, Hi_v2_1, Ja_v2_1, Kn_v6_3, Ko_v2_1, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th_v2_1, Zh_v2_1> { .init(rawValue: "textformat.superscript") }
 
     /// 􀇬
     /// Single Localization, 3 Layersets
@@ -14712,7 +14712,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "thermometerMedium")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "thermometerMedium")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "thermometerMedium")
-    static let thermometer = SFSymbol(rawValue: "thermometer")
+    static var thermometer: SFSymbol { .init(rawValue: "thermometer") }
 
     /// 􀇫
     /// Single Localization, 3 Layersets
@@ -14721,7 +14721,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let thermometerSnowflake = SFSymbol(rawValue: "thermometer.snowflake")
+    static var thermometerSnowflake: SFSymbol { .init(rawValue: "thermometer.snowflake") }
 
     /// 􀇪
     /// Single Localization, 3 Layersets
@@ -14730,7 +14730,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let thermometerSun = SFSymbol(rawValue: "thermometer.sun")
+    static var thermometerSun: SFSymbol { .init(rawValue: "thermometer.sun") }
 
     /// 􀇲
     /// Single Localization, 3 Layersets
@@ -14739,7 +14739,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let timelapse = SFSymbol(rawValue: "timelapse")
+    static var timelapse: SFSymbol { .init(rawValue: "timelapse") }
 
     /// 􀐱
     /// Single Localization, 3 Layersets
@@ -14748,7 +14748,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let timer = SFSymbol(rawValue: "timer")
+    static var timer: SFSymbol { .init(rawValue: "timer") }
 
     /// 􀇧
     /// Single Localization, 2 Layersets
@@ -14756,14 +14756,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let tornado = SFSymbol(rawValue: "tornado")
+    static var tornado: SFSymbol { .init(rawValue: "tornado") }
 
     /// 􀓐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tortoise = SFSymbol(rawValue: "tortoise")
+    static var tortoise: SFSymbol { .init(rawValue: "tortoise") }
 
     /// 􀓑
     /// Single Localization, 2 Layersets
@@ -14771,14 +14771,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tortoiseFill = SFSymbol(rawValue: "tortoise.fill")
+    static var tortoiseFill: SFSymbol { .init(rawValue: "tortoise.fill") }
 
     /// 􀝇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tramFill = SFSymbol(rawValue: "tram.fill")
+    static var tramFill: SFSymbol { .init(rawValue: "tram.fill") }
 
     /// 􀈑
     /// Single Localization, 2 Layersets
@@ -14786,7 +14786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trash = SFSymbol(rawValue: "trash")
+    static var trash: SFSymbol { .init(rawValue: "trash") }
 
     /// 􀈓
     /// Single Localization, 3 Layersets
@@ -14795,7 +14795,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trashCircle = SFSymbol(rawValue: "trash.circle")
+    static var trashCircle: SFSymbol { .init(rawValue: "trash.circle") }
 
     /// 􀈔
     /// Single Localization, 3 Layersets
@@ -14804,7 +14804,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trashCircleFill = SFSymbol(rawValue: "trash.circle.fill")
+    static var trashCircleFill: SFSymbol { .init(rawValue: "trash.circle.fill") }
 
     /// 􀈒
     /// Single Localization, 2 Layersets
@@ -14812,7 +14812,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trashFill = SFSymbol(rawValue: "trash.fill")
+    static var trashFill: SFSymbol { .init(rawValue: "trash.fill") }
 
     /// 􀜧
     /// Single Localization, 3 Layersets
@@ -14821,7 +14821,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trashSlash = SFSymbol(rawValue: "trash.slash")
+    static var trashSlash: SFSymbol { .init(rawValue: "trash.slash") }
 
     /// 􀜨
     /// Single Localization, 3 Layersets
@@ -14830,28 +14830,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trashSlashFill = SFSymbol(rawValue: "trash.slash.fill")
+    static var trashSlashFill: SFSymbol { .init(rawValue: "trash.slash.fill") }
 
     /// 􀈣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tray = SFSymbol(rawValue: "tray")
+    static var tray: SFSymbol { .init(rawValue: "tray") }
 
     /// 􀈩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tray2 = SFSymbol(rawValue: "tray.2")
+    static var tray2: SFSymbol { .init(rawValue: "tray.2") }
 
     /// 􀈪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tray2Fill = SFSymbol(rawValue: "tray.2.fill")
+    static var tray2Fill: SFSymbol { .init(rawValue: "tray.2.fill") }
 
     /// 􀈧
     /// Single Localization, 2 Layersets
@@ -14859,7 +14859,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayAndArrowDown = SFSymbol(rawValue: "tray.and.arrow.down")
+    static var trayAndArrowDown: SFSymbol { .init(rawValue: "tray.and.arrow.down") }
 
     /// 􀈨
     /// Single Localization, 2 Layersets
@@ -14867,7 +14867,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayAndArrowDownFill = SFSymbol(rawValue: "tray.and.arrow.down.fill")
+    static var trayAndArrowDownFill: SFSymbol { .init(rawValue: "tray.and.arrow.down.fill") }
 
     /// 􀈥
     /// Single Localization, 2 Layersets
@@ -14875,7 +14875,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayAndArrowUp = SFSymbol(rawValue: "tray.and.arrow.up")
+    static var trayAndArrowUp: SFSymbol { .init(rawValue: "tray.and.arrow.up") }
 
     /// 􀈦
     /// Single Localization, 2 Layersets
@@ -14883,42 +14883,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayAndArrowUpFill = SFSymbol(rawValue: "tray.and.arrow.up.fill")
+    static var trayAndArrowUpFill: SFSymbol { .init(rawValue: "tray.and.arrow.up.fill") }
 
     /// 􀈤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trayFill = SFSymbol(rawValue: "tray.fill")
+    static var trayFill: SFSymbol { .init(rawValue: "tray.fill") }
 
     /// 􀈫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trayFull = SFSymbol(rawValue: "tray.full")
+    static var trayFull: SFSymbol { .init(rawValue: "tray.full") }
 
     /// 􀈬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trayFullFill = SFSymbol(rawValue: "tray.full.fill")
+    static var trayFullFill: SFSymbol { .init(rawValue: "tray.full.fill") }
 
     /// 􀛣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangle = SFSymbol(rawValue: "triangle")
+    static var triangle: SFSymbol { .init(rawValue: "triangle") }
 
     /// 􀛤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleFill = SFSymbol(rawValue: "triangle.fill")
+    static var triangleFill: SFSymbol { .init(rawValue: "triangle.fill") }
 
     /// 􀚕
     /// Single Localization, Single Layerset
@@ -14930,7 +14930,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "triangleLefthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "triangleLefthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "triangleLefthalfFilled")
-    static let triangleLefthalfFill = SFSymbol(rawValue: "triangle.lefthalf.fill")
+    static var triangleLefthalfFill: SFSymbol { .init(rawValue: "triangle.lefthalf.fill") }
 
     /// 􀚖
     /// Single Localization, Single Layerset
@@ -14942,7 +14942,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "triangleRighthalfFilled")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "triangleRighthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "triangleRighthalfFilled")
-    static let triangleRighthalfFill = SFSymbol(rawValue: "triangle.righthalf.fill")
+    static var triangleRighthalfFill: SFSymbol { .init(rawValue: "triangle.righthalf.fill") }
 
     /// 􀇨
     /// Single Localization, 2 Layersets
@@ -14950,7 +14950,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let tropicalstorm = SFSymbol(rawValue: "tropicalstorm")
+    static var tropicalstorm: SFSymbol { .init(rawValue: "tropicalstorm") }
 
     /// 􀗇
     /// Single Localization, 2 Layersets
@@ -14958,7 +14958,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tugriksignCircle = SFSymbol(rawValue: "tugriksign.circle")
+    static var tugriksignCircle: SFSymbol { .init(rawValue: "tugriksign.circle") }
 
     /// 􀗈
     /// Single Localization, 3 Layersets
@@ -14967,7 +14967,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tugriksignCircleFill = SFSymbol(rawValue: "tugriksign.circle.fill")
+    static var tugriksignCircleFill: SFSymbol { .init(rawValue: "tugriksign.circle.fill") }
 
     /// 􀘇
     /// Single Localization, 2 Layersets
@@ -14975,7 +14975,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tugriksignSquare = SFSymbol(rawValue: "tugriksign.square")
+    static var tugriksignSquare: SFSymbol { .init(rawValue: "tugriksign.square") }
 
     /// 􀘈
     /// Single Localization, 3 Layersets
@@ -14984,14 +14984,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tugriksignSquareFill = SFSymbol(rawValue: "tugriksign.square.fill")
+    static var tugriksignSquareFill: SFSymbol { .init(rawValue: "tugriksign.square.fill") }
 
     /// 􀎐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tuningfork = SFSymbol(rawValue: "tuningfork")
+    static var tuningfork: SFSymbol { .init(rawValue: "tuningfork") }
 
     /// 􀖣
     /// Single Localization, 2 Layersets
@@ -14999,7 +14999,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let turkishlirasignCircle = SFSymbol(rawValue: "turkishlirasign.circle")
+    static var turkishlirasignCircle: SFSymbol { .init(rawValue: "turkishlirasign.circle") }
 
     /// 􀖤
     /// Single Localization, 3 Layersets
@@ -15008,7 +15008,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let turkishlirasignCircleFill = SFSymbol(rawValue: "turkishlirasign.circle.fill")
+    static var turkishlirasignCircleFill: SFSymbol { .init(rawValue: "turkishlirasign.circle.fill") }
 
     /// 􀗣
     /// Single Localization, 2 Layersets
@@ -15016,7 +15016,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let turkishlirasignSquare = SFSymbol(rawValue: "turkishlirasign.square")
+    static var turkishlirasignSquare: SFSymbol { .init(rawValue: "turkishlirasign.square") }
 
     /// 􀗤
     /// Single Localization, 3 Layersets
@@ -15025,7 +15025,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let turkishlirasignSquareFill = SFSymbol(rawValue: "turkishlirasign.square.fill")
+    static var turkishlirasignSquareFill: SFSymbol { .init(rawValue: "turkishlirasign.square.fill") }
 
     /// 􀎲
     /// Single Localization, 2 Layersets
@@ -15033,7 +15033,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tv = SFSymbol(rawValue: "tv")
+    static var tv: SFSymbol { .init(rawValue: "tv") }
 
     /// 􀎳
     /// Single Localization, 2 Layersets
@@ -15041,7 +15041,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tvCircle = SFSymbol(rawValue: "tv.circle")
+    static var tvCircle: SFSymbol { .init(rawValue: "tv.circle") }
 
     /// 􀎴
     /// Single Localization, 3 Layersets
@@ -15050,14 +15050,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tvCircleFill = SFSymbol(rawValue: "tv.circle.fill")
+    static var tvCircleFill: SFSymbol { .init(rawValue: "tv.circle.fill") }
 
     /// 􀒶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tvFill = SFSymbol(rawValue: "tv.fill")
+    static var tvFill: SFSymbol { .init(rawValue: "tv.fill") }
 
     /// 􀎵
     /// Single Localization, 2 Layersets
@@ -15070,7 +15070,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "musicNoteTv")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "musicNoteTv")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "musicNoteTv")
-    static let tvMusicNote = SFSymbol(rawValue: "tv.music.note")
+    static var tvMusicNote: SFSymbol { .init(rawValue: "tv.music.note") }
 
     /// 􀒷
     /// Single Localization, 3 Layersets
@@ -15084,7 +15084,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 15.0, renamed: "musicNoteTvFill")
     @available(watchOS, introduced: 6.0, deprecated: 8.0, renamed: "musicNoteTvFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "musicNoteTvFill")
-    static let tvMusicNoteFill = SFSymbol(rawValue: "tv.music.note.fill")
+    static var tvMusicNoteFill: SFSymbol { .init(rawValue: "tv.music.note.fill") }
 
     /// 􀀬
     /// Single Localization, 2 Layersets
@@ -15092,7 +15092,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let uCircle = SFSymbol(rawValue: "u.circle")
+    static var uCircle: SFSymbol { .init(rawValue: "u.circle") }
 
     /// 􀀭
     /// Single Localization, 3 Layersets
@@ -15101,7 +15101,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let uCircleFill = SFSymbol(rawValue: "u.circle.fill")
+    static var uCircleFill: SFSymbol { .init(rawValue: "u.circle.fill") }
 
     /// 􀂼
     /// Single Localization, 2 Layersets
@@ -15109,7 +15109,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let uSquare = SFSymbol(rawValue: "u.square")
+    static var uSquare: SFSymbol { .init(rawValue: "u.square") }
 
     /// 􀂽
     /// Single Localization, 3 Layersets
@@ -15118,28 +15118,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let uSquareFill = SFSymbol(rawValue: "u.square.fill")
+    static var uSquareFill: SFSymbol { .init(rawValue: "u.square.fill") }
 
     /// 􀏝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let uiwindowSplit2x1 = SFSymbol(rawValue: "uiwindow.split.2x1")
+    static var uiwindowSplit2x1: SFSymbol { .init(rawValue: "uiwindow.split.2x1") }
 
     /// 􀙕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let umbrella = SFSymbol(rawValue: "umbrella")
+    static var umbrella: SFSymbol { .init(rawValue: "umbrella") }
 
     /// 􀙖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let umbrellaFill = SFSymbol(rawValue: "umbrella.fill")
+    static var umbrellaFill: SFSymbol { .init(rawValue: "umbrella.fill") }
 
     /// 􀅕
     /// Single Localization, 3 Layersets
@@ -15148,7 +15148,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let underline = SFSymbol(rawValue: "underline")
+    static var underline: SFSymbol { .init(rawValue: "underline") }
 
     /// 􀀮
     /// Single Localization, 2 Layersets
@@ -15156,7 +15156,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let vCircle = SFSymbol(rawValue: "v.circle")
+    static var vCircle: SFSymbol { .init(rawValue: "v.circle") }
 
     /// 􀀯
     /// Single Localization, 3 Layersets
@@ -15165,7 +15165,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let vCircleFill = SFSymbol(rawValue: "v.circle.fill")
+    static var vCircleFill: SFSymbol { .init(rawValue: "v.circle.fill") }
 
     /// 􀂾
     /// Single Localization, 2 Layersets
@@ -15173,7 +15173,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let vSquare = SFSymbol(rawValue: "v.square")
+    static var vSquare: SFSymbol { .init(rawValue: "v.square") }
 
     /// 􀂿
     /// Single Localization, 3 Layersets
@@ -15182,7 +15182,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let vSquareFill = SFSymbol(rawValue: "v.square.fill")
+    static var vSquareFill: SFSymbol { .init(rawValue: "v.square.fill") }
 
     /// 􀍉
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -15192,7 +15192,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let video = SFSymbol(rawValue: "video")
+    static var video: SFSymbol { .init(rawValue: "video") }
 
     /// 􀜮
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15203,7 +15203,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBadgePlus = SFSymbol(rawValue: "video.badge.plus")
+    static var videoBadgePlus: SFSymbol { .init(rawValue: "video.badge.plus") }
 
     /// 􀜯
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15219,7 +15219,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "videoFillBadgePlus")
     @available(watchOS, introduced: 6.0, deprecated: 7.0, renamed: "videoFillBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "videoFillBadgePlus")
-    static let videoBadgePlusFill = SFSymbol(rawValue: "video.badge.plus.fill")
+    static var videoBadgePlusFill: SFSymbol { .init(rawValue: "video.badge.plus.fill") }
 
     /// 􀍋
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15230,7 +15230,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoCircle = SFSymbol(rawValue: "video.circle")
+    static var videoCircle: SFSymbol { .init(rawValue: "video.circle") }
 
     /// 􀍌
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15241,7 +15241,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoCircleFill = SFSymbol(rawValue: "video.circle.fill")
+    static var videoCircleFill: SFSymbol { .init(rawValue: "video.circle.fill") }
 
     /// 􀍊
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -15251,7 +15251,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoFill = SFSymbol(rawValue: "video.fill")
+    static var videoFill: SFSymbol { .init(rawValue: "video.fill") }
 
     /// 􀍍
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15262,7 +15262,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSlash = SFSymbol(rawValue: "video.slash")
+    static var videoSlash: SFSymbol { .init(rawValue: "video.slash") }
 
     /// 􀍎
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15273,28 +15273,28 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSlashFill = SFSymbol(rawValue: "video.slash.fill")
+    static var videoSlashFill: SFSymbol { .init(rawValue: "video.slash.fill") }
 
     /// 􀅙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let view2d = SFSymbol(rawValue: "view.2d")
+    static var view2d: SFSymbol { .init(rawValue: "view.2d") }
 
     /// 􀅪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let view3d = SFSymbol(rawValue: "view.3d")
+    static var view3d: SFSymbol { .init(rawValue: "view.3d") }
 
     /// 􀎹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let viewfinder = SFSymbol(rawValue: "viewfinder")
+    static var viewfinder: SFSymbol { .init(rawValue: "viewfinder") }
 
     /// 􀎿
     /// Single Localization, 2 Layersets
@@ -15302,7 +15302,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let viewfinderCircle = SFSymbol(rawValue: "viewfinder.circle")
+    static var viewfinderCircle: SFSymbol { .init(rawValue: "viewfinder.circle") }
 
     /// 􀏀
     /// Single Localization, 3 Layersets
@@ -15311,7 +15311,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let viewfinderCircleFill = SFSymbol(rawValue: "viewfinder.circle.fill")
+    static var viewfinderCircleFill: SFSymbol { .init(rawValue: "viewfinder.circle.fill") }
 
     /// 􀀰
     /// Single Localization, 2 Layersets
@@ -15319,7 +15319,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wCircle = SFSymbol(rawValue: "w.circle")
+    static var wCircle: SFSymbol { .init(rawValue: "w.circle") }
 
     /// 􀀱
     /// Single Localization, 3 Layersets
@@ -15328,7 +15328,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wCircleFill = SFSymbol(rawValue: "w.circle.fill")
+    static var wCircleFill: SFSymbol { .init(rawValue: "w.circle.fill") }
 
     /// 􀃀
     /// Single Localization, 2 Layersets
@@ -15336,7 +15336,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wSquare = SFSymbol(rawValue: "w.square")
+    static var wSquare: SFSymbol { .init(rawValue: "w.square") }
 
     /// 􀃁
     /// Single Localization, 3 Layersets
@@ -15345,7 +15345,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wSquareFill = SFSymbol(rawValue: "w.square.fill")
+    static var wSquareFill: SFSymbol { .init(rawValue: "w.square.fill") }
 
     /// 􀍱
     /// Single Localization, 3 Layersets
@@ -15354,7 +15354,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wandAndRays = SFSymbol(rawValue: "wand.and.rays")
+    static var wandAndRays: SFSymbol { .init(rawValue: "wand.and.rays") }
 
     /// 􀍲
     /// Single Localization, 3 Layersets
@@ -15363,7 +15363,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wandAndRaysInverse = SFSymbol(rawValue: "wand.and.rays.inverse")
+    static var wandAndRaysInverse: SFSymbol { .init(rawValue: "wand.and.rays.inverse") }
 
     /// 􀜍
     /// Single Localization, 2 Layersets
@@ -15376,7 +15376,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "wandAndSparkles")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "wandAndSparkles")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "wandAndSparkles")
-    static let wandAndStars = SFSymbol(rawValue: "wand.and.stars")
+    static var wandAndStars: SFSymbol { .init(rawValue: "wand.and.stars") }
 
     /// 􀜎
     /// Single Localization, 2 Layersets
@@ -15389,7 +15389,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 18.0, renamed: "wandAndSparklesInverse")
     @available(watchOS, introduced: 6.0, deprecated: 11.0, renamed: "wandAndSparklesInverse")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "wandAndSparklesInverse")
-    static let wandAndStarsInverse = SFSymbol(rawValue: "wand.and.stars.inverse")
+    static var wandAndStarsInverse: SFSymbol { .init(rawValue: "wand.and.stars.inverse") }
 
     /// 􀙫
     /// Single Localization, 3 Layersets
@@ -15398,7 +15398,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let waveform = SFSymbol(rawValue: "waveform")
+    static var waveform: SFSymbol { .init(rawValue: "waveform") }
 
     /// 􀞈
     /// Single Localization, 3 Layersets
@@ -15407,7 +15407,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let waveformCircle = SFSymbol(rawValue: "waveform.circle")
+    static var waveformCircle: SFSymbol { .init(rawValue: "waveform.circle") }
 
     /// 􀞉
     /// Single Localization, 3 Layersets
@@ -15416,14 +15416,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let waveformCircleFill = SFSymbol(rawValue: "waveform.circle.fill")
+    static var waveformCircleFill: SFSymbol { .init(rawValue: "waveform.circle.fill") }
 
     /// 􀑃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformPath = SFSymbol(rawValue: "waveform.path")
+    static var waveformPath: SFSymbol { .init(rawValue: "waveform.path") }
 
     /// 􀑅
     /// Single Localization, 3 Layersets
@@ -15432,7 +15432,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let waveformPathBadgeMinus = SFSymbol(rawValue: "waveform.path.badge.minus")
+    static var waveformPathBadgeMinus: SFSymbol { .init(rawValue: "waveform.path.badge.minus") }
 
     /// 􀑄
     /// Single Localization, 3 Layersets
@@ -15441,14 +15441,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let waveformPathBadgePlus = SFSymbol(rawValue: "waveform.path.badge.plus")
+    static var waveformPathBadgePlus: SFSymbol { .init(rawValue: "waveform.path.badge.plus") }
 
     /// 􀜟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformPathEcg = SFSymbol(rawValue: "waveform.path.ecg")
+    static var waveformPathEcg: SFSymbol { .init(rawValue: "waveform.path.ecg") }
 
     /// 􀙇
     /// Single Localization, 3 Layersets
@@ -15457,7 +15457,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wifi = SFSymbol(rawValue: "wifi")
+    static var wifi: SFSymbol { .init(rawValue: "wifi") }
 
     /// 􀙥
     /// Single Localization, 2 Layersets
@@ -15465,7 +15465,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wifiExclamationmark = SFSymbol(rawValue: "wifi.exclamationmark")
+    static var wifiExclamationmark: SFSymbol { .init(rawValue: "wifi.exclamationmark") }
 
     /// 􀙈
     /// Single Localization, 3 Layersets
@@ -15474,7 +15474,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let wifiSlash = SFSymbol(rawValue: "wifi.slash")
+    static var wifiSlash: SFSymbol { .init(rawValue: "wifi.slash") }
 
     /// 􀇤
     /// Single Localization, 2 Layersets
@@ -15482,7 +15482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
-    static let wind = SFSymbol(rawValue: "wind")
+    static var wind: SFSymbol { .init(rawValue: "wind") }
 
     /// 􀇦
     /// Single Localization, 3 Layersets
@@ -15491,7 +15491,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let windSnow = SFSymbol(rawValue: "wind.snow")
+    static var windSnow: SFSymbol { .init(rawValue: "wind.snow") }
 
     /// 􀖵
     /// Single Localization, 2 Layersets
@@ -15499,7 +15499,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wonsignCircle = SFSymbol(rawValue: "wonsign.circle")
+    static var wonsignCircle: SFSymbol { .init(rawValue: "wonsign.circle") }
 
     /// 􀖶
     /// Single Localization, 3 Layersets
@@ -15508,7 +15508,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wonsignCircleFill = SFSymbol(rawValue: "wonsign.circle.fill")
+    static var wonsignCircleFill: SFSymbol { .init(rawValue: "wonsign.circle.fill") }
 
     /// 􀗵
     /// Single Localization, 2 Layersets
@@ -15516,7 +15516,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wonsignSquare = SFSymbol(rawValue: "wonsign.square")
+    static var wonsignSquare: SFSymbol { .init(rawValue: "wonsign.square") }
 
     /// 􀗶
     /// Single Localization, 3 Layersets
@@ -15525,7 +15525,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wonsignSquareFill = SFSymbol(rawValue: "wonsign.square.fill")
+    static var wonsignSquareFill: SFSymbol { .init(rawValue: "wonsign.square.fill") }
 
     /// 􀎕
     /// Single Localization, Single Layerset
@@ -15537,7 +15537,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "wrenchAdjustable")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "wrenchAdjustable")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "wrenchAdjustable")
-    static let wrench = SFSymbol(rawValue: "wrench")
+    static var wrench: SFSymbol { .init(rawValue: "wrench") }
 
     /// 􀎖
     /// Single Localization, Single Layerset
@@ -15549,7 +15549,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 16.0, renamed: "wrenchAdjustableFill")
     @available(watchOS, introduced: 6.0, deprecated: 9.0, renamed: "wrenchAdjustableFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "wrenchAdjustableFill")
-    static let wrenchFill = SFSymbol(rawValue: "wrench.fill")
+    static var wrenchFill: SFSymbol { .init(rawValue: "wrench.fill") }
 
     /// 􀀲
     /// Single Localization, 2 Layersets
@@ -15557,7 +15557,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xCircle = SFSymbol(rawValue: "x.circle")
+    static var xCircle: SFSymbol { .init(rawValue: "x.circle") }
 
     /// 􀀳
     /// Single Localization, 3 Layersets
@@ -15566,7 +15566,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xCircleFill = SFSymbol(rawValue: "x.circle.fill")
+    static var xCircleFill: SFSymbol { .init(rawValue: "x.circle.fill") }
 
     /// 􀃂
     /// Single Localization, 2 Layersets
@@ -15574,7 +15574,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xSquare = SFSymbol(rawValue: "x.square")
+    static var xSquare: SFSymbol { .init(rawValue: "x.square") }
 
     /// 􀃃
     /// Single Localization, 3 Layersets
@@ -15583,7 +15583,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xSquareFill = SFSymbol(rawValue: "x.square.fill")
+    static var xSquareFill: SFSymbol { .init(rawValue: "x.square.fill") }
 
     /// 􀓪
     /// Single Localization, 2 Layersets
@@ -15591,7 +15591,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xSquareroot = SFSymbol(rawValue: "x.squareroot")
+    static var xSquareroot: SFSymbol { .init(rawValue: "x.squareroot") }
 
     /// 􀆄
     /// Single Localization, 2 Layersets
@@ -15599,7 +15599,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmark = SFSymbol(rawValue: "xmark")
+    static var xmark: SFSymbol { .init(rawValue: "xmark") }
 
     /// 􀁠
     /// Single Localization, 3 Layersets
@@ -15608,7 +15608,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkCircle = SFSymbol(rawValue: "xmark.circle")
+    static var xmarkCircle: SFSymbol { .init(rawValue: "xmark.circle") }
 
     /// 􀁡
     /// Single Localization, 3 Layersets
@@ -15617,7 +15617,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkCircleFill = SFSymbol(rawValue: "xmark.circle.fill")
+    static var xmarkCircleFill: SFSymbol { .init(rawValue: "xmark.circle.fill") }
 
     /// 􀌓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -15627,7 +15627,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let xmarkIcloud = SFSymbol(rawValue: "xmark.icloud")
+    static var xmarkIcloud: SFSymbol { .init(rawValue: "xmark.icloud") }
 
     /// 􀌔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -15638,7 +15638,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let xmarkIcloudFill = SFSymbol(rawValue: "xmark.icloud.fill")
+    static var xmarkIcloudFill: SFSymbol { .init(rawValue: "xmark.icloud.fill") }
 
     /// 􀒉
     /// Single Localization, 3 Layersets
@@ -15647,7 +15647,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkOctagon = SFSymbol(rawValue: "xmark.octagon")
+    static var xmarkOctagon: SFSymbol { .init(rawValue: "xmark.octagon") }
 
     /// 􀒊
     /// Single Localization, 3 Layersets
@@ -15656,7 +15656,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkOctagonFill = SFSymbol(rawValue: "xmark.octagon.fill")
+    static var xmarkOctagonFill: SFSymbol { .init(rawValue: "xmark.octagon.fill") }
 
     /// 􀏍
     /// Single Localization, 3 Layersets
@@ -15665,7 +15665,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkRectangle = SFSymbol(rawValue: "xmark.rectangle")
+    static var xmarkRectangle: SFSymbol { .init(rawValue: "xmark.rectangle") }
 
     /// 􀏎
     /// Single Localization, 3 Layersets
@@ -15674,7 +15674,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkRectangleFill = SFSymbol(rawValue: "xmark.rectangle.fill")
+    static var xmarkRectangleFill: SFSymbol { .init(rawValue: "xmark.rectangle.fill") }
 
     /// 􀇼
     /// Single Localization, 2 Layersets
@@ -15682,7 +15682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkSeal = SFSymbol(rawValue: "xmark.seal")
+    static var xmarkSeal: SFSymbol { .init(rawValue: "xmark.seal") }
 
     /// 􀇽
     /// Single Localization, 3 Layersets
@@ -15691,7 +15691,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkSealFill = SFSymbol(rawValue: "xmark.seal.fill")
+    static var xmarkSealFill: SFSymbol { .init(rawValue: "xmark.seal.fill") }
 
     /// 􀞝
     /// Single Localization, 3 Layersets
@@ -15700,7 +15700,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let xmarkShield = SFSymbol(rawValue: "xmark.shield")
+    static var xmarkShield: SFSymbol { .init(rawValue: "xmark.shield") }
 
     /// 􀞞
     /// Single Localization, 3 Layersets
@@ -15709,7 +15709,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkShieldFill = SFSymbol(rawValue: "xmark.shield.fill")
+    static var xmarkShieldFill: SFSymbol { .init(rawValue: "xmark.shield.fill") }
 
     /// 􀃰
     /// Single Localization, 3 Layersets
@@ -15718,7 +15718,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkSquare = SFSymbol(rawValue: "xmark.square")
+    static var xmarkSquare: SFSymbol { .init(rawValue: "xmark.square") }
 
     /// 􀃱
     /// Single Localization, 3 Layersets
@@ -15727,7 +15727,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkSquareFill = SFSymbol(rawValue: "xmark.square.fill")
+    static var xmarkSquareFill: SFSymbol { .init(rawValue: "xmark.square.fill") }
 
     /// 􀀴
     /// Single Localization, 2 Layersets
@@ -15735,7 +15735,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yCircle = SFSymbol(rawValue: "y.circle")
+    static var yCircle: SFSymbol { .init(rawValue: "y.circle") }
 
     /// 􀀵
     /// Single Localization, 3 Layersets
@@ -15744,7 +15744,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yCircleFill = SFSymbol(rawValue: "y.circle.fill")
+    static var yCircleFill: SFSymbol { .init(rawValue: "y.circle.fill") }
 
     /// 􀃄
     /// Single Localization, 2 Layersets
@@ -15752,7 +15752,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ySquare = SFSymbol(rawValue: "y.square")
+    static var ySquare: SFSymbol { .init(rawValue: "y.square") }
 
     /// 􀃅
     /// Single Localization, 3 Layersets
@@ -15761,7 +15761,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ySquareFill = SFSymbol(rawValue: "y.square.fill")
+    static var ySquareFill: SFSymbol { .init(rawValue: "y.square.fill") }
 
     /// 􀖛
     /// Single Localization, 2 Layersets
@@ -15769,7 +15769,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yensignCircle = SFSymbol(rawValue: "yensign.circle")
+    static var yensignCircle: SFSymbol { .init(rawValue: "yensign.circle") }
 
     /// 􀖜
     /// Single Localization, 3 Layersets
@@ -15778,7 +15778,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yensignCircleFill = SFSymbol(rawValue: "yensign.circle.fill")
+    static var yensignCircleFill: SFSymbol { .init(rawValue: "yensign.circle.fill") }
 
     /// 􀗛
     /// Single Localization, 2 Layersets
@@ -15786,7 +15786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yensignSquare = SFSymbol(rawValue: "yensign.square")
+    static var yensignSquare: SFSymbol { .init(rawValue: "yensign.square") }
 
     /// 􀗜
     /// Single Localization, 3 Layersets
@@ -15795,7 +15795,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let yensignSquareFill = SFSymbol(rawValue: "yensign.square.fill")
+    static var yensignSquareFill: SFSymbol { .init(rawValue: "yensign.square.fill") }
 
     /// 􀀶
     /// Single Localization, 2 Layersets
@@ -15803,7 +15803,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let zCircle = SFSymbol(rawValue: "z.circle")
+    static var zCircle: SFSymbol { .init(rawValue: "z.circle") }
 
     /// 􀀷
     /// Single Localization, 3 Layersets
@@ -15812,7 +15812,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let zCircleFill = SFSymbol(rawValue: "z.circle.fill")
+    static var zCircleFill: SFSymbol { .init(rawValue: "z.circle.fill") }
 
     /// 􀃆
     /// Single Localization, 2 Layersets
@@ -15820,7 +15820,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let zSquare = SFSymbol(rawValue: "z.square")
+    static var zSquare: SFSymbol { .init(rawValue: "z.square") }
 
     /// 􀃇
     /// Single Localization, 3 Layersets
@@ -15829,12 +15829,12 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let zSquareFill = SFSymbol(rawValue: "z.square.fill")
+    static var zSquareFill: SFSymbol { .init(rawValue: "z.square.fill") }
 
     /// 􀖃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let zzz = SFSymbol(rawValue: "zzz")
+    static var zzz: SFSymbol { .init(rawValue: "zzz") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+1.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+1.1.swift
@@ -10,21 +10,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnLeftCircleBadgeEllipsis = SFSymbol(rawValue: "arrow.uturn.left.circle.badge.ellipsis")
+    static var arrowUturnLeftCircleBadgeEllipsis: SFSymbol { .init(rawValue: "arrow.uturn.left.circle.badge.ellipsis") }
 
     /// 􀞖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let aspectratio = SFSymbol(rawValue: "aspectratio")
+    static var aspectratio: SFSymbol { .init(rawValue: "aspectratio") }
 
     /// 􀞏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let aspectratioFill = SFSymbol(rawValue: "aspectratio.fill")
+    static var aspectratioFill: SFSymbol { .init(rawValue: "aspectratio.fill") }
 
     /// 􀙘
     /// Single Localization, 2 Layersets
@@ -32,35 +32,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let car = SFSymbol(rawValue: "car")
+    static var car: SFSymbol { .init(rawValue: "car") }
 
     /// 􀞾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid2x2 = SFSymbol(rawValue: "circle.grid.2x2")
+    static var circleGrid2x2: SFSymbol { .init(rawValue: "circle.grid.2x2") }
 
     /// 􀞿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid2x2Fill = SFSymbol(rawValue: "circle.grid.2x2.fill")
+    static var circleGrid2x2Fill: SFSymbol { .init(rawValue: "circle.grid.2x2.fill") }
 
     /// 􀝌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flashlightOffFill = SFSymbol(rawValue: "flashlight.off.fill")
+    static var flashlightOffFill: SFSymbol { .init(rawValue: "flashlight.off.fill") }
 
     /// 􀞋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flashlightOnFill = SFSymbol(rawValue: "flashlight.on.fill")
+    static var flashlightOnFill: SFSymbol { .init(rawValue: "flashlight.on.fill") }
 
     /// 􀞒
     /// Single Localization, Single Layerset
@@ -72,7 +72,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRight")
     @available(watchOS, introduced: 6.1, deprecated: 7.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRight")
-    static let flipHorizontal = SFSymbol(rawValue: "flip.horizontal")
+    static var flipHorizontal: SFSymbol { .init(rawValue: "flip.horizontal") }
 
     /// 􀞓
     /// Single Localization, Single Layerset
@@ -84,7 +84,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 13.0, deprecated: 14.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRightFill")
     @available(watchOS, introduced: 6.1, deprecated: 7.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowLeftAndRightRighttriangleLeftRighttriangleRightFill")
-    static let flipHorizontalFill = SFSymbol(rawValue: "flip.horizontal.fill")
+    static var flipHorizontalFill: SFSymbol { .init(rawValue: "flip.horizontal.fill") }
 
     /// 􀜇
     /// Single Localization, 3 Layersets
@@ -93,7 +93,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mappinCircle = SFSymbol(rawValue: "mappin.circle")
+    static var mappinCircle: SFSymbol { .init(rawValue: "mappin.circle") }
 
     /// 􀜈
     /// Single Localization, 3 Layersets
@@ -102,7 +102,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let mappinCircleFill = SFSymbol(rawValue: "mappin.circle.fill")
+    static var mappinCircleFill: SFSymbol { .init(rawValue: "mappin.circle.fill") }
 
     /// 􀒔
     /// Single Localization, 3 Layersets
@@ -111,7 +111,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let paperclipCircle = SFSymbol(rawValue: "paperclip.circle")
+    static var paperclipCircle: SFSymbol { .init(rawValue: "paperclip.circle") }
 
     /// 􀒕
     /// Single Localization, 3 Layersets
@@ -120,7 +120,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let paperclipCircleFill = SFSymbol(rawValue: "paperclip.circle.fill")
+    static var paperclipCircleFill: SFSymbol { .init(rawValue: "paperclip.circle.fill") }
 
     /// 􀒴
     /// Single Localization, 3 Layersets
@@ -129,7 +129,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pinCircle = SFSymbol(rawValue: "pin.circle")
+    static var pinCircle: SFSymbol { .init(rawValue: "pin.circle") }
 
     /// 􀒵
     /// Single Localization, 3 Layersets
@@ -138,7 +138,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pinCircleFill = SFSymbol(rawValue: "pin.circle.fill")
+    static var pinCircleFill: SFSymbol { .init(rawValue: "pin.circle.fill") }
 
     /// 􀞷
     /// Single Localization, 3 Layersets
@@ -147,12 +147,12 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let scissorsBadgeEllipsis = SFSymbol(rawValue: "scissors.badge.ellipsis")
+    static var scissorsBadgeEllipsis: SFSymbol { .init(rawValue: "scissors.badge.ellipsis") }
 
     /// 􀑔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let studentdesk = SFSymbol(rawValue: "studentdesk")
+    static var studentdesk: SFSymbol { .init(rawValue: "studentdesk") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+2.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+2.0.swift
@@ -9,7 +9,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let _4kTv = SFSymbol(rawValue: "4k.tv")
+    static var _4kTv: SFSymbol { .init(rawValue: "4k.tv") }
 
     /// 􀦾
     /// Single Localization, 3 Layersets
@@ -18,7 +18,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let _4kTvFill = SFSymbol(rawValue: "4k.tv.fill")
+    static var _4kTvFill: SFSymbol { .init(rawValue: "4k.tv.fill") }
 
     /// 􀫕
     /// 8 Localizations, Single Layerset
@@ -40,7 +40,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 14.2, renamed: "characterBookClosed")
     @available(watchOS, introduced: 7.0, deprecated: 7.1, renamed: "characterBookClosed")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterBookClosed")
-    static let aBookClosed = SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh>(rawValue: "a.book.closed")
+    static var aBookClosed: SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh> { .init(rawValue: "a.book.closed") }
 
     /// 􀫖
     /// 8 Localizations, Single Layerset
@@ -62,7 +62,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 14.2, renamed: "characterBookClosedFill")
     @available(watchOS, introduced: 7.0, deprecated: 7.1, renamed: "characterBookClosedFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterBookClosedFill")
-    static let aBookClosedFill = SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh>(rawValue: "a.book.closed.fill")
+    static var aBookClosedFill: SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh> { .init(rawValue: "a.book.closed.fill") }
 
     /// 􀤍
     /// Single Localization, 3 Layersets
@@ -76,7 +76,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "characterMagnify")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "characterMagnify")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "characterMagnify")
-    static let aMagnify = SFSymbol(rawValue: "a.magnify")
+    static var aMagnify: SFSymbol { .init(rawValue: "a.magnify") }
 
     /// 􀥊
     /// Single Localization, Single Layerset
@@ -88,7 +88,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "charactersUppercase")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "charactersUppercase")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "charactersUppercase")
-    static let abc = SFSymbol(rawValue: "abc")
+    static var abc: SFSymbol { .init(rawValue: "abc") }
 
     /// 􀒸
     /// Single Localization, 3 Layersets
@@ -97,7 +97,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let airplaneCircle = SFSymbol(rawValue: "airplane.circle")
+    static var airplaneCircle: SFSymbol { .init(rawValue: "airplane.circle") }
 
     /// 􀒹
     /// Single Localization, 3 Layersets
@@ -106,7 +106,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let airplaneCircleFill = SFSymbol(rawValue: "airplane.circle.fill")
+    static var airplaneCircleFill: SFSymbol { .init(rawValue: "airplane.circle.fill") }
 
     /// 􀲌
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -115,7 +115,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodLeft = SFSymbol(rawValue: "airpod.left")
+    static var airpodLeft: SFSymbol { .init(rawValue: "airpod.left") }
 
     /// 􀲋
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -124,7 +124,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodRight = SFSymbol(rawValue: "airpod.right")
+    static var airpodRight: SFSymbol { .init(rawValue: "airpod.right") }
 
     /// 􀲎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -139,7 +139,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "airpodsProLeft")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "airpodsProLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProLeft")
-    static let airpodproLeft = SFSymbol(rawValue: "airpodpro.left")
+    static var airpodproLeft: SFSymbol { .init(rawValue: "airpodpro.left") }
 
     /// 􀲍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -154,7 +154,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "airpodsProRight")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "airpodsProRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProRight")
-    static let airpodproRight = SFSymbol(rawValue: "airpodpro.right")
+    static var airpodproRight: SFSymbol { .init(rawValue: "airpodpro.right") }
 
     /// 􀟥
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -163,7 +163,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpods = SFSymbol(rawValue: "airpods")
+    static var airpods: SFSymbol { .init(rawValue: "airpods") }
 
     /// 􀪷
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -178,7 +178,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "airpodsPro")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "airpodsPro")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsPro")
-    static let airpodspro = SFSymbol(rawValue: "airpodspro")
+    static var airpodspro: SFSymbol { .init(rawValue: "airpodspro") }
 
     /// 􀦯
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -187,7 +187,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPort Express.
-    static let airportExpress = SFSymbol(rawValue: "airport.express")
+    static var airportExpress: SFSymbol { .init(rawValue: "airport.express") }
 
     /// 􀑝
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -196,7 +196,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPort Extreme.
-    static let airportExtreme = SFSymbol(rawValue: "airport.extreme")
+    static var airportExtreme: SFSymbol { .init(rawValue: "airport.extreme") }
 
     /// 􀦰
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -205,14 +205,14 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPort Extreme.
-    static let airportExtremeTower = SFSymbol(rawValue: "airport.extreme.tower")
+    static var airportExtremeTower: SFSymbol { .init(rawValue: "airport.extreme.tower") }
 
     /// 􀧰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let amplifier = SFSymbol(rawValue: "amplifier")
+    static var amplifier: SFSymbol { .init(rawValue: "amplifier") }
 
     /// 􀭨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -222,7 +222,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s App Clips.
-    static let appclip = SFSymbol(rawValue: "appclip")
+    static var appclip: SFSymbol { .init(rawValue: "appclip") }
 
     /// 􀣺
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -236,7 +236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "appleLogo")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "appleLogo")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "appleLogo")
-    static let applelogo = SFSymbol(rawValue: "applelogo")
+    static var applelogo: SFSymbol { .init(rawValue: "applelogo") }
 
     /// 􀤭
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -245,7 +245,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AppleScript language.
-    static let applescript = SFSymbol(rawValue: "applescript")
+    static var applescript: SFSymbol { .init(rawValue: "applescript") }
 
     /// 􀤮
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -254,7 +254,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AppleScript language.
-    static let applescriptFill = SFSymbol(rawValue: "applescript.fill")
+    static var applescriptFill: SFSymbol { .init(rawValue: "applescript.fill") }
 
     /// 􀨫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -264,7 +264,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletv = SFSymbol(rawValue: "appletv")
+    static var appletv: SFSymbol { .init(rawValue: "appletv") }
 
     /// 􀡴
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -275,7 +275,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvFill = SFSymbol(rawValue: "appletv.fill")
+    static var appletvFill: SFSymbol { .init(rawValue: "appletv.fill") }
 
     /// 􀟤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -285,7 +285,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatch = SFSymbol(rawValue: "applewatch")
+    static var applewatch: SFSymbol { .init(rawValue: "applewatch") }
 
     /// 􀢷
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -296,7 +296,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchRadiowavesLeftAndRight = SFSymbol(rawValue: "applewatch.radiowaves.left.and.right")
+    static var applewatchRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "applewatch.radiowaves.left.and.right") }
 
     /// 􀨶
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -306,7 +306,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchSlash = SFSymbol(rawValue: "applewatch.slash")
+    static var applewatchSlash: SFSymbol { .init(rawValue: "applewatch.slash") }
 
     /// 􀫋
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -316,7 +316,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchWatchface = SFSymbol(rawValue: "applewatch.watchface")
+    static var applewatchWatchface: SFSymbol { .init(rawValue: "applewatch.watchface") }
 
     /// 􀮕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -326,7 +326,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let appsIpad = SFSymbol(rawValue: "apps.ipad")
+    static var appsIpad: SFSymbol { .init(rawValue: "apps.ipad") }
 
     /// 􀮖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -336,7 +336,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let appsIpadLandscape = SFSymbol(rawValue: "apps.ipad.landscape")
+    static var appsIpadLandscape: SFSymbol { .init(rawValue: "apps.ipad.landscape") }
 
     /// 􀟞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -346,7 +346,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let appsIphone = SFSymbol(rawValue: "apps.iphone")
+    static var appsIphone: SFSymbol { .init(rawValue: "apps.iphone") }
 
     /// 􀯖
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -357,7 +357,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let appsIphoneBadgePlus = SFSymbol(rawValue: "apps.iphone.badge.plus")
+    static var appsIphoneBadgePlus: SFSymbol { .init(rawValue: "apps.iphone.badge.plus") }
 
     /// 􀮔
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -371,7 +371,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let appsIphoneLandscape = SymbolWith1Localization<Rtl>(rawValue: "apps.iphone.landscape")
+    static var appsIphoneLandscape: SymbolWith1Localization<Rtl> { .init(rawValue: "apps.iphone.landscape") }
 
     /// 􀈯
     /// Single Localization, 2 Layersets
@@ -379,7 +379,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let archiveboxCircle = SFSymbol(rawValue: "archivebox.circle")
+    static var archiveboxCircle: SFSymbol { .init(rawValue: "archivebox.circle") }
 
     /// 􀈰
     /// Single Localization, 3 Layersets
@@ -388,14 +388,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let archiveboxCircleFill = SFSymbol(rawValue: "archivebox.circle.fill")
+    static var archiveboxCircleFill: SFSymbol { .init(rawValue: "archivebox.circle.fill") }
 
     /// 􀰌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowBackward = SFSymbol(rawValue: "arrow.backward")
+    static var arrowBackward: SFSymbol { .init(rawValue: "arrow.backward") }
 
     /// 􀰍
     /// Single Localization, 2 Layersets
@@ -403,7 +403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowBackwardCircle = SFSymbol(rawValue: "arrow.backward.circle")
+    static var arrowBackwardCircle: SFSymbol { .init(rawValue: "arrow.backward.circle") }
 
     /// 􀰎
     /// Single Localization, 3 Layersets
@@ -412,7 +412,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowBackwardCircleFill = SFSymbol(rawValue: "arrow.backward.circle.fill")
+    static var arrowBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.backward.circle.fill") }
 
     /// 􀰏
     /// Single Localization, 2 Layersets
@@ -420,7 +420,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowBackwardSquare = SFSymbol(rawValue: "arrow.backward.square")
+    static var arrowBackwardSquare: SFSymbol { .init(rawValue: "arrow.backward.square") }
 
     /// 􀰐
     /// Single Localization, 3 Layersets
@@ -429,7 +429,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowBackwardSquareFill = SFSymbol(rawValue: "arrow.backward.square.fill")
+    static var arrowBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.backward.square.fill") }
 
     /// 􀧡
     /// Single Localization, 2 Layersets
@@ -442,7 +442,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadClockwiseHeart")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadClockwiseHeart")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadClockwiseHeart")
-    static let arrowClockwiseHeart = SFSymbol(rawValue: "arrow.clockwise.heart")
+    static var arrowClockwiseHeart: SFSymbol { .init(rawValue: "arrow.clockwise.heart") }
 
     /// 􀧢
     /// Single Localization, 3 Layersets
@@ -456,7 +456,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadClockwiseHeartFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadClockwiseHeartFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadClockwiseHeartFill")
-    static let arrowClockwiseHeartFill = SFSymbol(rawValue: "arrow.clockwise.heart.fill")
+    static var arrowClockwiseHeartFill: SFSymbol { .init(rawValue: "arrow.clockwise.heart.fill") }
 
     /// 􀯴
     /// Single Localization, 2 Layersets
@@ -464,7 +464,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownApp = SFSymbol(rawValue: "arrow.down.app")
+    static var arrowDownApp: SFSymbol { .init(rawValue: "arrow.down.app") }
 
     /// 􀯵
     /// Single Localization, 3 Layersets
@@ -473,14 +473,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownAppFill = SFSymbol(rawValue: "arrow.down.app.fill")
+    static var arrowDownAppFill: SFSymbol { .init(rawValue: "arrow.down.app.fill") }
 
     /// 􀱃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownBackward = SFSymbol(rawValue: "arrow.down.backward")
+    static var arrowDownBackward: SFSymbol { .init(rawValue: "arrow.down.backward") }
 
     /// 􀱄
     /// Single Localization, 2 Layersets
@@ -488,7 +488,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownBackwardCircle = SFSymbol(rawValue: "arrow.down.backward.circle")
+    static var arrowDownBackwardCircle: SFSymbol { .init(rawValue: "arrow.down.backward.circle") }
 
     /// 􀱅
     /// Single Localization, 3 Layersets
@@ -497,7 +497,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownBackwardCircleFill = SFSymbol(rawValue: "arrow.down.backward.circle.fill")
+    static var arrowDownBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.down.backward.circle.fill") }
 
     /// 􀱆
     /// Single Localization, 2 Layersets
@@ -505,7 +505,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownBackwardSquare = SFSymbol(rawValue: "arrow.down.backward.square")
+    static var arrowDownBackwardSquare: SFSymbol { .init(rawValue: "arrow.down.backward.square") }
 
     /// 􀱇
     /// Single Localization, 3 Layersets
@@ -514,21 +514,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownBackwardSquareFill = SFSymbol(rawValue: "arrow.down.backward.square.fill")
+    static var arrowDownBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.down.backward.square.fill") }
 
     /// 􀱈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownForward = SFSymbol(rawValue: "arrow.down.forward")
+    static var arrowDownForward: SFSymbol { .init(rawValue: "arrow.down.forward") }
 
     /// 􀱻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownForwardAndArrowUpBackward = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward")
+    static var arrowDownForwardAndArrowUpBackward: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward") }
 
     /// 􀱼
     /// Single Localization, 2 Layersets
@@ -536,7 +536,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownForwardAndArrowUpBackwardCircle = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.circle")
+    static var arrowDownForwardAndArrowUpBackwardCircle: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.circle") }
 
     /// 􀱽
     /// Single Localization, 3 Layersets
@@ -545,7 +545,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownForwardAndArrowUpBackwardCircleFill = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.circle.fill")
+    static var arrowDownForwardAndArrowUpBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.circle.fill") }
 
     /// 􀱉
     /// Single Localization, 2 Layersets
@@ -553,7 +553,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownForwardCircle = SFSymbol(rawValue: "arrow.down.forward.circle")
+    static var arrowDownForwardCircle: SFSymbol { .init(rawValue: "arrow.down.forward.circle") }
 
     /// 􀱊
     /// Single Localization, 3 Layersets
@@ -562,7 +562,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownForwardCircleFill = SFSymbol(rawValue: "arrow.down.forward.circle.fill")
+    static var arrowDownForwardCircleFill: SFSymbol { .init(rawValue: "arrow.down.forward.circle.fill") }
 
     /// 􀱋
     /// Single Localization, 2 Layersets
@@ -570,7 +570,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownForwardSquare = SFSymbol(rawValue: "arrow.down.forward.square")
+    static var arrowDownForwardSquare: SFSymbol { .init(rawValue: "arrow.down.forward.square") }
 
     /// 􀱌
     /// Single Localization, 3 Layersets
@@ -579,7 +579,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownForwardSquareFill = SFSymbol(rawValue: "arrow.down.forward.square.fill")
+    static var arrowDownForwardSquareFill: SFSymbol { .init(rawValue: "arrow.down.forward.square.fill") }
 
     /// 􀲗
     /// Single Localization, 2 Layersets
@@ -587,7 +587,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownHeart = SFSymbol(rawValue: "arrow.down.heart")
+    static var arrowDownHeart: SFSymbol { .init(rawValue: "arrow.down.heart") }
 
     /// 􀲘
     /// Single Localization, 3 Layersets
@@ -596,7 +596,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowDownHeartFill = SFSymbol(rawValue: "arrow.down.heart.fill")
+    static var arrowDownHeartFill: SFSymbol { .init(rawValue: "arrow.down.heart.fill") }
 
     /// 􀫞
     /// Single Localization, 2 Layersets
@@ -604,7 +604,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownRightAndArrowUpLeftCircle = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.circle")
+    static var arrowDownRightAndArrowUpLeftCircle: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.circle") }
 
     /// 􀫟
     /// Single Localization, 3 Layersets
@@ -613,14 +613,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowDownRightAndArrowUpLeftCircleFill = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.circle.fill")
+    static var arrowDownRightAndArrowUpLeftCircleFill: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.circle.fill") }
 
     /// 􀰑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowForward = SFSymbol(rawValue: "arrow.forward")
+    static var arrowForward: SFSymbol { .init(rawValue: "arrow.forward") }
 
     /// 􀰒
     /// Single Localization, 2 Layersets
@@ -628,7 +628,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowForwardCircle = SFSymbol(rawValue: "arrow.forward.circle")
+    static var arrowForwardCircle: SFSymbol { .init(rawValue: "arrow.forward.circle") }
 
     /// 􀰓
     /// Single Localization, 3 Layersets
@@ -637,7 +637,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowForwardCircleFill = SFSymbol(rawValue: "arrow.forward.circle.fill")
+    static var arrowForwardCircleFill: SFSymbol { .init(rawValue: "arrow.forward.circle.fill") }
 
     /// 􀰔
     /// Single Localization, 2 Layersets
@@ -645,7 +645,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowForwardSquare = SFSymbol(rawValue: "arrow.forward.square")
+    static var arrowForwardSquare: SFSymbol { .init(rawValue: "arrow.forward.square") }
 
     /// 􀰕
     /// Single Localization, 3 Layersets
@@ -654,7 +654,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowForwardSquareFill = SFSymbol(rawValue: "arrow.forward.square.fill")
+    static var arrowForwardSquareFill: SFSymbol { .init(rawValue: "arrow.forward.square.fill") }
 
     /// 􀞒
     /// Single Localization, 2 Layersets
@@ -667,7 +667,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRight")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRight")
-    static let arrowLeftAndRightRighttriangleLeftRighttriangleRight = SFSymbol(rawValue: "arrow.left.and.right.righttriangle.left.righttriangle.right")
+    static var arrowLeftAndRightRighttriangleLeftRighttriangleRight: SFSymbol { .init(rawValue: "arrow.left.and.right.righttriangle.left.righttriangle.right") }
 
     /// 􀞓
     /// Single Localization, 2 Layersets
@@ -680,7 +680,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill")
-    static let arrowLeftAndRightRighttriangleLeftRighttriangleRightFill = SFSymbol(rawValue: "arrow.left.and.right.righttriangle.left.righttriangle.right.fill")
+    static var arrowLeftAndRightRighttriangleLeftRighttriangleRightFill: SFSymbol { .init(rawValue: "arrow.left.and.right.righttriangle.left.righttriangle.right.fill") }
 
     /// 􀄭
     /// Single Localization, 2 Layersets
@@ -688,7 +688,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowLeftArrowRight = SFSymbol(rawValue: "arrow.left.arrow.right")
+    static var arrowLeftArrowRight: SFSymbol { .init(rawValue: "arrow.left.arrow.right") }
 
     /// 􀂀
     /// Single Localization, 2 Layersets
@@ -696,7 +696,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftArrowRightCircle = SFSymbol(rawValue: "arrow.left.arrow.right.circle")
+    static var arrowLeftArrowRightCircle: SFSymbol { .init(rawValue: "arrow.left.arrow.right.circle") }
 
     /// 􀂁
     /// Single Localization, 3 Layersets
@@ -705,7 +705,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftArrowRightCircleFill = SFSymbol(rawValue: "arrow.left.arrow.right.circle.fill")
+    static var arrowLeftArrowRightCircleFill: SFSymbol { .init(rawValue: "arrow.left.arrow.right.circle.fill") }
 
     /// 􀄐
     /// Single Localization, 2 Layersets
@@ -713,7 +713,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowLeftArrowRightSquare = SFSymbol(rawValue: "arrow.left.arrow.right.square")
+    static var arrowLeftArrowRightSquare: SFSymbol { .init(rawValue: "arrow.left.arrow.right.square") }
 
     /// 􀄑
     /// Single Localization, 3 Layersets
@@ -722,7 +722,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowLeftArrowRightSquareFill = SFSymbol(rawValue: "arrow.left.arrow.right.square.fill")
+    static var arrowLeftArrowRightSquareFill: SFSymbol { .init(rawValue: "arrow.left.arrow.right.square.fill") }
 
     /// 􀣁
     /// Single Localization, Single Layerset
@@ -734,7 +734,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadRectanglepath")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadRectanglepath")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadRectanglepath")
-    static let arrowRectanglepath = SFSymbol(rawValue: "arrow.rectanglepath")
+    static var arrowRectanglepath: SFSymbol { .init(rawValue: "arrow.rectanglepath") }
 
     /// 􀫵
     /// Single Localization, 3 Layersets
@@ -748,7 +748,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowRightPageOnClipboard")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowRightPageOnClipboard")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowRightPageOnClipboard")
-    static let arrowRightDocOnClipboard = SFSymbol(rawValue: "arrow.right.doc.on.clipboard")
+    static var arrowRightDocOnClipboard: SFSymbol { .init(rawValue: "arrow.right.doc.on.clipboard") }
 
     /// 􀊯
     /// Single Localization, Single Layerset
@@ -760,7 +760,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90")
-    static let arrowTriangle2Circlepath = SFSymbol(rawValue: "arrow.triangle.2.circlepath")
+    static var arrowTriangle2Circlepath: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath") }
 
     /// 􀌢
     /// Single Localization, 2 Layersets
@@ -773,7 +773,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90Camera")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90Camera")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90Camera")
-    static let arrowTriangle2CirclepathCamera = SFSymbol(rawValue: "arrow.triangle.2.circlepath.camera")
+    static var arrowTriangle2CirclepathCamera: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.camera") }
 
     /// 􀌣
     /// Single Localization, 3 Layersets
@@ -787,7 +787,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90CameraFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90CameraFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90CameraFill")
-    static let arrowTriangle2CirclepathCameraFill = SFSymbol(rawValue: "arrow.triangle.2.circlepath.camera.fill")
+    static var arrowTriangle2CirclepathCameraFill: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.camera.fill") }
 
     /// 􀖊
     /// Single Localization, 2 Layersets
@@ -800,7 +800,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90Circle")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90Circle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90Circle")
-    static let arrowTriangle2CirclepathCircle = SFSymbol(rawValue: "arrow.triangle.2.circlepath.circle")
+    static var arrowTriangle2CirclepathCircle: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.circle") }
 
     /// 􀖋
     /// Single Localization, 3 Layersets
@@ -814,7 +814,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90CircleFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90CircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90CircleFill")
-    static let arrowTriangle2CirclepathCircleFill = SFSymbol(rawValue: "arrow.triangle.2.circlepath.circle.fill")
+    static var arrowTriangle2CirclepathCircleFill: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.circle.fill") }
 
     /// 􀫷
     /// Single Localization, 3 Layersets
@@ -828,7 +828,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90PageOnClipboard")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90PageOnClipboard")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90PageOnClipboard")
-    static let arrowTriangle2CirclepathDocOnClipboard = SFSymbol(rawValue: "arrow.triangle.2.circlepath.doc.on.clipboard")
+    static var arrowTriangle2CirclepathDocOnClipboard: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.doc.on.clipboard") }
 
     /// 􀙠
     /// Single Localization, Single Layerset
@@ -840,7 +840,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadBranch")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadBranch")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadBranch")
-    static let arrowTriangleBranch = SFSymbol(rawValue: "arrow.triangle.branch")
+    static var arrowTriangleBranch: SFSymbol { .init(rawValue: "arrow.triangle.branch") }
 
     /// 􀤖
     /// Single Localization, Single Layerset
@@ -852,7 +852,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadToprightCapsulepathClockwise")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadToprightCapsulepathClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadToprightCapsulepathClockwise")
-    static let arrowTriangleCapsulepath = SFSymbol(rawValue: "arrow.triangle.capsulepath")
+    static var arrowTriangleCapsulepath: SFSymbol { .init(rawValue: "arrow.triangle.capsulepath") }
 
     /// 􀖄
     /// Single Localization, Single Layerset
@@ -864,7 +864,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadMerge")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadMerge")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadMerge")
-    static let arrowTriangleMerge = SFSymbol(rawValue: "arrow.triangle.merge")
+    static var arrowTriangleMerge: SFSymbol { .init(rawValue: "arrow.triangle.merge") }
 
     /// 􀙡
     /// Single Localization, Single Layerset
@@ -876,7 +876,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadPull")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadPull")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadPull")
-    static let arrowTrianglePull = SFSymbol(rawValue: "arrow.triangle.pull")
+    static var arrowTrianglePull: SFSymbol { .init(rawValue: "arrow.triangle.pull") }
 
     /// 􀖅
     /// Single Localization, Single Layerset
@@ -888,7 +888,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadSwap")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadSwap")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadSwap")
-    static let arrowTriangleSwap = SFSymbol(rawValue: "arrow.triangle.swap")
+    static var arrowTriangleSwap: SFSymbol { .init(rawValue: "arrow.triangle.swap") }
 
     /// 􀟷
     /// Single Localization, 3 Layersets
@@ -902,7 +902,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadTurnUpRightCircle")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadTurnUpRightCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadTurnUpRightCircle")
-    static let arrowTriangleTurnUpRightCircle = SFSymbol(rawValue: "arrow.triangle.turn.up.right.circle")
+    static var arrowTriangleTurnUpRightCircle: SFSymbol { .init(rawValue: "arrow.triangle.turn.up.right.circle") }
 
     /// 􀟸
     /// Single Localization, 3 Layersets
@@ -916,7 +916,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadTurnUpRightCircleFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadTurnUpRightCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadTurnUpRightCircleFill")
-    static let arrowTriangleTurnUpRightCircleFill = SFSymbol(rawValue: "arrow.triangle.turn.up.right.circle.fill")
+    static var arrowTriangleTurnUpRightCircleFill: SFSymbol { .init(rawValue: "arrow.triangle.turn.up.right.circle.fill") }
 
     /// 􀙞
     /// Single Localization, 2 Layersets
@@ -929,7 +929,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadTurnUpRightDiamond")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadTurnUpRightDiamond")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadTurnUpRightDiamond")
-    static let arrowTriangleTurnUpRightDiamond = SFSymbol(rawValue: "arrow.triangle.turn.up.right.diamond")
+    static var arrowTriangleTurnUpRightDiamond: SFSymbol { .init(rawValue: "arrow.triangle.turn.up.right.diamond") }
 
     /// 􀙟
     /// Single Localization, 3 Layersets
@@ -943,7 +943,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadTurnUpRightDiamondFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadTurnUpRightDiamondFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadTurnUpRightDiamondFill")
-    static let arrowTriangleTurnUpRightDiamondFill = SFSymbol(rawValue: "arrow.triangle.turn.up.right.diamond.fill")
+    static var arrowTriangleTurnUpRightDiamondFill: SFSymbol { .init(rawValue: "arrow.triangle.turn.up.right.diamond.fill") }
 
     /// 􀬫
     /// Single Localization, 2 Layersets
@@ -951,7 +951,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowTurnUpForwardIphone = SFSymbol(rawValue: "arrow.turn.up.forward.iphone")
+    static var arrowTurnUpForwardIphone: SFSymbol { .init(rawValue: "arrow.turn.up.forward.iphone") }
 
     /// 􀬬
     /// Single Localization, 2 Layersets
@@ -959,14 +959,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowTurnUpForwardIphoneFill = SFSymbol(rawValue: "arrow.turn.up.forward.iphone.fill")
+    static var arrowTurnUpForwardIphoneFill: SFSymbol { .init(rawValue: "arrow.turn.up.forward.iphone.fill") }
 
     /// 􀧐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpAndDownAndArrowLeftAndRight = SFSymbol(rawValue: "arrow.up.and.down.and.arrow.left.and.right")
+    static var arrowUpAndDownAndArrowLeftAndRight: SFSymbol { .init(rawValue: "arrow.up.and.down.and.arrow.left.and.right") }
 
     /// 􀟩
     /// Single Localization, Single Layerset
@@ -978,7 +978,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "arrowUpAndDownRighttriangleUpRighttriangleDownFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "arrowUpAndDownRighttriangleUpRighttriangleDownFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowUpAndDownRighttriangleUpRighttriangleDownFill")
-    static let arrowUpAndDownRighttriangleUpFillRighttriangleDownFill = SFSymbol(rawValue: "arrow.up.and.down.righttriangle.up.fill.righttriangle.down.fill")
+    static var arrowUpAndDownRighttriangleUpFillRighttriangleDownFill: SFSymbol { .init(rawValue: "arrow.up.and.down.righttriangle.up.fill.righttriangle.down.fill") }
 
     /// 􀟨
     /// Single Localization, 2 Layersets
@@ -991,7 +991,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDown")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDown")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDown")
-    static let arrowUpAndDownRighttriangleUpRighttriangleDown = SFSymbol(rawValue: "arrow.up.and.down.righttriangle.up.righttriangle.down")
+    static var arrowUpAndDownRighttriangleUpRighttriangleDown: SFSymbol { .init(rawValue: "arrow.up.and.down.righttriangle.up.righttriangle.down") }
 
     /// 􀪨
     /// Single Localization, 2 Layersets
@@ -999,7 +999,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndPersonRectanglePortrait = SFSymbol(rawValue: "arrow.up.and.person.rectangle.portrait")
+    static var arrowUpAndPersonRectanglePortrait: SFSymbol { .init(rawValue: "arrow.up.and.person.rectangle.portrait") }
 
     /// 􀪪
     /// Single Localization, 2 Layersets
@@ -1007,7 +1007,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndPersonRectangleTurnLeft = SFSymbol(rawValue: "arrow.up.and.person.rectangle.turn.left")
+    static var arrowUpAndPersonRectangleTurnLeft: SFSymbol { .init(rawValue: "arrow.up.and.person.rectangle.turn.left") }
 
     /// 􀪩
     /// Single Localization, 2 Layersets
@@ -1015,21 +1015,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpAndPersonRectangleTurnRight = SFSymbol(rawValue: "arrow.up.and.person.rectangle.turn.right")
+    static var arrowUpAndPersonRectangleTurnRight: SFSymbol { .init(rawValue: "arrow.up.and.person.rectangle.turn.right") }
 
     /// 􀰹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpBackward = SFSymbol(rawValue: "arrow.up.backward")
+    static var arrowUpBackward: SFSymbol { .init(rawValue: "arrow.up.backward") }
 
     /// 􀱶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpBackwardAndArrowDownForward = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward")
+    static var arrowUpBackwardAndArrowDownForward: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward") }
 
     /// 􀱷
     /// Single Localization, 2 Layersets
@@ -1037,7 +1037,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBackwardAndArrowDownForwardCircle = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.circle")
+    static var arrowUpBackwardAndArrowDownForwardCircle: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.circle") }
 
     /// 􀱸
     /// Single Localization, 3 Layersets
@@ -1046,7 +1046,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBackwardAndArrowDownForwardCircleFill = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.circle.fill")
+    static var arrowUpBackwardAndArrowDownForwardCircleFill: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.circle.fill") }
 
     /// 􀰺
     /// Single Localization, 2 Layersets
@@ -1054,7 +1054,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBackwardCircle = SFSymbol(rawValue: "arrow.up.backward.circle")
+    static var arrowUpBackwardCircle: SFSymbol { .init(rawValue: "arrow.up.backward.circle") }
 
     /// 􀰻
     /// Single Localization, 3 Layersets
@@ -1063,7 +1063,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBackwardCircleFill = SFSymbol(rawValue: "arrow.up.backward.circle.fill")
+    static var arrowUpBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.up.backward.circle.fill") }
 
     /// 􀰼
     /// Single Localization, 2 Layersets
@@ -1071,7 +1071,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpBackwardSquare = SFSymbol(rawValue: "arrow.up.backward.square")
+    static var arrowUpBackwardSquare: SFSymbol { .init(rawValue: "arrow.up.backward.square") }
 
     /// 􀰽
     /// Single Localization, 3 Layersets
@@ -1080,7 +1080,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpBackwardSquareFill = SFSymbol(rawValue: "arrow.up.backward.square.fill")
+    static var arrowUpBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.up.backward.square.fill") }
 
     /// 􀫶
     /// Single Localization, 3 Layersets
@@ -1094,14 +1094,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "arrowUpPageOnClipboard")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "arrowUpPageOnClipboard")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowUpPageOnClipboard")
-    static let arrowUpDocOnClipboard = SFSymbol(rawValue: "arrow.up.doc.on.clipboard")
+    static var arrowUpDocOnClipboard: SFSymbol { .init(rawValue: "arrow.up.doc.on.clipboard") }
 
     /// 􀰾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpForward = SFSymbol(rawValue: "arrow.up.forward")
+    static var arrowUpForward: SFSymbol { .init(rawValue: "arrow.up.forward") }
 
     /// 􀮵
     /// Single Localization, 2 Layersets
@@ -1109,7 +1109,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpForwardApp = SFSymbol(rawValue: "arrow.up.forward.app")
+    static var arrowUpForwardApp: SFSymbol { .init(rawValue: "arrow.up.forward.app") }
 
     /// 􀮶
     /// Single Localization, 3 Layersets
@@ -1118,7 +1118,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpForwardAppFill = SFSymbol(rawValue: "arrow.up.forward.app.fill")
+    static var arrowUpForwardAppFill: SFSymbol { .init(rawValue: "arrow.up.forward.app.fill") }
 
     /// 􀰿
     /// Single Localization, 2 Layersets
@@ -1126,7 +1126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpForwardCircle = SFSymbol(rawValue: "arrow.up.forward.circle")
+    static var arrowUpForwardCircle: SFSymbol { .init(rawValue: "arrow.up.forward.circle") }
 
     /// 􀱀
     /// Single Localization, 3 Layersets
@@ -1135,7 +1135,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpForwardCircleFill = SFSymbol(rawValue: "arrow.up.forward.circle.fill")
+    static var arrowUpForwardCircleFill: SFSymbol { .init(rawValue: "arrow.up.forward.circle.fill") }
 
     /// 􀱁
     /// Single Localization, 2 Layersets
@@ -1143,7 +1143,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpForwardSquare = SFSymbol(rawValue: "arrow.up.forward.square")
+    static var arrowUpForwardSquare: SFSymbol { .init(rawValue: "arrow.up.forward.square") }
 
     /// 􀱂
     /// Single Localization, 3 Layersets
@@ -1152,7 +1152,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpForwardSquareFill = SFSymbol(rawValue: "arrow.up.forward.square.fill")
+    static var arrowUpForwardSquareFill: SFSymbol { .init(rawValue: "arrow.up.forward.square.fill") }
 
     /// 􀲕
     /// Single Localization, 2 Layersets
@@ -1160,7 +1160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpHeart = SFSymbol(rawValue: "arrow.up.heart")
+    static var arrowUpHeart: SFSymbol { .init(rawValue: "arrow.up.heart") }
 
     /// 􀲖
     /// Single Localization, 3 Layersets
@@ -1169,7 +1169,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpHeartFill = SFSymbol(rawValue: "arrow.up.heart.fill")
+    static var arrowUpHeartFill: SFSymbol { .init(rawValue: "arrow.up.heart.fill") }
 
     /// 􀧛
     /// Single Localization, 2 Layersets
@@ -1177,7 +1177,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpLeftAndArrowDownRightCircle = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.circle")
+    static var arrowUpLeftAndArrowDownRightCircle: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.circle") }
 
     /// 􀧜
     /// Single Localization, 3 Layersets
@@ -1186,14 +1186,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpLeftAndArrowDownRightCircleFill = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.circle.fill")
+    static var arrowUpLeftAndArrowDownRightCircleFill: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.circle.fill") }
 
     /// 􀬑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpLeftAndDownRightAndArrowUpRightAndDownLeft = SFSymbol(rawValue: "arrow.up.left.and.down.right.and.arrow.up.right.and.down.left")
+    static var arrowUpLeftAndDownRightAndArrowUpRightAndDownLeft: SFSymbol { .init(rawValue: "arrow.up.left.and.down.right.and.arrow.up.right.and.down.left") }
 
     /// 􀥩
     /// Single Localization, 2 Layersets
@@ -1201,7 +1201,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let arrowUpLeftAndDownRightMagnifyingglass = SFSymbol(rawValue: "arrow.up.left.and.down.right.magnifyingglass")
+    static var arrowUpLeftAndDownRightMagnifyingglass: SFSymbol { .init(rawValue: "arrow.up.left.and.down.right.magnifyingglass") }
 
     /// 􀜃
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1211,7 +1211,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let arrowUpMessage = SFSymbol(rawValue: "arrow.up.message")
+    static var arrowUpMessage: SFSymbol { .init(rawValue: "arrow.up.message") }
 
     /// 􀜄
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1222,7 +1222,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let arrowUpMessageFill = SFSymbol(rawValue: "arrow.up.message.fill")
+    static var arrowUpMessageFill: SFSymbol { .init(rawValue: "arrow.up.message.fill") }
 
     /// 􀢿
     /// Single Localization, 2 Layersets
@@ -1230,7 +1230,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUpRightAndArrowDownLeftRectangle = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.rectangle")
+    static var arrowUpRightAndArrowDownLeftRectangle: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.rectangle") }
 
     /// 􀣀
     /// Single Localization, 3 Layersets
@@ -1239,14 +1239,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUpRightAndArrowDownLeftRectangleFill = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.rectangle.fill")
+    static var arrowUpRightAndArrowDownLeftRectangleFill: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.rectangle.fill") }
 
     /// 􀱍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnBackward = SFSymbol(rawValue: "arrow.uturn.backward")
+    static var arrowUturnBackward: SFSymbol { .init(rawValue: "arrow.uturn.backward") }
 
     /// 􀱎
     /// Single Localization, 2 Layersets
@@ -1254,7 +1254,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnBackwardCircle = SFSymbol(rawValue: "arrow.uturn.backward.circle")
+    static var arrowUturnBackwardCircle: SFSymbol { .init(rawValue: "arrow.uturn.backward.circle") }
 
     /// 􀱐
     /// Single Localization, 3 Layersets
@@ -1263,7 +1263,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnBackwardCircleBadgeEllipsis = SFSymbol(rawValue: "arrow.uturn.backward.circle.badge.ellipsis")
+    static var arrowUturnBackwardCircleBadgeEllipsis: SFSymbol { .init(rawValue: "arrow.uturn.backward.circle.badge.ellipsis") }
 
     /// 􀱏
     /// Single Localization, 3 Layersets
@@ -1272,7 +1272,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnBackwardCircleFill = SFSymbol(rawValue: "arrow.uturn.backward.circle.fill")
+    static var arrowUturnBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.backward.circle.fill") }
 
     /// 􀱑
     /// Single Localization, 2 Layersets
@@ -1280,7 +1280,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnBackwardSquare = SFSymbol(rawValue: "arrow.uturn.backward.square")
+    static var arrowUturnBackwardSquare: SFSymbol { .init(rawValue: "arrow.uturn.backward.square") }
 
     /// 􀱒
     /// Single Localization, 3 Layersets
@@ -1289,14 +1289,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnBackwardSquareFill = SFSymbol(rawValue: "arrow.uturn.backward.square.fill")
+    static var arrowUturnBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.backward.square.fill") }
 
     /// 􀱓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUturnForward = SFSymbol(rawValue: "arrow.uturn.forward")
+    static var arrowUturnForward: SFSymbol { .init(rawValue: "arrow.uturn.forward") }
 
     /// 􀱔
     /// Single Localization, 2 Layersets
@@ -1304,7 +1304,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnForwardCircle = SFSymbol(rawValue: "arrow.uturn.forward.circle")
+    static var arrowUturnForwardCircle: SFSymbol { .init(rawValue: "arrow.uturn.forward.circle") }
 
     /// 􀱕
     /// Single Localization, 3 Layersets
@@ -1313,7 +1313,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnForwardCircleFill = SFSymbol(rawValue: "arrow.uturn.forward.circle.fill")
+    static var arrowUturnForwardCircleFill: SFSymbol { .init(rawValue: "arrow.uturn.forward.circle.fill") }
 
     /// 􀱖
     /// Single Localization, 2 Layersets
@@ -1321,7 +1321,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowUturnForwardSquare = SFSymbol(rawValue: "arrow.uturn.forward.square")
+    static var arrowUturnForwardSquare: SFSymbol { .init(rawValue: "arrow.uturn.forward.square") }
 
     /// 􀱗
     /// Single Localization, 3 Layersets
@@ -1330,49 +1330,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowUturnForwardSquareFill = SFSymbol(rawValue: "arrow.uturn.forward.square.fill")
+    static var arrowUturnForwardSquareFill: SFSymbol { .init(rawValue: "arrow.uturn.forward.square.fill") }
 
     /// 􀰨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBounceForward = SFSymbol(rawValue: "arrowshape.bounce.forward")
+    static var arrowshapeBounceForward: SFSymbol { .init(rawValue: "arrowshape.bounce.forward") }
 
     /// 􀰩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBounceForwardFill = SFSymbol(rawValue: "arrowshape.bounce.forward.fill")
+    static var arrowshapeBounceForwardFill: SFSymbol { .init(rawValue: "arrowshape.bounce.forward.fill") }
 
     /// 􀉙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBounceRight = SFSymbol(rawValue: "arrowshape.bounce.right")
+    static var arrowshapeBounceRight: SFSymbol { .init(rawValue: "arrowshape.bounce.right") }
 
     /// 􀒑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBounceRightFill = SFSymbol(rawValue: "arrowshape.bounce.right.fill")
+    static var arrowshapeBounceRightFill: SFSymbol { .init(rawValue: "arrowshape.bounce.right.fill") }
 
     /// 􀰚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpBackward = SFSymbol(rawValue: "arrowshape.turn.up.backward")
+    static var arrowshapeTurnUpBackward: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward") }
 
     /// 􀰢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpBackward2 = SFSymbol(rawValue: "arrowshape.turn.up.backward.2")
+    static var arrowshapeTurnUpBackward2: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.2") }
 
     /// 􀰤
     /// Single Localization, 2 Layersets
@@ -1380,7 +1380,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpBackward2Circle = SFSymbol(rawValue: "arrowshape.turn.up.backward.2.circle")
+    static var arrowshapeTurnUpBackward2Circle: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.2.circle") }
 
     /// 􀰥
     /// Single Localization, 3 Layersets
@@ -1389,14 +1389,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpBackward2CircleFill = SFSymbol(rawValue: "arrowshape.turn.up.backward.2.circle.fill")
+    static var arrowshapeTurnUpBackward2CircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.2.circle.fill") }
 
     /// 􀰣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpBackward2Fill = SFSymbol(rawValue: "arrowshape.turn.up.backward.2.fill")
+    static var arrowshapeTurnUpBackward2Fill: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.2.fill") }
 
     /// 􀰜
     /// Single Localization, 2 Layersets
@@ -1404,7 +1404,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpBackwardCircle = SFSymbol(rawValue: "arrowshape.turn.up.backward.circle")
+    static var arrowshapeTurnUpBackwardCircle: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.circle") }
 
     /// 􀰝
     /// Single Localization, 3 Layersets
@@ -1413,21 +1413,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpBackwardCircleFill = SFSymbol(rawValue: "arrowshape.turn.up.backward.circle.fill")
+    static var arrowshapeTurnUpBackwardCircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.circle.fill") }
 
     /// 􀰛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpBackwardFill = SFSymbol(rawValue: "arrowshape.turn.up.backward.fill")
+    static var arrowshapeTurnUpBackwardFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.backward.fill") }
 
     /// 􀰞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpForward = SFSymbol(rawValue: "arrowshape.turn.up.forward")
+    static var arrowshapeTurnUpForward: SFSymbol { .init(rawValue: "arrowshape.turn.up.forward") }
 
     /// 􀰠
     /// Single Localization, 2 Layersets
@@ -1435,7 +1435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpForwardCircle = SFSymbol(rawValue: "arrowshape.turn.up.forward.circle")
+    static var arrowshapeTurnUpForwardCircle: SFSymbol { .init(rawValue: "arrowshape.turn.up.forward.circle") }
 
     /// 􀰡
     /// Single Localization, 3 Layersets
@@ -1444,14 +1444,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpForwardCircleFill = SFSymbol(rawValue: "arrowshape.turn.up.forward.circle.fill")
+    static var arrowshapeTurnUpForwardCircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.forward.circle.fill") }
 
     /// 􀰟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeTurnUpForwardFill = SFSymbol(rawValue: "arrowshape.turn.up.forward.fill")
+    static var arrowshapeTurnUpForwardFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.forward.fill") }
 
     /// 􀉖
     /// Single Localization, 2 Layersets
@@ -1459,7 +1459,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpLeft2Circle = SFSymbol(rawValue: "arrowshape.turn.up.left.2.circle")
+    static var arrowshapeTurnUpLeft2Circle: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.2.circle") }
 
     /// 􀉗
     /// Single Localization, 3 Layersets
@@ -1468,42 +1468,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowshapeTurnUpLeft2CircleFill = SFSymbol(rawValue: "arrowshape.turn.up.left.2.circle.fill")
+    static var arrowshapeTurnUpLeft2CircleFill: SFSymbol { .init(rawValue: "arrowshape.turn.up.left.2.circle.fill") }
 
     /// 􀰦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeZigzagForward = SFSymbol(rawValue: "arrowshape.zigzag.forward")
+    static var arrowshapeZigzagForward: SFSymbol { .init(rawValue: "arrowshape.zigzag.forward") }
 
     /// 􀰧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeZigzagForwardFill = SFSymbol(rawValue: "arrowshape.zigzag.forward.fill")
+    static var arrowshapeZigzagForwardFill: SFSymbol { .init(rawValue: "arrowshape.zigzag.forward.fill") }
 
     /// 􀉘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeZigzagRight = SFSymbol(rawValue: "arrowshape.zigzag.right")
+    static var arrowshapeZigzagRight: SFSymbol { .init(rawValue: "arrowshape.zigzag.right") }
 
     /// 􀒐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeZigzagRightFill = SFSymbol(rawValue: "arrowshape.zigzag.right.fill")
+    static var arrowshapeZigzagRightFill: SFSymbol { .init(rawValue: "arrowshape.zigzag.right.fill") }
 
     /// 􀰀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleBackward = SFSymbol(rawValue: "arrowtriangle.backward")
+    static var arrowtriangleBackward: SFSymbol { .init(rawValue: "arrowtriangle.backward") }
 
     /// 􀰂
     /// Single Localization, 2 Layersets
@@ -1511,7 +1511,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleBackwardCircle = SFSymbol(rawValue: "arrowtriangle.backward.circle")
+    static var arrowtriangleBackwardCircle: SFSymbol { .init(rawValue: "arrowtriangle.backward.circle") }
 
     /// 􀰃
     /// Single Localization, 3 Layersets
@@ -1520,14 +1520,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleBackwardCircleFill = SFSymbol(rawValue: "arrowtriangle.backward.circle.fill")
+    static var arrowtriangleBackwardCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.backward.circle.fill") }
 
     /// 􀰁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleBackwardFill = SFSymbol(rawValue: "arrowtriangle.backward.fill")
+    static var arrowtriangleBackwardFill: SFSymbol { .init(rawValue: "arrowtriangle.backward.fill") }
 
     /// 􀰄
     /// Single Localization, 2 Layersets
@@ -1535,7 +1535,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleBackwardSquare = SFSymbol(rawValue: "arrowtriangle.backward.square")
+    static var arrowtriangleBackwardSquare: SFSymbol { .init(rawValue: "arrowtriangle.backward.square") }
 
     /// 􀰅
     /// Single Localization, 3 Layersets
@@ -1544,14 +1544,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleBackwardSquareFill = SFSymbol(rawValue: "arrowtriangle.backward.square.fill")
+    static var arrowtriangleBackwardSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.backward.square.fill") }
 
     /// 􀰆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleForward = SFSymbol(rawValue: "arrowtriangle.forward")
+    static var arrowtriangleForward: SFSymbol { .init(rawValue: "arrowtriangle.forward") }
 
     /// 􀰈
     /// Single Localization, 2 Layersets
@@ -1559,7 +1559,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleForwardCircle = SFSymbol(rawValue: "arrowtriangle.forward.circle")
+    static var arrowtriangleForwardCircle: SFSymbol { .init(rawValue: "arrowtriangle.forward.circle") }
 
     /// 􀰉
     /// Single Localization, 3 Layersets
@@ -1568,14 +1568,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleForwardCircleFill = SFSymbol(rawValue: "arrowtriangle.forward.circle.fill")
+    static var arrowtriangleForwardCircleFill: SFSymbol { .init(rawValue: "arrowtriangle.forward.circle.fill") }
 
     /// 􀰇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleForwardFill = SFSymbol(rawValue: "arrowtriangle.forward.fill")
+    static var arrowtriangleForwardFill: SFSymbol { .init(rawValue: "arrowtriangle.forward.fill") }
 
     /// 􀰊
     /// Single Localization, 2 Layersets
@@ -1583,7 +1583,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let arrowtriangleForwardSquare = SFSymbol(rawValue: "arrowtriangle.forward.square")
+    static var arrowtriangleForwardSquare: SFSymbol { .init(rawValue: "arrowtriangle.forward.square") }
 
     /// 􀰋
     /// Single Localization, 3 Layersets
@@ -1592,14 +1592,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let arrowtriangleForwardSquareFill = SFSymbol(rawValue: "arrowtriangle.forward.square.fill")
+    static var arrowtriangleForwardSquareFill: SFSymbol { .init(rawValue: "arrowtriangle.forward.square.fill") }
 
     /// 􀠉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleLeftAndLineVerticalAndArrowtriangleRight = SFSymbol(rawValue: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right")
+    static var arrowtriangleLeftAndLineVerticalAndArrowtriangleRight: SFSymbol { .init(rawValue: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right") }
 
     /// 􀟦
     /// Single Localization, Single Layerset
@@ -1611,14 +1611,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill")
-    static let arrowtriangleLeftFillAndLineVerticalAndArrowtriangleRightFill = SFSymbol(rawValue: "arrowtriangle.left.fill.and.line.vertical.and.arrowtriangle.right.fill")
+    static var arrowtriangleLeftFillAndLineVerticalAndArrowtriangleRightFill: SFSymbol { .init(rawValue: "arrowtriangle.left.fill.and.line.vertical.and.arrowtriangle.right.fill") }
 
     /// 􀠊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleRightAndLineVerticalAndArrowtriangleLeft = SFSymbol(rawValue: "arrowtriangle.right.and.line.vertical.and.arrowtriangle.left")
+    static var arrowtriangleRightAndLineVerticalAndArrowtriangleLeft: SFSymbol { .init(rawValue: "arrowtriangle.right.and.line.vertical.and.arrowtriangle.left") }
 
     /// 􀟧
     /// Single Localization, Single Layerset
@@ -1630,7 +1630,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill")
-    static let arrowtriangleRightFillAndLineVerticalAndArrowtriangleLeftFill = SFSymbol(rawValue: "arrowtriangle.right.fill.and.line.vertical.and.arrowtriangle.left.fill")
+    static var arrowtriangleRightFillAndLineVerticalAndArrowtriangleLeftFill: SFSymbol { .init(rawValue: "arrowtriangle.right.fill.and.line.vertical.and.arrowtriangle.left.fill") }
 
     /// 􀢐
     /// Single Localization, 3 Layersets
@@ -1639,7 +1639,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let atCircle = SFSymbol(rawValue: "at.circle")
+    static var atCircle: SFSymbol { .init(rawValue: "at.circle") }
 
     /// 􀢑
     /// Single Localization, 3 Layersets
@@ -1648,7 +1648,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let atCircleFill = SFSymbol(rawValue: "at.circle.fill")
+    static var atCircleFill: SFSymbol { .init(rawValue: "at.circle.fill") }
 
     /// 􀬚
     /// Single Localization, 2 Layersets
@@ -1656,21 +1656,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let atom = SFSymbol(rawValue: "atom")
+    static var atom: SFSymbol { .init(rawValue: "atom") }
 
     /// 􀩨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardFrame = SFSymbol(rawValue: "backward.frame")
+    static var backwardFrame: SFSymbol { .init(rawValue: "backward.frame") }
 
     /// 􀩩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backwardFrameFill = SFSymbol(rawValue: "backward.frame.fill")
+    static var backwardFrameFill: SFSymbol { .init(rawValue: "backward.frame.fill") }
 
     /// 􀰮
     /// Single Localization, 3 Layersets
@@ -1679,7 +1679,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let badgePlusRadiowavesForward = SFSymbol(rawValue: "badge.plus.radiowaves.forward")
+    static var badgePlusRadiowavesForward: SFSymbol { .init(rawValue: "badge.plus.radiowaves.forward") }
 
     /// 􀒫
     /// Single Localization, 2 Layersets
@@ -1687,7 +1687,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagCircle = SFSymbol(rawValue: "bag.circle")
+    static var bagCircle: SFSymbol { .init(rawValue: "bag.circle") }
 
     /// 􀒬
     /// Single Localization, 3 Layersets
@@ -1696,7 +1696,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bagCircleFill = SFSymbol(rawValue: "bag.circle.fill")
+    static var bagCircleFill: SFSymbol { .init(rawValue: "bag.circle.fill") }
 
     /// 􀭿
     /// Single Localization, 2 Layersets
@@ -1704,7 +1704,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let banknote = SFSymbol(rawValue: "banknote")
+    static var banknote: SFSymbol { .init(rawValue: "banknote") }
 
     /// 􀮀
     /// Single Localization, 2 Layersets
@@ -1712,7 +1712,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let banknoteFill = SFSymbol(rawValue: "banknote.fill")
+    static var banknoteFill: SFSymbol { .init(rawValue: "banknote.fill") }
 
     /// 􀬧
     /// Single Localization, 2 Layersets
@@ -1720,7 +1720,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let barometer = SFSymbol(rawValue: "barometer")
+    static var barometer: SFSymbol { .init(rawValue: "barometer") }
 
     /// 􀢋
     /// 2 Localizations, 3 Layersets
@@ -1738,7 +1738,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "battery100percentBolt")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "battery100percentBolt")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery100percentBolt")
-    static let battery100Bolt = SymbolWith1Localization<Rtl>(rawValue: "battery.100.bolt")
+    static var battery100Bolt: SymbolWith1Localization<Rtl> { .init(rawValue: "battery.100.bolt") }
 
     /// 􀝖
     /// Single Localization, 3 Layersets
@@ -1747,7 +1747,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellBadge = SFSymbol(rawValue: "bell.badge")
+    static var bellBadge: SFSymbol { .init(rawValue: "bell.badge") }
 
     /// 􀝗
     /// Single Localization, 3 Layersets
@@ -1756,7 +1756,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellBadgeFill = SFSymbol(rawValue: "bell.badge.fill")
+    static var bellBadgeFill: SFSymbol { .init(rawValue: "bell.badge.fill") }
 
     /// 􀋟
     /// Single Localization, 3 Layersets
@@ -1765,7 +1765,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let bellSlashCircle = SFSymbol(rawValue: "bell.slash.circle")
+    static var bellSlashCircle: SFSymbol { .init(rawValue: "bell.slash.circle") }
 
     /// 􀋠
     /// Single Localization, 3 Layersets
@@ -1774,14 +1774,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bellSlashCircleFill = SFSymbol(rawValue: "bell.slash.circle.fill")
+    static var bellSlashCircleFill: SFSymbol { .init(rawValue: "bell.slash.circle.fill") }
 
     /// 􀡥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bicycle = SFSymbol(rawValue: "bicycle")
+    static var bicycle: SFSymbol { .init(rawValue: "bicycle") }
 
     /// 􀱬
     /// Single Localization, 2 Layersets
@@ -1789,7 +1789,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bicycleCircle = SFSymbol(rawValue: "bicycle.circle")
+    static var bicycleCircle: SFSymbol { .init(rawValue: "bicycle.circle") }
 
     /// 􀱭
     /// Single Localization, 3 Layersets
@@ -1798,21 +1798,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bicycleCircleFill = SFSymbol(rawValue: "bicycle.circle.fill")
+    static var bicycleCircleFill: SFSymbol { .init(rawValue: "bicycle.circle.fill") }
 
     /// 􀠍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let binoculars = SFSymbol(rawValue: "binoculars")
+    static var binoculars: SFSymbol { .init(rawValue: "binoculars") }
 
     /// 􀠎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let binocularsFill = SFSymbol(rawValue: "binoculars.fill")
+    static var binocularsFill: SFSymbol { .init(rawValue: "binoculars.fill") }
 
     /// 􀡞
     /// Single Localization, 3 Layersets
@@ -1821,7 +1821,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltCar = SFSymbol(rawValue: "bolt.car")
+    static var boltCar: SFSymbol { .init(rawValue: "bolt.car") }
 
     /// 􀝃
     /// Single Localization, 3 Layersets
@@ -1830,7 +1830,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltCarFill = SFSymbol(rawValue: "bolt.car.fill")
+    static var boltCarFill: SFSymbol { .init(rawValue: "bolt.car.fill") }
 
     /// 􀫮
     /// Single Localization, 2 Layersets
@@ -1843,7 +1843,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "boltBatteryblock")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "boltBatteryblock")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "boltBatteryblock")
-    static let boltFillBatteryblock = SFSymbol(rawValue: "bolt.fill.batteryblock")
+    static var boltFillBatteryblock: SFSymbol { .init(rawValue: "bolt.fill.batteryblock") }
 
     /// 􀫯
     /// Single Localization, 3 Layersets
@@ -1857,7 +1857,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "boltBatteryblockFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "boltBatteryblockFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "boltBatteryblockFill")
-    static let boltFillBatteryblockFill = SFSymbol(rawValue: "bolt.fill.batteryblock.fill")
+    static var boltFillBatteryblockFill: SFSymbol { .init(rawValue: "bolt.fill.batteryblock.fill") }
 
     /// 􀞽
     /// Single Localization, 2 Layersets
@@ -1865,7 +1865,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltHeart = SFSymbol(rawValue: "bolt.heart")
+    static var boltHeart: SFSymbol { .init(rawValue: "bolt.heart") }
 
     /// 􀛥
     /// Single Localization, 3 Layersets
@@ -1874,7 +1874,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let boltHeartFill = SFSymbol(rawValue: "bolt.heart.fill")
+    static var boltHeartFill: SFSymbol { .init(rawValue: "bolt.heart.fill") }
 
     /// 􀋫
     /// Single Localization, 3 Layersets
@@ -1883,7 +1883,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let boltSlashCircle = SFSymbol(rawValue: "bolt.slash.circle")
+    static var boltSlashCircle: SFSymbol { .init(rawValue: "bolt.slash.circle") }
 
     /// 􀋬
     /// Single Localization, 3 Layersets
@@ -1892,7 +1892,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let boltSlashCircleFill = SFSymbol(rawValue: "bolt.slash.circle.fill")
+    static var boltSlashCircleFill: SFSymbol { .init(rawValue: "bolt.slash.circle.fill") }
 
     /// 􀥠
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1903,21 +1903,21 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Bonjour networking.
-    static let bonjour = SFSymbol(rawValue: "bonjour")
+    static var bonjour: SFSymbol { .init(rawValue: "bonjour") }
 
     /// 􀤞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bookClosed = SFSymbol(rawValue: "book.closed")
+    static var bookClosed: SFSymbol { .init(rawValue: "book.closed") }
 
     /// 􀤟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bookClosedFill = SFSymbol(rawValue: "book.closed.fill")
+    static var bookClosedFill: SFSymbol { .init(rawValue: "book.closed.fill") }
 
     /// 􀉠
     /// Single Localization, 3 Layersets
@@ -1926,7 +1926,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookmarkCircle = SFSymbol(rawValue: "bookmark.circle")
+    static var bookmarkCircle: SFSymbol { .init(rawValue: "bookmark.circle") }
 
     /// 􀉡
     /// Single Localization, 3 Layersets
@@ -1935,7 +1935,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookmarkCircleFill = SFSymbol(rawValue: "bookmark.circle.fill")
+    static var bookmarkCircleFill: SFSymbol { .init(rawValue: "bookmark.circle.fill") }
 
     /// 􀟍
     /// Single Localization, 3 Layersets
@@ -1944,7 +1944,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookmarkSlash = SFSymbol(rawValue: "bookmark.slash")
+    static var bookmarkSlash: SFSymbol { .init(rawValue: "bookmark.slash") }
 
     /// 􀟎
     /// Single Localization, 3 Layersets
@@ -1953,28 +1953,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let bookmarkSlashFill = SFSymbol(rawValue: "bookmark.slash.fill")
+    static var bookmarkSlashFill: SFSymbol { .init(rawValue: "bookmark.slash.fill") }
 
     /// 􀬒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let booksVertical = SFSymbol(rawValue: "books.vertical")
+    static var booksVertical: SFSymbol { .init(rawValue: "books.vertical") }
 
     /// 􀬓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let booksVerticalFill = SFSymbol(rawValue: "books.vertical.fill")
+    static var booksVerticalFill: SFSymbol { .init(rawValue: "books.vertical.fill") }
 
     /// 􀮅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let building = SFSymbol(rawValue: "building")
+    static var building: SFSymbol { .init(rawValue: "building") }
 
     /// 􀝒
     /// Single Localization, 3 Layersets
@@ -1983,14 +1983,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let building2 = SFSymbol(rawValue: "building.2")
+    static var building2: SFSymbol { .init(rawValue: "building.2") }
 
     /// 􀝔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let building2CropCircle = SFSymbol(rawValue: "building.2.crop.circle")
+    static var building2CropCircle: SFSymbol { .init(rawValue: "building.2.crop.circle") }
 
     /// 􀝕
     /// Single Localization, 3 Layersets
@@ -1999,7 +1999,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let building2CropCircleFill = SFSymbol(rawValue: "building.2.crop.circle.fill")
+    static var building2CropCircleFill: SFSymbol { .init(rawValue: "building.2.crop.circle.fill") }
 
     /// 􀝓
     /// Single Localization, 2 Layersets
@@ -2007,56 +2007,56 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let building2Fill = SFSymbol(rawValue: "building.2.fill")
+    static var building2Fill: SFSymbol { .init(rawValue: "building.2.fill") }
 
     /// 􀤨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buildingColumns = SFSymbol(rawValue: "building.columns")
+    static var buildingColumns: SFSymbol { .init(rawValue: "building.columns") }
 
     /// 􀤩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buildingColumnsFill = SFSymbol(rawValue: "building.columns.fill")
+    static var buildingColumnsFill: SFSymbol { .init(rawValue: "building.columns.fill") }
 
     /// 􀮆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buildingFill = SFSymbol(rawValue: "building.fill")
+    static var buildingFill: SFSymbol { .init(rawValue: "building.fill") }
 
     /// 􀝈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bus = SFSymbol(rawValue: "bus")
+    static var bus: SFSymbol { .init(rawValue: "bus") }
 
     /// 􀜛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let busDoubledecker = SFSymbol(rawValue: "bus.doubledecker")
+    static var busDoubledecker: SFSymbol { .init(rawValue: "bus.doubledecker") }
 
     /// 􀜜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let busDoubledeckerFill = SFSymbol(rawValue: "bus.doubledecker.fill")
+    static var busDoubledeckerFill: SFSymbol { .init(rawValue: "bus.doubledecker.fill") }
 
     /// 􀝉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let busFill = SFSymbol(rawValue: "bus.fill")
+    static var busFill: SFSymbol { .init(rawValue: "bus.fill") }
 
     /// 􀧞
     /// 2 Localizations, 3 Layersets
@@ -2069,7 +2069,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "calendar.badge.clock")
+    static var calendarBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "calendar.badge.clock") }
 
     /// 􀮝
     /// Single Localization, 3 Layersets
@@ -2078,14 +2078,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let calendarBadgeExclamationmark = SFSymbol(rawValue: "calendar.badge.exclamationmark")
+    static var calendarBadgeExclamationmark: SFSymbol { .init(rawValue: "calendar.badge.exclamationmark") }
 
     /// 􀨺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cameraAperture = SFSymbol(rawValue: "camera.aperture")
+    static var cameraAperture: SFSymbol { .init(rawValue: "camera.aperture") }
 
     /// 􀢗
     /// Single Localization, 3 Layersets
@@ -2094,7 +2094,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraBadgeEllipsis = SFSymbol(rawValue: "camera.badge.ellipsis")
+    static var cameraBadgeEllipsis: SFSymbol { .init(rawValue: "camera.badge.ellipsis") }
 
     /// 􀢘
     /// Single Localization, 3 Layersets
@@ -2108,7 +2108,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "cameraBadgeEllipsisFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "cameraBadgeEllipsisFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "cameraBadgeEllipsisFill")
-    static let cameraFillBadgeEllipsis = SFSymbol(rawValue: "camera.fill.badge.ellipsis")
+    static var cameraFillBadgeEllipsis: SFSymbol { .init(rawValue: "camera.fill.badge.ellipsis") }
 
     /// 􀟗
     /// Single Localization, 3 Layersets
@@ -2117,7 +2117,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraFilters = SFSymbol(rawValue: "camera.filters")
+    static var cameraFilters: SFSymbol { .init(rawValue: "camera.filters") }
 
     /// 􀢪
     /// Single Localization, 3 Layersets
@@ -2126,14 +2126,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraMeteringCenterWeighted = SFSymbol(rawValue: "camera.metering.center.weighted")
+    static var cameraMeteringCenterWeighted: SFSymbol { .init(rawValue: "camera.metering.center.weighted") }
 
     /// 􀞲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cameraMeteringCenterWeightedAverage = SFSymbol(rawValue: "camera.metering.center.weighted.average")
+    static var cameraMeteringCenterWeightedAverage: SFSymbol { .init(rawValue: "camera.metering.center.weighted.average") }
 
     /// 􀢫
     /// Single Localization, 3 Layersets
@@ -2142,7 +2142,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraMeteringMatrix = SFSymbol(rawValue: "camera.metering.matrix")
+    static var cameraMeteringMatrix: SFSymbol { .init(rawValue: "camera.metering.matrix") }
 
     /// 􀢬
     /// Single Localization, 3 Layersets
@@ -2151,7 +2151,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraMeteringMultispot = SFSymbol(rawValue: "camera.metering.multispot")
+    static var cameraMeteringMultispot: SFSymbol { .init(rawValue: "camera.metering.multispot") }
 
     /// 􀢭
     /// Single Localization, 2 Layersets
@@ -2159,7 +2159,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraMeteringNone = SFSymbol(rawValue: "camera.metering.none")
+    static var cameraMeteringNone: SFSymbol { .init(rawValue: "camera.metering.none") }
 
     /// 􀢮
     /// Single Localization, 2 Layersets
@@ -2167,7 +2167,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraMeteringPartial = SFSymbol(rawValue: "camera.metering.partial")
+    static var cameraMeteringPartial: SFSymbol { .init(rawValue: "camera.metering.partial") }
 
     /// 􀢯
     /// Single Localization, 2 Layersets
@@ -2175,7 +2175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraMeteringSpot = SFSymbol(rawValue: "camera.metering.spot")
+    static var cameraMeteringSpot: SFSymbol { .init(rawValue: "camera.metering.spot") }
 
     /// 􀢰
     /// 2 Localizations, 2 Layersets
@@ -2187,28 +2187,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cameraMeteringUnknown = SymbolWith1Localization<Ar>(rawValue: "camera.metering.unknown")
+    static var cameraMeteringUnknown: SymbolWith1Localization<Ar> { .init(rawValue: "camera.metering.unknown") }
 
     /// 􀪳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let candybarphone = SFSymbol(rawValue: "candybarphone")
+    static var candybarphone: SFSymbol { .init(rawValue: "candybarphone") }
 
     /// 􀧶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortrait = SFSymbol(rawValue: "capsule.portrait")
+    static var capsulePortrait: SFSymbol { .init(rawValue: "capsule.portrait") }
 
     /// 􀧷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortraitFill = SFSymbol(rawValue: "capsule.portrait.fill")
+    static var capsulePortraitFill: SFSymbol { .init(rawValue: "capsule.portrait.fill") }
 
     /// 􀝄
     /// Single Localization, 3 Layersets
@@ -2217,7 +2217,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let car2 = SFSymbol(rawValue: "car.2")
+    static var car2: SFSymbol { .init(rawValue: "car.2") }
 
     /// 􀝅
     /// Single Localization, 2 Layersets
@@ -2225,7 +2225,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let car2Fill = SFSymbol(rawValue: "car.2.fill")
+    static var car2Fill: SFSymbol { .init(rawValue: "car.2.fill") }
 
     /// 􀭯
     /// Single Localization, 3 Layersets
@@ -2234,7 +2234,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let carCircle = SFSymbol(rawValue: "car.circle")
+    static var carCircle: SFSymbol { .init(rawValue: "car.circle") }
 
     /// 􀭰
     /// Single Localization, 3 Layersets
@@ -2243,21 +2243,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let carCircleFill = SFSymbol(rawValue: "car.circle.fill")
+    static var carCircleFill: SFSymbol { .init(rawValue: "car.circle.fill") }
 
     /// 􀯡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let `case` = SFSymbol(rawValue: "case")
+    static var `case`: SFSymbol { .init(rawValue: "case") }
 
     /// 􀯢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let caseFill = SFSymbol(rawValue: "case.fill")
+    static var caseFill: SFSymbol { .init(rawValue: "case.fill") }
 
     /// 􀥜
     /// Single Localization, 3 Layersets
@@ -2271,7 +2271,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "chartBarHorizontalPage")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "chartBarHorizontalPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "chartBarHorizontalPage")
-    static let chartBarDocHorizontal = SFSymbol(rawValue: "chart.bar.doc.horizontal")
+    static var chartBarDocHorizontal: SFSymbol { .init(rawValue: "chart.bar.doc.horizontal") }
 
     /// 􀦌
     /// Single Localization, 3 Layersets
@@ -2285,7 +2285,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "chartBarHorizontalPageFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "chartBarHorizontalPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "chartBarHorizontalPageFill")
-    static let chartBarDocHorizontalFill = SFSymbol(rawValue: "chart.bar.doc.horizontal.fill")
+    static var chartBarDocHorizontalFill: SFSymbol { .init(rawValue: "chart.bar.doc.horizontal.fill") }
 
     /// 􀣉
     /// Single Localization, 3 Layersets
@@ -2294,7 +2294,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartBarXaxis = SFSymbol(rawValue: "chart.bar.xaxis")
+    static var chartBarXaxis: SFSymbol { .init(rawValue: "chart.bar.xaxis") }
 
     /// 􀪫
     /// Single Localization, Single Layerset
@@ -2306,7 +2306,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rectangleCheckered")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rectangleCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleCheckered")
-    static let checkerboardRectangle = SFSymbol(rawValue: "checkerboard.rectangle")
+    static var checkerboardRectangle: SFSymbol { .init(rawValue: "checkerboard.rectangle") }
 
     /// 􀢓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2316,7 +2316,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let checkmarkIcloud = SFSymbol(rawValue: "checkmark.icloud")
+    static var checkmarkIcloud: SFSymbol { .init(rawValue: "checkmark.icloud") }
 
     /// 􀢔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2327,7 +2327,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let checkmarkIcloudFill = SFSymbol(rawValue: "checkmark.icloud.fill")
+    static var checkmarkIcloudFill: SFSymbol { .init(rawValue: "checkmark.icloud.fill") }
 
     /// 􀡮
     /// Single Localization, 3 Layersets
@@ -2336,7 +2336,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkRectanglePortrait = SFSymbol(rawValue: "checkmark.rectangle.portrait")
+    static var checkmarkRectanglePortrait: SFSymbol { .init(rawValue: "checkmark.rectangle.portrait") }
 
     /// 􀡯
     /// Single Localization, 3 Layersets
@@ -2345,21 +2345,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkRectanglePortraitFill = SFSymbol(rawValue: "checkmark.rectangle.portrait.fill")
+    static var checkmarkRectanglePortraitFill: SFSymbol { .init(rawValue: "checkmark.rectangle.portrait.fill") }
 
     /// 􀯶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronBackward = SFSymbol(rawValue: "chevron.backward")
+    static var chevronBackward: SFSymbol { .init(rawValue: "chevron.backward") }
 
     /// 􀰪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronBackward2 = SFSymbol(rawValue: "chevron.backward.2")
+    static var chevronBackward2: SFSymbol { .init(rawValue: "chevron.backward.2") }
 
     /// 􀯷
     /// Single Localization, 2 Layersets
@@ -2367,7 +2367,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronBackwardCircle = SFSymbol(rawValue: "chevron.backward.circle")
+    static var chevronBackwardCircle: SFSymbol { .init(rawValue: "chevron.backward.circle") }
 
     /// 􀯸
     /// Single Localization, 3 Layersets
@@ -2376,7 +2376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronBackwardCircleFill = SFSymbol(rawValue: "chevron.backward.circle.fill")
+    static var chevronBackwardCircleFill: SFSymbol { .init(rawValue: "chevron.backward.circle.fill") }
 
     /// 􀯹
     /// Single Localization, 2 Layersets
@@ -2384,7 +2384,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronBackwardSquare = SFSymbol(rawValue: "chevron.backward.square")
+    static var chevronBackwardSquare: SFSymbol { .init(rawValue: "chevron.backward.square") }
 
     /// 􀯺
     /// Single Localization, 3 Layersets
@@ -2393,21 +2393,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronBackwardSquareFill = SFSymbol(rawValue: "chevron.backward.square.fill")
+    static var chevronBackwardSquareFill: SFSymbol { .init(rawValue: "chevron.backward.square.fill") }
 
     /// 􀯻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronForward = SFSymbol(rawValue: "chevron.forward")
+    static var chevronForward: SFSymbol { .init(rawValue: "chevron.forward") }
 
     /// 􀰫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronForward2 = SFSymbol(rawValue: "chevron.forward.2")
+    static var chevronForward2: SFSymbol { .init(rawValue: "chevron.forward.2") }
 
     /// 􀯼
     /// Single Localization, 2 Layersets
@@ -2415,7 +2415,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronForwardCircle = SFSymbol(rawValue: "chevron.forward.circle")
+    static var chevronForwardCircle: SFSymbol { .init(rawValue: "chevron.forward.circle") }
 
     /// 􀯽
     /// Single Localization, 3 Layersets
@@ -2424,7 +2424,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronForwardCircleFill = SFSymbol(rawValue: "chevron.forward.circle.fill")
+    static var chevronForwardCircleFill: SFSymbol { .init(rawValue: "chevron.forward.circle.fill") }
 
     /// 􀯾
     /// Single Localization, 2 Layersets
@@ -2432,7 +2432,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let chevronForwardSquare = SFSymbol(rawValue: "chevron.forward.square")
+    static var chevronForwardSquare: SFSymbol { .init(rawValue: "chevron.forward.square") }
 
     /// 􀯿
     /// Single Localization, 3 Layersets
@@ -2441,7 +2441,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chevronForwardSquareFill = SFSymbol(rawValue: "chevron.forward.square.fill")
+    static var chevronForwardSquareFill: SFSymbol { .init(rawValue: "chevron.forward.square.fill") }
 
     /// 􀪖
     /// Single Localization, Single Layerset
@@ -2453,7 +2453,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleBottomhalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleBottomhalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleBottomhalfFilled")
-    static let circleBottomhalfFill = SFSymbol(rawValue: "circle.bottomhalf.fill")
+    static var circleBottomhalfFill: SFSymbol { .init(rawValue: "circle.bottomhalf.fill") }
 
     /// 􀨁
     /// Single Localization, 2 Layersets
@@ -2461,7 +2461,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let circleCircle = SFSymbol(rawValue: "circle.circle")
+    static var circleCircle: SFSymbol { .init(rawValue: "circle.circle") }
 
     /// 􀨂
     /// Single Localization, 3 Layersets
@@ -2470,14 +2470,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let circleCircleFill = SFSymbol(rawValue: "circle.circle.fill")
+    static var circleCircleFill: SFSymbol { .init(rawValue: "circle.circle.fill") }
 
     /// 􀓞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleDashed = SFSymbol(rawValue: "circle.dashed")
+    static var circleDashed: SFSymbol { .init(rawValue: "circle.dashed") }
 
     /// 􀧒
     /// Single Localization, Single Layerset
@@ -2489,7 +2489,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleDashedInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleDashedInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleDashedInsetFilled")
-    static let circleDashedInsetFill = SFSymbol(rawValue: "circle.dashed.inset.fill")
+    static var circleDashedInsetFill: SFSymbol { .init(rawValue: "circle.dashed.inset.fill") }
 
     /// 􀧻
     /// Single Localization, 3 Layersets
@@ -2503,14 +2503,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleSquareFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleSquareFill")
-    static let circleFillSquareFill = SFSymbol(rawValue: "circle.fill.square.fill")
+    static var circleFillSquareFill: SFSymbol { .init(rawValue: "circle.fill.square.fill") }
 
     /// 􀧸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGridCross = SFSymbol(rawValue: "circle.grid.cross")
+    static var circleGridCross: SFSymbol { .init(rawValue: "circle.grid.cross") }
 
     /// 􀩇
     /// Single Localization, 2 Layersets
@@ -2523,14 +2523,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleGridCrossDownFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleGridCrossDownFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleGridCrossDownFilled")
-    static let circleGridCrossDownFill = SFSymbol(rawValue: "circle.grid.cross.down.fill")
+    static var circleGridCrossDownFill: SFSymbol { .init(rawValue: "circle.grid.cross.down.fill") }
 
     /// 􀧹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGridCrossFill = SFSymbol(rawValue: "circle.grid.cross.fill")
+    static var circleGridCrossFill: SFSymbol { .init(rawValue: "circle.grid.cross.fill") }
 
     /// 􀩄
     /// Single Localization, 2 Layersets
@@ -2543,7 +2543,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleGridCrossLeftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleGridCrossLeftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleGridCrossLeftFilled")
-    static let circleGridCrossLeftFill = SFSymbol(rawValue: "circle.grid.cross.left.fill")
+    static var circleGridCrossLeftFill: SFSymbol { .init(rawValue: "circle.grid.cross.left.fill") }
 
     /// 􀩆
     /// Single Localization, 2 Layersets
@@ -2556,7 +2556,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleGridCrossRightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleGridCrossRightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleGridCrossRightFilled")
-    static let circleGridCrossRightFill = SFSymbol(rawValue: "circle.grid.cross.right.fill")
+    static var circleGridCrossRightFill: SFSymbol { .init(rawValue: "circle.grid.cross.right.fill") }
 
     /// 􀩅
     /// Single Localization, 2 Layersets
@@ -2569,7 +2569,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleGridCrossUpFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleGridCrossUpFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleGridCrossUpFilled")
-    static let circleGridCrossUpFill = SFSymbol(rawValue: "circle.grid.cross.up.fill")
+    static var circleGridCrossUpFill: SFSymbol { .init(rawValue: "circle.grid.cross.up.fill") }
 
     /// 􀧺
     /// Single Localization, 2 Layersets
@@ -2577,7 +2577,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let circleSquare = SFSymbol(rawValue: "circle.square")
+    static var circleSquare: SFSymbol { .init(rawValue: "circle.square") }
 
     /// 􀪗
     /// Single Localization, Single Layerset
@@ -2589,28 +2589,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleTophalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleTophalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleTophalfFilled")
-    static let circleTophalfFill = SFSymbol(rawValue: "circle.tophalf.fill")
+    static var circleTophalfFill: SFSymbol { .init(rawValue: "circle.tophalf.fill") }
 
     /// 􀧙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circlebadge = SFSymbol(rawValue: "circlebadge")
+    static var circlebadge: SFSymbol { .init(rawValue: "circlebadge") }
 
     /// 􀫲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circlebadge2 = SFSymbol(rawValue: "circlebadge.2")
+    static var circlebadge2: SFSymbol { .init(rawValue: "circlebadge.2") }
 
     /// 􀣽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circlebadge2Fill = SFSymbol(rawValue: "circlebadge.2.fill")
+    static var circlebadge2Fill: SFSymbol { .init(rawValue: "circlebadge.2.fill") }
 
     /// 􀜞
     /// Single Localization, 2 Layersets
@@ -2618,7 +2618,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let circlebadgeFill = SFSymbol(rawValue: "circlebadge.fill")
+    static var circlebadgeFill: SFSymbol { .init(rawValue: "circlebadge.fill") }
 
     /// 􀙢
     /// Single Localization, Single Layerset
@@ -2630,7 +2630,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleHexagongrid")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleHexagongrid")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleHexagongrid")
-    static let circlesHexagongrid = SFSymbol(rawValue: "circles.hexagongrid")
+    static var circlesHexagongrid: SFSymbol { .init(rawValue: "circles.hexagongrid") }
 
     /// 􀙣
     /// Single Localization, 2 Layersets
@@ -2643,7 +2643,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleHexagongridFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleHexagongridFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleHexagongridFill")
-    static let circlesHexagongridFill = SFSymbol(rawValue: "circles.hexagongrid.fill")
+    static var circlesHexagongridFill: SFSymbol { .init(rawValue: "circles.hexagongrid.fill") }
 
     /// 􀬎
     /// Single Localization, Single Layerset
@@ -2655,7 +2655,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleHexagonpath")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleHexagonpath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleHexagonpath")
-    static let circlesHexagonpath = SFSymbol(rawValue: "circles.hexagonpath")
+    static var circlesHexagonpath: SFSymbol { .init(rawValue: "circles.hexagonpath") }
 
     /// 􀬏
     /// Single Localization, Single Layerset
@@ -2667,7 +2667,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "circleHexagonpathFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "circleHexagonpathFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "circleHexagonpathFill")
-    static let circlesHexagonpathFill = SFSymbol(rawValue: "circles.hexagonpath.fill")
+    static var circlesHexagonpathFill: SFSymbol { .init(rawValue: "circles.hexagonpath.fill") }
 
     /// 􀣔
     /// Single Localization, 2 Layersets
@@ -2680,21 +2680,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "clockArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "clockArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "clockArrowTriangleheadCounterclockwiseRotate90")
-    static let clockArrowCirclepath = SFSymbol(rawValue: "clock.arrow.circlepath")
+    static var clockArrowCirclepath: SFSymbol { .init(rawValue: "clock.arrow.circlepath") }
 
     /// 􀦈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let comb = SFSymbol(rawValue: "comb")
+    static var comb: SFSymbol { .init(rawValue: "comb") }
 
     /// 􀦉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let combFill = SFSymbol(rawValue: "comb.fill")
+    static var combFill: SFSymbol { .init(rawValue: "comb.fill") }
 
     /// 􀩿
     /// Single Localization, 2 Layersets
@@ -2702,7 +2702,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let commandCircle = SFSymbol(rawValue: "command.circle")
+    static var commandCircle: SFSymbol { .init(rawValue: "command.circle") }
 
     /// 􀪀
     /// Single Localization, 3 Layersets
@@ -2711,7 +2711,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let commandCircleFill = SFSymbol(rawValue: "command.circle.fill")
+    static var commandCircleFill: SFSymbol { .init(rawValue: "command.circle.fill") }
 
     /// 􀪁
     /// Single Localization, 2 Layersets
@@ -2719,7 +2719,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let commandSquare = SFSymbol(rawValue: "command.square")
+    static var commandSquare: SFSymbol { .init(rawValue: "command.square") }
 
     /// 􀪂
     /// Single Localization, 3 Layersets
@@ -2728,21 +2728,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let commandSquareFill = SFSymbol(rawValue: "command.square.fill")
+    static var commandSquareFill: SFSymbol { .init(rawValue: "command.square.fill") }
 
     /// 􀳇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cone = SFSymbol(rawValue: "cone")
+    static var cone: SFSymbol { .init(rawValue: "cone") }
 
     /// 􀳈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let coneFill = SFSymbol(rawValue: "cone.fill")
+    static var coneFill: SFSymbol { .init(rawValue: "cone.fill") }
 
     /// 􀭈
     /// Single Localization, 2 Layersets
@@ -2755,14 +2755,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "contextualmenuAndPointerArrow")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "contextualmenuAndPointerArrow")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "contextualmenuAndPointerArrow")
-    static let contextualmenuAndCursorarrow = SFSymbol(rawValue: "contextualmenu.and.cursorarrow")
+    static var contextualmenuAndCursorarrow: SFSymbol { .init(rawValue: "contextualmenu.and.cursorarrow") }
 
     /// 􀫥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cpu = SFSymbol(rawValue: "cpu")
+    static var cpu: SFSymbol { .init(rawValue: "cpu") }
 
     /// 􀒯
     /// Single Localization, 2 Layersets
@@ -2770,7 +2770,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let creditcardCircle = SFSymbol(rawValue: "creditcard.circle")
+    static var creditcardCircle: SFSymbol { .init(rawValue: "creditcard.circle") }
 
     /// 􀒰
     /// Single Localization, 3 Layersets
@@ -2779,7 +2779,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let creditcardCircleFill = SFSymbol(rawValue: "creditcard.circle.fill")
+    static var creditcardCircleFill: SFSymbol { .init(rawValue: "creditcard.circle.fill") }
 
     /// 􀣜
     /// Single Localization, 2 Layersets
@@ -2787,7 +2787,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let cross = SFSymbol(rawValue: "cross")
+    static var cross: SFSymbol { .init(rawValue: "cross") }
 
     /// 􀯙
     /// Single Localization, 2 Layersets
@@ -2795,7 +2795,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let crossCase = SFSymbol(rawValue: "cross.case")
+    static var crossCase: SFSymbol { .init(rawValue: "cross.case") }
 
     /// 􀯚
     /// Single Localization, 3 Layersets
@@ -2804,7 +2804,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let crossCaseFill = SFSymbol(rawValue: "cross.case.fill")
+    static var crossCaseFill: SFSymbol { .init(rawValue: "cross.case.fill") }
 
     /// 􀣞
     /// Single Localization, 3 Layersets
@@ -2813,7 +2813,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let crossCircle = SFSymbol(rawValue: "cross.circle")
+    static var crossCircle: SFSymbol { .init(rawValue: "cross.circle") }
 
     /// 􀣟
     /// Single Localization, 3 Layersets
@@ -2822,7 +2822,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let crossCircleFill = SFSymbol(rawValue: "cross.circle.fill")
+    static var crossCircleFill: SFSymbol { .init(rawValue: "cross.circle.fill") }
 
     /// 􀣝
     /// Single Localization, 2 Layersets
@@ -2830,42 +2830,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let crossFill = SFSymbol(rawValue: "cross.fill")
+    static var crossFill: SFSymbol { .init(rawValue: "cross.fill") }
 
     /// 􀦅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let crown = SFSymbol(rawValue: "crown")
+    static var crown: SFSymbol { .init(rawValue: "crown") }
 
     /// 􀦆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let crownFill = SFSymbol(rawValue: "crown.fill")
+    static var crownFill: SFSymbol { .init(rawValue: "crown.fill") }
 
     /// 􀬨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cubeTransparent = SFSymbol(rawValue: "cube.transparent")
+    static var cubeTransparent: SFSymbol { .init(rawValue: "cube.transparent") }
 
     /// 􀳴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cubeTransparentFill = SFSymbol(rawValue: "cube.transparent.fill")
+    static var cubeTransparentFill: SFSymbol { .init(rawValue: "cube.transparent.fill") }
 
     /// 􀡅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let curlybraces = SFSymbol(rawValue: "curlybraces")
+    static var curlybraces: SFSymbol { .init(rawValue: "curlybraces") }
 
     /// 􀤘
     /// Single Localization, 2 Layersets
@@ -2873,7 +2873,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let curlybracesSquare = SFSymbol(rawValue: "curlybraces.square")
+    static var curlybracesSquare: SFSymbol { .init(rawValue: "curlybraces.square") }
 
     /// 􀤙
     /// Single Localization, 3 Layersets
@@ -2882,7 +2882,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let curlybracesSquareFill = SFSymbol(rawValue: "curlybraces.square.fill")
+    static var curlybracesSquareFill: SFSymbol { .init(rawValue: "curlybraces.square.fill") }
 
     /// 􀫌
     /// Single Localization, Single Layerset
@@ -2894,7 +2894,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.4, renamed: "cursorarrowResizeNorthEastSouthEast")
     @available(watchOS, introduced: 7.0, deprecated: 11.4, renamed: "cursorarrowResizeNorthEastSouthEast")
     @available(visionOS, introduced: 1.0, deprecated: 2.4, renamed: "cursorarrowResizeNorthEastSouthEast")
-    static let cursorarrow = SFSymbol(rawValue: "cursorarrow")
+    static var cursorarrow: SFSymbol { .init(rawValue: "cursorarrow") }
 
     /// 􀮐
     /// Single Localization, 2 Layersets
@@ -2907,7 +2907,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowAndSquareOnSquareDashed")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowAndSquareOnSquareDashed")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowAndSquareOnSquareDashed")
-    static let cursorarrowAndSquareOnSquareDashed = SFSymbol(rawValue: "cursorarrow.and.square.on.square.dashed")
+    static var cursorarrowAndSquareOnSquareDashed: SFSymbol { .init(rawValue: "cursorarrow.and.square.on.square.dashed") }
 
     /// 􀭆
     /// Single Localization, 2 Layersets
@@ -2920,7 +2920,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowClick")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowClick")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowClick")
-    static let cursorarrowClick = SFSymbol(rawValue: "cursorarrow.click")
+    static var cursorarrowClick: SFSymbol { .init(rawValue: "cursorarrow.click") }
 
     /// 􀭇
     /// Single Localization, 3 Layersets
@@ -2934,7 +2934,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowClick2")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowClick2")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowClick2")
-    static let cursorarrowClick2 = SFSymbol(rawValue: "cursorarrow.click.2")
+    static var cursorarrowClick2: SFSymbol { .init(rawValue: "cursorarrow.click.2") }
 
     /// 􀮴
     /// Single Localization, 3 Layersets
@@ -2948,7 +2948,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowClickBadgeClock")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowClickBadgeClock")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowClickBadgeClock")
-    static let cursorarrowClickBadgeClock = SFSymbol(rawValue: "cursorarrow.click.badge.clock")
+    static var cursorarrowClickBadgeClock: SFSymbol { .init(rawValue: "cursorarrow.click.badge.clock") }
 
     /// 􀣠
     /// Single Localization, Single Layerset
@@ -2960,7 +2960,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowMotionlines")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowMotionlines")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowMotionlines")
-    static let cursorarrowMotionlines = SFSymbol(rawValue: "cursorarrow.motionlines")
+    static var cursorarrowMotionlines: SFSymbol { .init(rawValue: "cursorarrow.motionlines") }
 
     /// 􀣡
     /// Single Localization, 2 Layersets
@@ -2973,7 +2973,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowMotionlinesClick")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowMotionlinesClick")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowMotionlinesClick")
-    static let cursorarrowMotionlinesClick = SFSymbol(rawValue: "cursorarrow.motionlines.click")
+    static var cursorarrowMotionlinesClick: SFSymbol { .init(rawValue: "cursorarrow.motionlines.click") }
 
     /// 􀇰
     /// Single Localization, 2 Layersets
@@ -2986,7 +2986,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowRays")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowRays")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowRays")
-    static let cursorarrowRays = SFSymbol(rawValue: "cursorarrow.rays")
+    static var cursorarrowRays: SFSymbol { .init(rawValue: "cursorarrow.rays") }
 
     /// 􀭅
     /// Single Localization, 2 Layersets
@@ -2999,35 +2999,35 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "pointerArrowSquare")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "pointerArrowSquare")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowSquare")
-    static let cursorarrowSquare = SFSymbol(rawValue: "cursorarrow.square")
+    static var cursorarrowSquare: SFSymbol { .init(rawValue: "cursorarrow.square") }
 
     /// 􀳃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cylinder = SFSymbol(rawValue: "cylinder")
+    static var cylinder: SFSymbol { .init(rawValue: "cylinder") }
 
     /// 􀳄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cylinderFill = SFSymbol(rawValue: "cylinder.fill")
+    static var cylinderFill: SFSymbol { .init(rawValue: "cylinder.fill") }
 
     /// 􀡓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cylinderSplit1x2 = SFSymbol(rawValue: "cylinder.split.1x2")
+    static var cylinderSplit1x2: SFSymbol { .init(rawValue: "cylinder.split.1x2") }
 
     /// 􀡔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cylinderSplit1x2Fill = SFSymbol(rawValue: "cylinder.split.1x2.fill")
+    static var cylinderSplit1x2Fill: SFSymbol { .init(rawValue: "cylinder.split.1x2.fill") }
 
     /// 􀡑
     /// Single Localization, 2 Layersets
@@ -3035,7 +3035,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let deskclock = SFSymbol(rawValue: "deskclock")
+    static var deskclock: SFSymbol { .init(rawValue: "deskclock") }
 
     /// 􀡒
     /// Single Localization, 2 Layersets
@@ -3043,7 +3043,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let deskclockFill = SFSymbol(rawValue: "deskclock.fill")
+    static var deskclockFill: SFSymbol { .init(rawValue: "deskclock.fill") }
 
     /// 􀪐
     /// Single Localization, 2 Layersets
@@ -3056,7 +3056,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "dialHigh")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "dialHigh")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialHigh")
-    static let dialMax = SFSymbol(rawValue: "dial.max")
+    static var dialMax: SFSymbol { .init(rawValue: "dial.max") }
 
     /// 􀪑
     /// Single Localization, 2 Layersets
@@ -3069,7 +3069,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "dialHighFill")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "dialHighFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialHighFill")
-    static let dialMaxFill = SFSymbol(rawValue: "dial.max.fill")
+    static var dialMaxFill: SFSymbol { .init(rawValue: "dial.max.fill") }
 
     /// 􀍺
     /// Single Localization, 2 Layersets
@@ -3082,7 +3082,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "dialLow")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "dialLow")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialLow")
-    static let dialMin = SFSymbol(rawValue: "dial.min")
+    static var dialMin: SFSymbol { .init(rawValue: "dial.min") }
 
     /// 􀍻
     /// Single Localization, 2 Layersets
@@ -3095,21 +3095,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "dialLowFill")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "dialLowFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dialLowFill")
-    static let dialMinFill = SFSymbol(rawValue: "dial.min.fill")
+    static var dialMinFill: SFSymbol { .init(rawValue: "dial.min.fill") }
 
     /// 􀟈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamond = SFSymbol(rawValue: "diamond")
+    static var diamond: SFSymbol { .init(rawValue: "diamond") }
 
     /// 􀟉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamondFill = SFSymbol(rawValue: "diamond.fill")
+    static var diamondFill: SFSymbol { .init(rawValue: "diamond.fill") }
 
     /// 􀧣
     /// Single Localization, 2 Layersets
@@ -3117,7 +3117,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace1 = SFSymbol(rawValue: "die.face.1")
+    static var dieFace1: SFSymbol { .init(rawValue: "die.face.1") }
 
     /// 􀧤
     /// Single Localization, 3 Layersets
@@ -3126,7 +3126,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace1Fill = SFSymbol(rawValue: "die.face.1.fill")
+    static var dieFace1Fill: SFSymbol { .init(rawValue: "die.face.1.fill") }
 
     /// 􀧥
     /// Single Localization, 2 Layersets
@@ -3134,7 +3134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace2 = SFSymbol(rawValue: "die.face.2")
+    static var dieFace2: SFSymbol { .init(rawValue: "die.face.2") }
 
     /// 􀧦
     /// Single Localization, 3 Layersets
@@ -3143,7 +3143,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace2Fill = SFSymbol(rawValue: "die.face.2.fill")
+    static var dieFace2Fill: SFSymbol { .init(rawValue: "die.face.2.fill") }
 
     /// 􀧧
     /// Single Localization, 2 Layersets
@@ -3151,7 +3151,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace3 = SFSymbol(rawValue: "die.face.3")
+    static var dieFace3: SFSymbol { .init(rawValue: "die.face.3") }
 
     /// 􀧨
     /// Single Localization, 3 Layersets
@@ -3160,7 +3160,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace3Fill = SFSymbol(rawValue: "die.face.3.fill")
+    static var dieFace3Fill: SFSymbol { .init(rawValue: "die.face.3.fill") }
 
     /// 􀧩
     /// Single Localization, 2 Layersets
@@ -3168,7 +3168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace4 = SFSymbol(rawValue: "die.face.4")
+    static var dieFace4: SFSymbol { .init(rawValue: "die.face.4") }
 
     /// 􀧪
     /// Single Localization, 3 Layersets
@@ -3177,7 +3177,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace4Fill = SFSymbol(rawValue: "die.face.4.fill")
+    static var dieFace4Fill: SFSymbol { .init(rawValue: "die.face.4.fill") }
 
     /// 􀧫
     /// Single Localization, 2 Layersets
@@ -3185,7 +3185,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace5 = SFSymbol(rawValue: "die.face.5")
+    static var dieFace5: SFSymbol { .init(rawValue: "die.face.5") }
 
     /// 􀧬
     /// Single Localization, 3 Layersets
@@ -3194,7 +3194,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace5Fill = SFSymbol(rawValue: "die.face.5.fill")
+    static var dieFace5Fill: SFSymbol { .init(rawValue: "die.face.5.fill") }
 
     /// 􀧭
     /// Single Localization, 2 Layersets
@@ -3202,7 +3202,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dieFace6 = SFSymbol(rawValue: "die.face.6")
+    static var dieFace6: SFSymbol { .init(rawValue: "die.face.6") }
 
     /// 􀧮
     /// Single Localization, 3 Layersets
@@ -3211,7 +3211,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dieFace6Fill = SFSymbol(rawValue: "die.face.6.fill")
+    static var dieFace6Fill: SFSymbol { .init(rawValue: "die.face.6.fill") }
 
     /// 􀢹
     /// Single Localization, 2 Layersets
@@ -3219,7 +3219,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let display = SFSymbol(rawValue: "display")
+    static var display: SFSymbol { .init(rawValue: "display") }
 
     /// 􀨧
     /// Single Localization, 3 Layersets
@@ -3228,7 +3228,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let display2 = SFSymbol(rawValue: "display.2")
+    static var display2: SFSymbol { .init(rawValue: "display.2") }
 
     /// 􀨦
     /// Single Localization, 3 Layersets
@@ -3237,7 +3237,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let displayTrianglebadgeExclamationmark = SFSymbol(rawValue: "display.trianglebadge.exclamationmark")
+    static var displayTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "display.trianglebadge.exclamationmark") }
 
     /// 􀦋
     /// 2 Localizations, Single Layerset
@@ -3253,7 +3253,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "appendPageFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "appendPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "appendPageFill")
-    static let docAppendFill = SymbolWith1Localization<Rtl>(rawValue: "doc.append.fill")
+    static var docAppendFill: SymbolWith1Localization<Rtl> { .init(rawValue: "doc.append.fill") }
 
     /// 􀩴
     /// Single Localization, 3 Layersets
@@ -3267,7 +3267,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgeEllipsis")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgeEllipsis")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeEllipsis")
-    static let docBadgeEllipsis = SFSymbol(rawValue: "doc.badge.ellipsis")
+    static var docBadgeEllipsis: SFSymbol { .init(rawValue: "doc.badge.ellipsis") }
 
     /// 􀩚
     /// Single Localization, 2 Layersets
@@ -3280,7 +3280,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgeGearshape")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgeGearshape")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeGearshape")
-    static let docBadgeGearshape = SFSymbol(rawValue: "doc.badge.gearshape")
+    static var docBadgeGearshape: SFSymbol { .init(rawValue: "doc.badge.gearshape") }
 
     /// 􀩛
     /// Single Localization, 2 Layersets
@@ -3293,7 +3293,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgeGearshapeFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgeGearshapeFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeGearshapeFill")
-    static let docBadgeGearshapeFill = SFSymbol(rawValue: "doc.badge.gearshape.fill")
+    static var docBadgeGearshapeFill: SFSymbol { .init(rawValue: "doc.badge.gearshape.fill") }
 
     /// 􀣗
     /// Single Localization, 3 Layersets
@@ -3307,7 +3307,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgePlus")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgePlus")
-    static let docBadgePlus = SFSymbol(rawValue: "doc.badge.plus")
+    static var docBadgePlus: SFSymbol { .init(rawValue: "doc.badge.plus") }
 
     /// 􀩵
     /// Single Localization, 3 Layersets
@@ -3321,7 +3321,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgeEllipsisFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgeEllipsisFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeEllipsisFill")
-    static let docFillBadgeEllipsis = SFSymbol(rawValue: "doc.fill.badge.ellipsis")
+    static var docFillBadgeEllipsis: SFSymbol { .init(rawValue: "doc.fill.badge.ellipsis") }
 
     /// 􀣘
     /// Single Localization, 3 Layersets
@@ -3335,7 +3335,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "documentBadgePlusFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "documentBadgePlusFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgePlusFill")
-    static let docFillBadgePlus = SFSymbol(rawValue: "doc.fill.badge.plus")
+    static var docFillBadgePlus: SFSymbol { .init(rawValue: "doc.fill.badge.plus") }
 
     /// 􀥨
     /// Single Localization, 3 Layersets
@@ -3349,7 +3349,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "textPageFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "textPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textPageFill")
-    static let docPlaintextFill = SFSymbol(rawValue: "doc.plaintext.fill")
+    static var docPlaintextFill: SFSymbol { .init(rawValue: "doc.plaintext.fill") }
 
     /// 􀦊
     /// 8 Localizations, Single Layerset
@@ -3371,7 +3371,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "richtextPageFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "richtextPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "richtextPageFill")
-    static let docRichtextFill = SymbolWith7Localizations<Ar, He, Hi_v3, Ja_v3, Ko_v3, Th_v3, Zh_v3>(rawValue: "doc.richtext.fill")
+    static var docRichtextFill: SymbolWith7Localizations<Ar, He, Hi_v3, Ja_v3, Ko_v3, Th_v3, Zh_v3> { .init(rawValue: "doc.richtext.fill") }
 
     /// 􀳼
     /// 2 Localizations, Single Layerset
@@ -3387,7 +3387,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ecgTextPage")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ecgTextPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ecgTextPage")
-    static let docTextBelowEcg = SymbolWith1Localization<Rtl_v2_1>(rawValue: "doc.text.below.ecg")
+    static var docTextBelowEcg: SymbolWith1Localization<Rtl_v2_1> { .init(rawValue: "doc.text.below.ecg") }
 
     /// 􀳽
     /// 2 Localizations, Single Layerset
@@ -3403,7 +3403,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ecgTextPageFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ecgTextPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ecgTextPageFill")
-    static let docTextBelowEcgFill = SymbolWith1Localization<Rtl_v2_1>(rawValue: "doc.text.below.ecg.fill")
+    static var docTextBelowEcgFill: SymbolWith1Localization<Rtl_v2_1> { .init(rawValue: "doc.text.below.ecg.fill") }
 
     /// 􀡢
     /// Single Localization, Single Layerset
@@ -3415,7 +3415,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "docViewfinderFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "docViewfinderFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "docViewfinderFill")
-    static let docTextFillViewfinder = SFSymbol(rawValue: "doc.text.fill.viewfinder")
+    static var docTextFillViewfinder: SFSymbol { .init(rawValue: "doc.text.fill.viewfinder") }
 
     /// 􀤧
     /// Single Localization, Single Layerset
@@ -3427,7 +3427,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "zipperPage")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "zipperPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "zipperPage")
-    static let docZipper = SFSymbol(rawValue: "doc.zipper")
+    static var docZipper: SFSymbol { .init(rawValue: "doc.zipper") }
 
     /// 􀣿
     /// Single Localization, 2 Layersets
@@ -3435,7 +3435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dockArrowDownRectangle = SFSymbol(rawValue: "dock.arrow.down.rectangle")
+    static var dockArrowDownRectangle: SFSymbol { .init(rawValue: "dock.arrow.down.rectangle") }
 
     /// 􀣾
     /// Single Localization, 2 Layersets
@@ -3443,7 +3443,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dockArrowUpRectangle = SFSymbol(rawValue: "dock.arrow.up.rectangle")
+    static var dockArrowUpRectangle: SFSymbol { .init(rawValue: "dock.arrow.up.rectangle") }
 
     /// 􀏞
     /// Single Localization, 2 Layersets
@@ -3451,7 +3451,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dockRectangle = SFSymbol(rawValue: "dock.rectangle")
+    static var dockRectangle: SFSymbol { .init(rawValue: "dock.rectangle") }
 
     /// 􀝯
     /// Single Localization, 2 Layersets
@@ -3459,7 +3459,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dotArrowtrianglesUpRightDownLeftCircle = SFSymbol(rawValue: "dot.arrowtriangles.up.right.down.left.circle")
+    static var dotArrowtrianglesUpRightDownLeftCircle: SFSymbol { .init(rawValue: "dot.arrowtriangles.up.right.down.left.circle") }
 
     /// 􀫍
     /// Single Localization, 2 Layersets
@@ -3472,7 +3472,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "dotCircleAndPointerArrow")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "dotCircleAndPointerArrow")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "dotCircleAndPointerArrow")
-    static let dotCircleAndCursorarrow = SFSymbol(rawValue: "dot.circle.and.cursorarrow")
+    static var dotCircleAndCursorarrow: SFSymbol { .init(rawValue: "dot.circle.and.cursorarrow") }
 
     /// 􀰭
     /// Single Localization, 3 Layersets
@@ -3481,7 +3481,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotRadiowavesForward = SFSymbol(rawValue: "dot.radiowaves.forward")
+    static var dotRadiowavesForward: SFSymbol { .init(rawValue: "dot.radiowaves.forward") }
 
     /// 􀪵
     /// Single Localization, 2 Layersets
@@ -3489,7 +3489,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let dotSquareshape = SFSymbol(rawValue: "dot.squareshape")
+    static var dotSquareshape: SFSymbol { .init(rawValue: "dot.squareshape") }
 
     /// 􀪶
     /// Single Localization, 3 Layersets
@@ -3498,7 +3498,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotSquareshapeFill = SFSymbol(rawValue: "dot.squareshape.fill")
+    static var dotSquareshapeFill: SFSymbol { .init(rawValue: "dot.squareshape.fill") }
 
     /// 􀮋
     /// Single Localization, 2 Layersets
@@ -3506,14 +3506,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let dotSquareshapeSplit2x2 = SFSymbol(rawValue: "dot.squareshape.split.2x2")
+    static var dotSquareshapeSplit2x2: SFSymbol { .init(rawValue: "dot.squareshape.split.2x2") }
 
     /// 􀨲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dpad = SFSymbol(rawValue: "dpad")
+    static var dpad: SFSymbol { .init(rawValue: "dpad") }
 
     /// 􀨀
     /// Single Localization, 2 Layersets
@@ -3526,14 +3526,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "dpadDownFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "dpadDownFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dpadDownFilled")
-    static let dpadDownFill = SFSymbol(rawValue: "dpad.down.fill")
+    static var dpadDownFill: SFSymbol { .init(rawValue: "dpad.down.fill") }
 
     /// 􀧼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dpadFill = SFSymbol(rawValue: "dpad.fill")
+    static var dpadFill: SFSymbol { .init(rawValue: "dpad.fill") }
 
     /// 􀧽
     /// Single Localization, 2 Layersets
@@ -3546,7 +3546,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "dpadLeftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "dpadLeftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dpadLeftFilled")
-    static let dpadLeftFill = SFSymbol(rawValue: "dpad.left.fill")
+    static var dpadLeftFill: SFSymbol { .init(rawValue: "dpad.left.fill") }
 
     /// 􀧿
     /// Single Localization, 2 Layersets
@@ -3559,7 +3559,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "dpadRightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "dpadRightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dpadRightFilled")
-    static let dpadRightFill = SFSymbol(rawValue: "dpad.right.fill")
+    static var dpadRightFill: SFSymbol { .init(rawValue: "dpad.right.fill") }
 
     /// 􀧾
     /// Single Localization, 2 Layersets
@@ -3572,21 +3572,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "dpadUpFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "dpadUpFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "dpadUpFilled")
-    static let dpadUpFill = SFSymbol(rawValue: "dpad.up.fill")
+    static var dpadUpFill: SFSymbol { .init(rawValue: "dpad.up.fill") }
 
     /// 􀠑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let drop = SFSymbol(rawValue: "drop")
+    static var drop: SFSymbol { .init(rawValue: "drop") }
 
     /// 􀠒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dropFill = SFSymbol(rawValue: "drop.fill")
+    static var dropFill: SFSymbol { .init(rawValue: "drop.fill") }
 
     /// 􀦿
     /// Single Localization, 3 Layersets
@@ -3595,7 +3595,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let earBadgeCheckmark = SFSymbol(rawValue: "ear.badge.checkmark")
+    static var earBadgeCheckmark: SFSymbol { .init(rawValue: "ear.badge.checkmark") }
 
     /// 􀞇
     /// Single Localization, 2 Layersets
@@ -3603,7 +3603,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let earFill = SFSymbol(rawValue: "ear.fill")
+    static var earFill: SFSymbol { .init(rawValue: "ear.fill") }
 
     /// 􀧁
     /// Single Localization, 3 Layersets
@@ -3612,7 +3612,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let earTrianglebadgeExclamationmark = SFSymbol(rawValue: "ear.trianglebadge.exclamationmark")
+    static var earTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "ear.trianglebadge.exclamationmark") }
 
     /// 􀠦
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3621,7 +3621,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s EarPods.
-    static let earpods = SFSymbol(rawValue: "earpods")
+    static var earpods: SFSymbol { .init(rawValue: "earpods") }
 
     /// 􀢡
     /// Single Localization, 2 Layersets
@@ -3629,7 +3629,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ejectCircle = SFSymbol(rawValue: "eject.circle")
+    static var ejectCircle: SFSymbol { .init(rawValue: "eject.circle") }
 
     /// 􀢢
     /// Single Localization, 3 Layersets
@@ -3638,7 +3638,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let ejectCircleFill = SFSymbol(rawValue: "eject.circle.fill")
+    static var ejectCircleFill: SFSymbol { .init(rawValue: "eject.circle.fill") }
 
     /// 􀕺
     /// Single Localization, 3 Layersets
@@ -3647,7 +3647,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisBubble = SFSymbol(rawValue: "ellipsis.bubble")
+    static var ellipsisBubble: SFSymbol { .init(rawValue: "ellipsis.bubble") }
 
     /// 􀕻
     /// Single Localization, 3 Layersets
@@ -3656,7 +3656,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisBubbleFill = SFSymbol(rawValue: "ellipsis.bubble.fill")
+    static var ellipsisBubbleFill: SFSymbol { .init(rawValue: "ellipsis.bubble.fill") }
 
     /// 􀠩
     /// Single Localization, 3 Layersets
@@ -3665,7 +3665,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisRectangle = SFSymbol(rawValue: "ellipsis.rectangle")
+    static var ellipsisRectangle: SFSymbol { .init(rawValue: "ellipsis.rectangle") }
 
     /// 􀠪
     /// Single Localization, 3 Layersets
@@ -3674,7 +3674,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisRectangleFill = SFSymbol(rawValue: "ellipsis.rectangle.fill")
+    static var ellipsisRectangleFill: SFSymbol { .init(rawValue: "ellipsis.rectangle.fill") }
 
     /// 􀦗
     /// Single Localization, 2 Layersets
@@ -3687,7 +3687,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "envelopeAndArrowTriangleheadBranch")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "envelopeAndArrowTriangleheadBranch")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "envelopeAndArrowTriangleheadBranch")
-    static let envelopeArrowTriangleBranch = SFSymbol(rawValue: "envelope.arrow.triangle.branch")
+    static var envelopeArrowTriangleBranch: SFSymbol { .init(rawValue: "envelope.arrow.triangle.branch") }
 
     /// 􀦘
     /// Single Localization, 2 Layersets
@@ -3700,7 +3700,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "envelopeAndArrowTriangleheadBranchFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "envelopeAndArrowTriangleheadBranchFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "envelopeAndArrowTriangleheadBranchFill")
-    static let envelopeArrowTriangleBranchFill = SFSymbol(rawValue: "envelope.arrow.triangle.branch.fill")
+    static var envelopeArrowTriangleBranchFill: SFSymbol { .init(rawValue: "envelope.arrow.triangle.branch.fill") }
 
     /// 􀫙
     /// Single Localization, 2 Layersets
@@ -3713,7 +3713,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "envelopeBadgeShieldHalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "envelopeBadgeShieldHalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "envelopeBadgeShieldHalfFilled")
-    static let envelopeBadgeShieldLeadinghalfFill = SFSymbol(rawValue: "envelope.badge.shield.leadinghalf.fill")
+    static var envelopeBadgeShieldLeadinghalfFill: SFSymbol { .init(rawValue: "envelope.badge.shield.leadinghalf.fill") }
 
     /// 􀫚
     /// Single Localization, 2 Layersets
@@ -3726,21 +3726,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "envelopeBadgeShieldHalfFilledFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "envelopeBadgeShieldHalfFilledFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "envelopeBadgeShieldHalfFilledFill")
-    static let envelopeFillBadgeShieldTrailinghalfFill = SFSymbol(rawValue: "envelope.fill.badge.shield.trailinghalf.fill")
+    static var envelopeFillBadgeShieldTrailinghalfFill: SFSymbol { .init(rawValue: "envelope.fill.badge.shield.trailinghalf.fill") }
 
     /// 􀲵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let esim = SFSymbol(rawValue: "esim")
+    static var esim: SFSymbol { .init(rawValue: "esim") }
 
     /// 􀲶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let esimFill = SFSymbol(rawValue: "esim.fill")
+    static var esimFill: SFSymbol { .init(rawValue: "esim.fill") }
 
     /// 􀢒
     /// Single Localization, 2 Layersets
@@ -3748,7 +3748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmark2 = SFSymbol(rawValue: "exclamationmark.2")
+    static var exclamationmark2: SFSymbol { .init(rawValue: "exclamationmark.2") }
 
     /// 􀣴
     /// Single Localization, 2 Layersets
@@ -3756,7 +3756,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let exclamationmark3 = SFSymbol(rawValue: "exclamationmark.3")
+    static var exclamationmark3: SFSymbol { .init(rawValue: "exclamationmark.3") }
 
     /// 􀱨
     /// Single Localization, 2 Layersets
@@ -3769,7 +3769,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "exclamationmarkArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "exclamationmarkArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "exclamationmarkArrowTriangleheadCounterclockwiseRotate90")
-    static let exclamationmarkArrowCirclepath = SFSymbol(rawValue: "exclamationmark.arrow.circlepath")
+    static var exclamationmarkArrowCirclepath: SFSymbol { .init(rawValue: "exclamationmark.arrow.circlepath") }
 
     /// 􀢤
     /// Single Localization, 2 Layersets
@@ -3782,14 +3782,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "exclamationmarkArrowTrianglehead2ClockwiseRotate90")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "exclamationmarkArrowTrianglehead2ClockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "exclamationmarkArrowTrianglehead2ClockwiseRotate90")
-    static let exclamationmarkArrowTriangle2Circlepath = SFSymbol(rawValue: "exclamationmark.arrow.triangle.2.circlepath")
+    static var exclamationmarkArrowTriangle2Circlepath: SFSymbol { .init(rawValue: "exclamationmark.arrow.triangle.2.circlepath") }
 
     /// 􀤂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let externaldrive = SFSymbol(rawValue: "externaldrive")
+    static var externaldrive: SFSymbol { .init(rawValue: "externaldrive") }
 
     /// 􀩐
     /// Single Localization, 3 Layersets
@@ -3798,7 +3798,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgeCheckmark = SFSymbol(rawValue: "externaldrive.badge.checkmark")
+    static var externaldriveBadgeCheckmark: SFSymbol { .init(rawValue: "externaldrive.badge.checkmark") }
 
     /// 􀪹
     /// Single Localization, 3 Layersets
@@ -3807,7 +3807,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let externaldriveBadgeIcloud = SFSymbol(rawValue: "externaldrive.badge.icloud")
+    static var externaldriveBadgeIcloud: SFSymbol { .init(rawValue: "externaldrive.badge.icloud") }
 
     /// 􀩏
     /// Single Localization, 3 Layersets
@@ -3816,7 +3816,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgeMinus = SFSymbol(rawValue: "externaldrive.badge.minus")
+    static var externaldriveBadgeMinus: SFSymbol { .init(rawValue: "externaldrive.badge.minus") }
 
     /// 􀩬
     /// Single Localization, 3 Layersets
@@ -3825,7 +3825,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let externaldriveBadgePersonCrop = SFSymbol(rawValue: "externaldrive.badge.person.crop")
+    static var externaldriveBadgePersonCrop: SFSymbol { .init(rawValue: "externaldrive.badge.person.crop") }
 
     /// 􀩎
     /// Single Localization, 3 Layersets
@@ -3834,7 +3834,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgePlus = SFSymbol(rawValue: "externaldrive.badge.plus")
+    static var externaldriveBadgePlus: SFSymbol { .init(rawValue: "externaldrive.badge.plus") }
 
     /// 􀤜
     /// Single Localization, 2 Layersets
@@ -3842,7 +3842,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgeTimemachine = SFSymbol(rawValue: "externaldrive.badge.timemachine")
+    static var externaldriveBadgeTimemachine: SFSymbol { .init(rawValue: "externaldrive.badge.timemachine") }
 
     /// 􀩮
     /// Single Localization, 3 Layersets
@@ -3851,7 +3851,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgeWifi = SFSymbol(rawValue: "externaldrive.badge.wifi")
+    static var externaldriveBadgeWifi: SFSymbol { .init(rawValue: "externaldrive.badge.wifi") }
 
     /// 􀩑
     /// Single Localization, 3 Layersets
@@ -3860,28 +3860,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveBadgeXmark = SFSymbol(rawValue: "externaldrive.badge.xmark")
+    static var externaldriveBadgeXmark: SFSymbol { .init(rawValue: "externaldrive.badge.xmark") }
 
     /// 􀨤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let externaldriveConnectedToLineBelow = SFSymbol(rawValue: "externaldrive.connected.to.line.below")
+    static var externaldriveConnectedToLineBelow: SFSymbol { .init(rawValue: "externaldrive.connected.to.line.below") }
 
     /// 􀨥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let externaldriveConnectedToLineBelowFill = SFSymbol(rawValue: "externaldrive.connected.to.line.below.fill")
+    static var externaldriveConnectedToLineBelowFill: SFSymbol { .init(rawValue: "externaldrive.connected.to.line.below.fill") }
 
     /// 􀤃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let externaldriveFill = SFSymbol(rawValue: "externaldrive.fill")
+    static var externaldriveFill: SFSymbol { .init(rawValue: "externaldrive.fill") }
 
     /// 􀩔
     /// Single Localization, 3 Layersets
@@ -3890,7 +3890,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgeCheckmark = SFSymbol(rawValue: "externaldrive.fill.badge.checkmark")
+    static var externaldriveFillBadgeCheckmark: SFSymbol { .init(rawValue: "externaldrive.fill.badge.checkmark") }
 
     /// 􀪺
     /// Single Localization, 3 Layersets
@@ -3899,7 +3899,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let externaldriveFillBadgeIcloud = SFSymbol(rawValue: "externaldrive.fill.badge.icloud")
+    static var externaldriveFillBadgeIcloud: SFSymbol { .init(rawValue: "externaldrive.fill.badge.icloud") }
 
     /// 􀩓
     /// Single Localization, 3 Layersets
@@ -3908,7 +3908,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgeMinus = SFSymbol(rawValue: "externaldrive.fill.badge.minus")
+    static var externaldriveFillBadgeMinus: SFSymbol { .init(rawValue: "externaldrive.fill.badge.minus") }
 
     /// 􀩭
     /// Single Localization, 3 Layersets
@@ -3917,7 +3917,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let externaldriveFillBadgePersonCrop = SFSymbol(rawValue: "externaldrive.fill.badge.person.crop")
+    static var externaldriveFillBadgePersonCrop: SFSymbol { .init(rawValue: "externaldrive.fill.badge.person.crop") }
 
     /// 􀩒
     /// Single Localization, 3 Layersets
@@ -3926,7 +3926,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgePlus = SFSymbol(rawValue: "externaldrive.fill.badge.plus")
+    static var externaldriveFillBadgePlus: SFSymbol { .init(rawValue: "externaldrive.fill.badge.plus") }
 
     /// 􀤝
     /// Single Localization, 2 Layersets
@@ -3934,7 +3934,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgeTimemachine = SFSymbol(rawValue: "externaldrive.fill.badge.timemachine")
+    static var externaldriveFillBadgeTimemachine: SFSymbol { .init(rawValue: "externaldrive.fill.badge.timemachine") }
 
     /// 􀩯
     /// Single Localization, 3 Layersets
@@ -3943,7 +3943,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgeWifi = SFSymbol(rawValue: "externaldrive.fill.badge.wifi")
+    static var externaldriveFillBadgeWifi: SFSymbol { .init(rawValue: "externaldrive.fill.badge.wifi") }
 
     /// 􀩕
     /// Single Localization, 3 Layersets
@@ -3952,7 +3952,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 14.2, macOS 11.0, tvOS 14.2, watchOS 7.1)
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let externaldriveFillBadgeXmark = SFSymbol(rawValue: "externaldrive.fill.badge.xmark")
+    static var externaldriveFillBadgeXmark: SFSymbol { .init(rawValue: "externaldrive.fill.badge.xmark") }
 
     /// 􀛿
     /// Single Localization, 2 Layersets
@@ -3960,7 +3960,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eyeCircle = SFSymbol(rawValue: "eye.circle")
+    static var eyeCircle: SFSymbol { .init(rawValue: "eye.circle") }
 
     /// 􀜀
     /// Single Localization, 3 Layersets
@@ -3969,7 +3969,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eyeCircleFill = SFSymbol(rawValue: "eye.circle.fill")
+    static var eyeCircleFill: SFSymbol { .init(rawValue: "eye.circle.fill") }
 
     /// 􀦭
     /// Single Localization, 2 Layersets
@@ -3977,21 +3977,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let eyebrow = SFSymbol(rawValue: "eyebrow")
+    static var eyebrow: SFSymbol { .init(rawValue: "eyebrow") }
 
     /// 􀦧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyes = SFSymbol(rawValue: "eyes")
+    static var eyes: SFSymbol { .init(rawValue: "eyes") }
 
     /// 􀨭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyesInverse = SFSymbol(rawValue: "eyes.inverse")
+    static var eyesInverse: SFSymbol { .init(rawValue: "eyes.inverse") }
 
     /// 􀥧
     /// Single Localization, 2 Layersets
@@ -3999,7 +3999,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let faceDashed = SFSymbol(rawValue: "face.dashed")
+    static var faceDashed: SFSymbol { .init(rawValue: "face.dashed") }
 
     /// 􀨸
     /// Single Localization, 2 Layersets
@@ -4007,7 +4007,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let faceDashedFill = SFSymbol(rawValue: "face.dashed.fill")
+    static var faceDashedFill: SFSymbol { .init(rawValue: "face.dashed.fill") }
 
     /// 􀎸
     /// Single Localization, 2 Layersets
@@ -4015,7 +4015,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let faceSmiling = SFSymbol(rawValue: "face.smiling")
+    static var faceSmiling: SFSymbol { .init(rawValue: "face.smiling") }
 
     /// 􀙌
     /// Single Localization, 3 Layersets
@@ -4029,14 +4029,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "faceSmilingInverse")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "faceSmilingInverse")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "faceSmilingInverse")
-    static let faceSmilingFill = SFSymbol(rawValue: "face.smiling.fill")
+    static var faceSmilingFill: SFSymbol { .init(rawValue: "face.smiling.fill") }
 
     /// 􀪌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let faxmachine = SFSymbol(rawValue: "faxmachine")
+    static var faxmachine: SFSymbol { .init(rawValue: "faxmachine") }
 
     /// 􀥢
     /// Single Localization, Single Layerset
@@ -4048,14 +4048,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "fibrechannel")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "fibrechannel")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "fibrechannel")
-    static let fiberchannel = SFSymbol(rawValue: "fiberchannel")
+    static var fiberchannel: SFSymbol { .init(rawValue: "fiberchannel") }
 
     /// 􀳾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStand = SFSymbol(rawValue: "figure.stand")
+    static var figureStand: SFSymbol { .init(rawValue: "figure.stand") }
 
     /// 􀳿
     /// Single Localization, 2 Layersets
@@ -4063,14 +4063,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureStandLineDottedFigureStand = SFSymbol(rawValue: "figure.stand.line.dotted.figure.stand")
+    static var figureStandLineDottedFigureStand: SFSymbol { .init(rawValue: "figure.stand.line.dotted.figure.stand") }
 
     /// 􀝢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWalk = SFSymbol(rawValue: "figure.walk")
+    static var figureWalk: SFSymbol { .init(rawValue: "figure.walk") }
 
     /// 􀝣
     /// Single Localization, 2 Layersets
@@ -4078,7 +4078,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureWalkCircle = SFSymbol(rawValue: "figure.walk.circle")
+    static var figureWalkCircle: SFSymbol { .init(rawValue: "figure.walk.circle") }
 
     /// 􀝤
     /// Single Localization, 3 Layersets
@@ -4087,7 +4087,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureWalkCircleFill = SFSymbol(rawValue: "figure.walk.circle.fill")
+    static var figureWalkCircleFill: SFSymbol { .init(rawValue: "figure.walk.circle.fill") }
 
     /// 􀪢
     /// Single Localization, 2 Layersets
@@ -4095,7 +4095,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureWalkDiamond = SFSymbol(rawValue: "figure.walk.diamond")
+    static var figureWalkDiamond: SFSymbol { .init(rawValue: "figure.walk.diamond") }
 
     /// 􀪣
     /// Single Localization, 3 Layersets
@@ -4104,14 +4104,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let figureWalkDiamondFill = SFSymbol(rawValue: "figure.walk.diamond.fill")
+    static var figureWalkDiamondFill: SFSymbol { .init(rawValue: "figure.walk.diamond.fill") }
 
     /// 􀝻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWave = SFSymbol(rawValue: "figure.wave")
+    static var figureWave: SFSymbol { .init(rawValue: "figure.wave") }
 
     /// 􀝼
     /// Single Localization, 2 Layersets
@@ -4119,7 +4119,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureWaveCircle = SFSymbol(rawValue: "figure.wave.circle")
+    static var figureWaveCircle: SFSymbol { .init(rawValue: "figure.wave.circle") }
 
     /// 􀝽
     /// Single Localization, 3 Layersets
@@ -4128,7 +4128,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let figureWaveCircleFill = SFSymbol(rawValue: "figure.wave.circle.fill")
+    static var figureWaveCircleFill: SFSymbol { .init(rawValue: "figure.wave.circle.fill") }
 
     /// 􀯪
     /// 2 Localizations, 2 Layersets
@@ -4145,7 +4145,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "filemenuAndPointerArrow")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "filemenuAndPointerArrow")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "filemenuAndPointerArrow")
-    static let filemenuAndCursorarrow = SymbolWith1Localization<Rtl>(rawValue: "filemenu.and.cursorarrow")
+    static var filemenuAndCursorarrow: SymbolWith1Localization<Rtl> { .init(rawValue: "filemenu.and.cursorarrow") }
 
     /// 􀱢
     /// Single Localization, 3 Layersets
@@ -4154,7 +4154,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let filemenuAndSelection = SFSymbol(rawValue: "filemenu.and.selection")
+    static var filemenuAndSelection: SFSymbol { .init(rawValue: "filemenu.and.selection") }
 
     /// 􀤔
     /// Single Localization, 3 Layersets
@@ -4163,7 +4163,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let flagBadgeEllipsis = SFSymbol(rawValue: "flag.badge.ellipsis")
+    static var flagBadgeEllipsis: SFSymbol { .init(rawValue: "flag.badge.ellipsis") }
 
     /// 􀤕
     /// Single Localization, 3 Layersets
@@ -4172,7 +4172,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let flagBadgeEllipsisFill = SFSymbol(rawValue: "flag.badge.ellipsis.fill")
+    static var flagBadgeEllipsisFill: SFSymbol { .init(rawValue: "flag.badge.ellipsis.fill") }
 
     /// 􀋏
     /// Single Localization, 3 Layersets
@@ -4181,7 +4181,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let flagSlashCircle = SFSymbol(rawValue: "flag.slash.circle")
+    static var flagSlashCircle: SFSymbol { .init(rawValue: "flag.slash.circle") }
 
     /// 􀋐
     /// Single Localization, 3 Layersets
@@ -4190,21 +4190,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let flagSlashCircleFill = SFSymbol(rawValue: "flag.slash.circle.fill")
+    static var flagSlashCircleFill: SFSymbol { .init(rawValue: "flag.slash.circle.fill") }
 
     /// 􀪴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flipphone = SFSymbol(rawValue: "flipphone")
+    static var flipphone: SFSymbol { .init(rawValue: "flipphone") }
 
     /// 􀥌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fn = SFSymbol(rawValue: "fn")
+    static var fn: SFSymbol { .init(rawValue: "fn") }
 
     /// 􀣍
     /// Single Localization, 2 Layersets
@@ -4217,7 +4217,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "folderBadgeGearshape")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "folderBadgeGearshape")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "folderBadgeGearshape")
-    static let folderBadgeGear = SFSymbol(rawValue: "folder.badge.gear")
+    static var folderBadgeGear: SFSymbol { .init(rawValue: "folder.badge.gear") }
 
     /// 􀧆
     /// 2 Localizations, 3 Layersets
@@ -4230,7 +4230,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "folder.badge.questionmark")
+    static var folderBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "folder.badge.questionmark") }
 
     /// 􀣎
     /// Single Localization, 2 Layersets
@@ -4243,7 +4243,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "folderFillBadgeGearshape")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "folderFillBadgeGearshape")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "folderFillBadgeGearshape")
-    static let folderFillBadgeGear = SFSymbol(rawValue: "folder.fill.badge.gear")
+    static var folderFillBadgeGear: SFSymbol { .init(rawValue: "folder.fill.badge.gear") }
 
     /// 􀧇
     /// 2 Localizations, 3 Layersets
@@ -4256,49 +4256,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let folderFillBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "folder.fill.badge.questionmark")
+    static var folderFillBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "folder.fill.badge.questionmark") }
 
     /// 􀩪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardFrame = SFSymbol(rawValue: "forward.frame")
+    static var forwardFrame: SFSymbol { .init(rawValue: "forward.frame") }
 
     /// 􀩫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let forwardFrameFill = SFSymbol(rawValue: "forward.frame.fill")
+    static var forwardFrameFill: SFSymbol { .init(rawValue: "forward.frame.fill") }
 
     /// 􀣋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gearshape = SFSymbol(rawValue: "gearshape")
+    static var gearshape: SFSymbol { .init(rawValue: "gearshape") }
 
     /// 􀥎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gearshape2 = SFSymbol(rawValue: "gearshape.2")
+    static var gearshape2: SFSymbol { .init(rawValue: "gearshape.2") }
 
     /// 􀥏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gearshape2Fill = SFSymbol(rawValue: "gearshape.2.fill")
+    static var gearshape2Fill: SFSymbol { .init(rawValue: "gearshape.2.fill") }
 
     /// 􀣌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gearshapeFill = SFSymbol(rawValue: "gearshape.fill")
+    static var gearshapeFill: SFSymbol { .init(rawValue: "gearshape.fill") }
 
     /// 􀓀
     /// Single Localization, 3 Layersets
@@ -4307,7 +4307,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let giftCircle = SFSymbol(rawValue: "gift.circle")
+    static var giftCircle: SFSymbol { .init(rawValue: "gift.circle") }
 
     /// 􀓁
     /// Single Localization, 3 Layersets
@@ -4316,49 +4316,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let giftCircleFill = SFSymbol(rawValue: "gift.circle.fill")
+    static var giftCircleFill: SFSymbol { .init(rawValue: "gift.circle.fill") }
 
     /// 􀦠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let giftcard = SFSymbol(rawValue: "giftcard")
+    static var giftcard: SFSymbol { .init(rawValue: "giftcard") }
 
     /// 􀦡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let giftcardFill = SFSymbol(rawValue: "giftcard.fill")
+    static var giftcardFill: SFSymbol { .init(rawValue: "giftcard.fill") }
 
     /// 􀫓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let graduationcap = SFSymbol(rawValue: "graduationcap")
+    static var graduationcap: SFSymbol { .init(rawValue: "graduationcap") }
 
     /// 􀫔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let graduationcapFill = SFSymbol(rawValue: "graduationcap.fill")
+    static var graduationcapFill: SFSymbol { .init(rawValue: "graduationcap.fill") }
 
     /// 􀤠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let greetingcard = SFSymbol(rawValue: "greetingcard")
+    static var greetingcard: SFSymbol { .init(rawValue: "greetingcard") }
 
     /// 􀤡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let greetingcardFill = SFSymbol(rawValue: "greetingcard.fill")
+    static var greetingcardFill: SFSymbol { .init(rawValue: "greetingcard.fill") }
 
     /// 􀟑
     /// Single Localization, 2 Layersets
@@ -4366,14 +4366,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let guitarsFill = SFSymbol(rawValue: "guitars.fill")
+    static var guitarsFill: SFSymbol { .init(rawValue: "guitars.fill") }
 
     /// 􀬗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gyroscope = SFSymbol(rawValue: "gyroscope")
+    static var gyroscope: SFSymbol { .init(rawValue: "gyroscope") }
 
     /// 􀭝
     /// Single Localization, 3 Layersets
@@ -4387,7 +4387,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "hSquareOnSquareFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "hSquareOnSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "hSquareOnSquareFill")
-    static let hSquareFillOnSquareFill = SFSymbol(rawValue: "h.square.fill.on.square.fill")
+    static var hSquareFillOnSquareFill: SFSymbol { .init(rawValue: "h.square.fill.on.square.fill") }
 
     /// 􀭜
     /// Single Localization, 3 Layersets
@@ -4396,28 +4396,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let hSquareOnSquare = SFSymbol(rawValue: "h.square.on.square")
+    static var hSquareOnSquare: SFSymbol { .init(rawValue: "h.square.on.square") }
 
     /// 􀤻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointDown = SFSymbol(rawValue: "hand.point.down")
+    static var handPointDown: SFSymbol { .init(rawValue: "hand.point.down") }
 
     /// 􀤼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointDownFill = SFSymbol(rawValue: "hand.point.down.fill")
+    static var handPointDownFill: SFSymbol { .init(rawValue: "hand.point.down.fill") }
 
     /// 􀤹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointUp = SFSymbol(rawValue: "hand.point.up")
+    static var handPointUp: SFSymbol { .init(rawValue: "hand.point.up") }
 
     /// 􀦂
     /// Single Localization, 2 Layersets
@@ -4425,7 +4425,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handPointUpBraille = SFSymbol(rawValue: "hand.point.up.braille")
+    static var handPointUpBraille: SFSymbol { .init(rawValue: "hand.point.up.braille") }
 
     /// 􀦃
     /// Single Localization, 2 Layersets
@@ -4433,28 +4433,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handPointUpBrailleFill = SFSymbol(rawValue: "hand.point.up.braille.fill")
+    static var handPointUpBrailleFill: SFSymbol { .init(rawValue: "hand.point.up.braille.fill") }
 
     /// 􀤺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointUpFill = SFSymbol(rawValue: "hand.point.up.fill")
+    static var handPointUpFill: SFSymbol { .init(rawValue: "hand.point.up.fill") }
 
     /// 􀝰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointUpLeft = SFSymbol(rawValue: "hand.point.up.left")
+    static var handPointUpLeft: SFSymbol { .init(rawValue: "hand.point.up.left") }
 
     /// 􀝱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPointUpLeftFill = SFSymbol(rawValue: "hand.point.up.left.fill")
+    static var handPointUpLeftFill: SFSymbol { .init(rawValue: "hand.point.up.left.fill") }
 
     /// 􀬁
     /// Single Localization, 2 Layersets
@@ -4462,7 +4462,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handTap = SFSymbol(rawValue: "hand.tap")
+    static var handTap: SFSymbol { .init(rawValue: "hand.tap") }
 
     /// 􀬂
     /// Single Localization, 2 Layersets
@@ -4470,21 +4470,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handTapFill = SFSymbol(rawValue: "hand.tap.fill")
+    static var handTapFill: SFSymbol { .init(rawValue: "hand.tap.fill") }
 
     /// 􀟰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handWave = SFSymbol(rawValue: "hand.wave")
+    static var handWave: SFSymbol { .init(rawValue: "hand.wave") }
 
     /// 􀟱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handWaveFill = SFSymbol(rawValue: "hand.wave.fill")
+    static var handWaveFill: SFSymbol { .init(rawValue: "hand.wave.fill") }
 
     /// 􀟮
     /// Single Localization, 2 Layersets
@@ -4492,7 +4492,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handsClap = SFSymbol(rawValue: "hands.clap")
+    static var handsClap: SFSymbol { .init(rawValue: "hands.clap") }
 
     /// 􀟯
     /// Single Localization, 2 Layersets
@@ -4500,7 +4500,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let handsClapFill = SFSymbol(rawValue: "hands.clap.fill")
+    static var handsClapFill: SFSymbol { .init(rawValue: "hands.clap.fill") }
 
     /// 􀲮
     /// Single Localization, 2 Layersets
@@ -4513,7 +4513,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "handsAndSparkles")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "handsAndSparkles")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "handsAndSparkles")
-    static let handsSparkles = SFSymbol(rawValue: "hands.sparkles")
+    static var handsSparkles: SFSymbol { .init(rawValue: "hands.sparkles") }
 
     /// 􀲯
     /// Single Localization, 2 Layersets
@@ -4526,7 +4526,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "handsAndSparklesFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "handsAndSparklesFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "handsAndSparklesFill")
-    static let handsSparklesFill = SFSymbol(rawValue: "hands.sparkles.fill")
+    static var handsSparklesFill: SFSymbol { .init(rawValue: "hands.sparkles.fill") }
 
     /// 􀒾
     /// Single Localization, 2 Layersets
@@ -4534,7 +4534,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let headphonesCircle = SFSymbol(rawValue: "headphones.circle")
+    static var headphonesCircle: SFSymbol { .init(rawValue: "headphones.circle") }
 
     /// 􀒿
     /// Single Localization, 3 Layersets
@@ -4543,7 +4543,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let headphonesCircleFill = SFSymbol(rawValue: "headphones.circle.fill")
+    static var headphonesCircleFill: SFSymbol { .init(rawValue: "headphones.circle.fill") }
 
     /// 􀪓
     /// Single Localization, 2 Layersets
@@ -4556,7 +4556,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "hearingdeviceEar")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "hearingdeviceEar")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "hearingdeviceEar")
-    static let hearingaidEar = SFSymbol(rawValue: "hearingaid.ear")
+    static var hearingaidEar: SFSymbol { .init(rawValue: "hearingaid.ear") }
 
     /// 􀥴
     /// Single Localization, 2 Layersets
@@ -4564,7 +4564,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let heartTextSquare = SFSymbol(rawValue: "heart.text.square")
+    static var heartTextSquare: SFSymbol { .init(rawValue: "heart.text.square") }
 
     /// 􀥵
     /// Single Localization, 3 Layersets
@@ -4573,14 +4573,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let heartTextSquareFill = SFSymbol(rawValue: "heart.text.square.fill")
+    static var heartTextSquareFill: SFSymbol { .init(rawValue: "heart.text.square.fill") }
 
     /// 􀟵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hifispeaker2 = SFSymbol(rawValue: "hifispeaker.2")
+    static var hifispeaker2: SFSymbol { .init(rawValue: "hifispeaker.2") }
 
     /// 􀟶
     /// Single Localization, 2 Layersets
@@ -4588,7 +4588,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let hifispeaker2Fill = SFSymbol(rawValue: "hifispeaker.2.fill")
+    static var hifispeaker2Fill: SFSymbol { .init(rawValue: "hifispeaker.2.fill") }
 
     /// 􀮎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4598,7 +4598,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepod = SFSymbol(rawValue: "hifispeaker.and.homepod")
+    static var hifispeakerAndHomepod: SFSymbol { .init(rawValue: "hifispeaker.and.homepod") }
 
     /// 􀟴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4608,7 +4608,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepodFill = SFSymbol(rawValue: "hifispeaker.and.homepod.fill")
+    static var hifispeakerAndHomepodFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.fill") }
 
     /// 􀦇
     /// Single Localization, 2 Layersets
@@ -4616,7 +4616,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let highlighter = SFSymbol(rawValue: "highlighter")
+    static var highlighter: SFSymbol { .init(rawValue: "highlighter") }
 
     /// 􀠀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4632,7 +4632,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "appleHomekit")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "appleHomekit")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "appleHomekit")
-    static let homekit = SFSymbol(rawValue: "homekit")
+    static var homekit: SFSymbol { .init(rawValue: "homekit") }
 
     /// 􀟢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4642,7 +4642,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod = SFSymbol(rawValue: "homepod")
+    static var homepod: SFSymbol { .init(rawValue: "homepod") }
 
     /// 􀮍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4652,7 +4652,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2 = SFSymbol(rawValue: "homepod.2")
+    static var homepod2: SFSymbol { .init(rawValue: "homepod.2") }
 
     /// 􀟳
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4662,7 +4662,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2Fill = SFSymbol(rawValue: "homepod.2.fill")
+    static var homepod2Fill: SFSymbol { .init(rawValue: "homepod.2.fill") }
 
     /// 􀟣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4672,7 +4672,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodFill = SFSymbol(rawValue: "homepod.fill")
+    static var homepodFill: SFSymbol { .init(rawValue: "homepod.fill") }
 
     /// 􀣬
     /// Single Localization, 3 Layersets
@@ -4681,7 +4681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let hourglassBadgePlus = SFSymbol(rawValue: "hourglass.badge.plus")
+    static var hourglassBadgePlus: SFSymbol { .init(rawValue: "hourglass.badge.plus") }
 
     /// 􀥆
     /// Single Localization, 3 Layersets
@@ -4690,7 +4690,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let houseCircle = SFSymbol(rawValue: "house.circle")
+    static var houseCircle: SFSymbol { .init(rawValue: "house.circle") }
 
     /// 􀥇
     /// Single Localization, 3 Layersets
@@ -4699,28 +4699,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let houseCircleFill = SFSymbol(rawValue: "house.circle.fill")
+    static var houseCircleFill: SFSymbol { .init(rawValue: "house.circle.fill") }
 
     /// 􀯠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let infinity = SFSymbol(rawValue: "infinity")
+    static var infinity: SFSymbol { .init(rawValue: "infinity") }
 
     /// 􀥾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let internaldrive = SFSymbol(rawValue: "internaldrive")
+    static var internaldrive: SFSymbol { .init(rawValue: "internaldrive") }
 
     /// 􀨪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let internaldriveFill = SFSymbol(rawValue: "internaldrive.fill")
+    static var internaldriveFill: SFSymbol { .init(rawValue: "internaldrive.fill") }
 
     /// 􀟠
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4730,7 +4730,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipad = SFSymbol(rawValue: "ipad")
+    static var ipad: SFSymbol { .init(rawValue: "ipad") }
 
     /// 􀟟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4745,7 +4745,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "ipadGen1")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "ipadGen1")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ipadGen1")
-    static let ipadHomebutton = SFSymbol(rawValue: "ipad.homebutton")
+    static var ipadHomebutton: SFSymbol { .init(rawValue: "ipad.homebutton") }
 
     /// 􀥓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4760,7 +4760,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "ipadGen1Landscape")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "ipadGen1Landscape")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ipadGen1Landscape")
-    static let ipadHomebuttonLandscape = SFSymbol(rawValue: "ipad.homebutton.landscape")
+    static var ipadHomebuttonLandscape: SFSymbol { .init(rawValue: "ipad.homebutton.landscape") }
 
     /// 􀥔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4770,7 +4770,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadLandscape = SFSymbol(rawValue: "ipad.landscape")
+    static var ipadLandscape: SFSymbol { .init(rawValue: "ipad.landscape") }
 
     /// 􀟜
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4780,7 +4780,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphone = SFSymbol(rawValue: "iphone")
+    static var iphone: SFSymbol { .init(rawValue: "iphone") }
 
     /// 􀟝
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4795,7 +4795,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "iphoneGen1")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "iphoneGen1")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1")
-    static let iphoneHomebutton = SFSymbol(rawValue: "iphone.homebutton")
+    static var iphoneHomebutton: SFSymbol { .init(rawValue: "iphone.homebutton") }
 
     /// 􀡆
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4811,7 +4811,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "iphoneGen1RadiowavesLeftAndRight")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "iphoneGen1RadiowavesLeftAndRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1RadiowavesLeftAndRight")
-    static let iphoneHomebuttonRadiowavesLeftAndRight = SFSymbol(rawValue: "iphone.homebutton.radiowaves.left.and.right")
+    static var iphoneHomebuttonRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "iphone.homebutton.radiowaves.left.and.right") }
 
     /// 􀨴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4826,7 +4826,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "iphoneGen1Slash")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "iphoneGen1Slash")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1Slash")
-    static let iphoneHomebuttonSlash = SFSymbol(rawValue: "iphone.homebutton.slash")
+    static var iphoneHomebuttonSlash: SFSymbol { .init(rawValue: "iphone.homebutton.slash") }
 
     /// 􀡇
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4837,7 +4837,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneRadiowavesLeftAndRight = SFSymbol(rawValue: "iphone.radiowaves.left.and.right")
+    static var iphoneRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "iphone.radiowaves.left.and.right") }
 
     /// 􀨵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4847,7 +4847,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneSlash = SFSymbol(rawValue: "iphone.slash")
+    static var iphoneSlash: SFSymbol { .init(rawValue: "iphone.slash") }
 
     /// 􀢺
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4857,7 +4857,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod.
-    static let ipod = SFSymbol(rawValue: "ipod")
+    static var ipod: SFSymbol { .init(rawValue: "ipod") }
 
     /// 􀫨
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4871,7 +4871,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ipodShuffleGen1")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ipodShuffleGen1")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodShuffleGen1")
-    static let ipodshuffleGen1 = SFSymbol(rawValue: "ipodshuffle.gen1")
+    static var ipodshuffleGen1: SFSymbol { .init(rawValue: "ipodshuffle.gen1") }
 
     /// 􀫩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4885,7 +4885,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ipodShuffleGen2")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ipodShuffleGen2")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodShuffleGen2")
-    static let ipodshuffleGen2 = SFSymbol(rawValue: "ipodshuffle.gen2")
+    static var ipodshuffleGen2: SFSymbol { .init(rawValue: "ipodshuffle.gen2") }
 
     /// 􀫪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4899,7 +4899,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ipodShuffleGen3")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ipodShuffleGen3")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodShuffleGen3")
-    static let ipodshuffleGen3 = SFSymbol(rawValue: "ipodshuffle.gen3")
+    static var ipodshuffleGen3: SFSymbol { .init(rawValue: "ipodshuffle.gen3") }
 
     /// 􀫫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4913,7 +4913,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ipodShuffleGen4")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ipodShuffleGen4")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodShuffleGen4")
-    static let ipodshuffleGen4 = SFSymbol(rawValue: "ipodshuffle.gen4")
+    static var ipodshuffleGen4: SFSymbol { .init(rawValue: "ipodshuffle.gen4") }
 
     /// 􀫧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4928,7 +4928,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "ipodTouch")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "ipodTouch")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodTouch")
-    static let ipodtouch = SFSymbol(rawValue: "ipodtouch")
+    static var ipodtouch: SFSymbol { .init(rawValue: "ipodtouch") }
 
     /// 􀭛
     /// Single Localization, 3 Layersets
@@ -4942,7 +4942,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "jSquareOnSquareFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "jSquareOnSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "jSquareOnSquareFill")
-    static let jSquareFillOnSquareFill = SFSymbol(rawValue: "j.square.fill.on.square.fill")
+    static var jSquareFillOnSquareFill: SFSymbol { .init(rawValue: "j.square.fill.on.square.fill") }
 
     /// 􀭚
     /// Single Localization, 3 Layersets
@@ -4951,28 +4951,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let jSquareOnSquare = SFSymbol(rawValue: "j.square.on.square")
+    static var jSquareOnSquare: SFSymbol { .init(rawValue: "j.square.on.square") }
 
     /// 􀥋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let k = SFSymbol(rawValue: "k")
+    static var k: SFSymbol { .init(rawValue: "k") }
 
     /// 􀟕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let key = SFSymbol(rawValue: "key")
+    static var key: SFSymbol { .init(rawValue: "key") }
 
     /// 􀟖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyFill = SFSymbol(rawValue: "key.fill")
+    static var keyFill: SFSymbol { .init(rawValue: "key.fill") }
 
     /// 􀢕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4982,7 +4982,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let keyIcloud = SFSymbol(rawValue: "key.icloud")
+    static var keyIcloud: SFSymbol { .init(rawValue: "key.icloud") }
 
     /// 􀢖
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4993,7 +4993,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let keyIcloudFill = SFSymbol(rawValue: "key.icloud.fill")
+    static var keyIcloudFill: SFSymbol { .init(rawValue: "key.icloud.fill") }
 
     /// 􀫒
     /// Single Localization, 3 Layersets
@@ -5002,21 +5002,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let keyboardBadgeEllipsis = SFSymbol(rawValue: "keyboard.badge.ellipsis")
+    static var keyboardBadgeEllipsis: SFSymbol { .init(rawValue: "keyboard.badge.ellipsis") }
 
     /// 􀣭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardChevronCompactLeft = SFSymbol(rawValue: "keyboard.chevron.compact.left")
+    static var keyboardChevronCompactLeft: SFSymbol { .init(rawValue: "keyboard.chevron.compact.left") }
 
     /// 􀤯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardMacwindow = SFSymbol(rawValue: "keyboard.macwindow")
+    static var keyboardMacwindow: SFSymbol { .init(rawValue: "keyboard.macwindow") }
 
     /// 􀞹
     /// Single Localization, 2 Layersets
@@ -5024,7 +5024,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let keyboardOnehandedLeft = SFSymbol(rawValue: "keyboard.onehanded.left")
+    static var keyboardOnehandedLeft: SFSymbol { .init(rawValue: "keyboard.onehanded.left") }
 
     /// 􀞺
     /// Single Localization, 2 Layersets
@@ -5032,7 +5032,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let keyboardOnehandedRight = SFSymbol(rawValue: "keyboard.onehanded.right")
+    static var keyboardOnehandedRight: SFSymbol { .init(rawValue: "keyboard.onehanded.right") }
 
     /// 􀦒
     /// Single Localization, 2 Layersets
@@ -5040,7 +5040,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lJoystick = SFSymbol(rawValue: "l.joystick")
+    static var lJoystick: SFSymbol { .init(rawValue: "l.joystick") }
 
     /// 􀦔
     /// Single Localization, 2 Layersets
@@ -5053,7 +5053,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "lJoystickPressDown")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "lJoystickPressDown")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lJoystickPressDown")
-    static let lJoystickDown = SFSymbol(rawValue: "l.joystick.down")
+    static var lJoystickDown: SFSymbol { .init(rawValue: "l.joystick.down") }
 
     /// 􀫃
     /// Single Localization, 3 Layersets
@@ -5067,7 +5067,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "lJoystickPressDownFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "lJoystickPressDownFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lJoystickPressDownFill")
-    static let lJoystickDownFill = SFSymbol(rawValue: "l.joystick.down.fill")
+    static var lJoystickDownFill: SFSymbol { .init(rawValue: "l.joystick.down.fill") }
 
     /// 􀫁
     /// Single Localization, 3 Layersets
@@ -5076,7 +5076,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lJoystickFill = SFSymbol(rawValue: "l.joystick.fill")
+    static var lJoystickFill: SFSymbol { .init(rawValue: "l.joystick.fill") }
 
     /// 􀨇
     /// Single Localization, 2 Layersets
@@ -5089,7 +5089,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "lButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "lButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lButtonRoundedbottomHorizontal")
-    static let lRectangleRoundedbottom = SFSymbol(rawValue: "l.rectangle.roundedbottom")
+    static var lRectangleRoundedbottom: SFSymbol { .init(rawValue: "l.rectangle.roundedbottom") }
 
     /// 􀨈
     /// Single Localization, 3 Layersets
@@ -5103,7 +5103,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "lButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "lButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lButtonRoundedbottomHorizontalFill")
-    static let lRectangleRoundedbottomFill = SFSymbol(rawValue: "l.rectangle.roundedbottom.fill")
+    static var lRectangleRoundedbottomFill: SFSymbol { .init(rawValue: "l.rectangle.roundedbottom.fill") }
 
     /// 􀨉
     /// Single Localization, 2 Layersets
@@ -5116,7 +5116,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "l1ButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "l1ButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "l1ButtonRoundedbottomHorizontal")
-    static let l1RectangleRoundedbottom = SFSymbol(rawValue: "l1.rectangle.roundedbottom")
+    static var l1RectangleRoundedbottom: SFSymbol { .init(rawValue: "l1.rectangle.roundedbottom") }
 
     /// 􀨊
     /// Single Localization, 3 Layersets
@@ -5130,7 +5130,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "l1ButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "l1ButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "l1ButtonRoundedbottomHorizontalFill")
-    static let l1RectangleRoundedbottomFill = SFSymbol(rawValue: "l1.rectangle.roundedbottom.fill")
+    static var l1RectangleRoundedbottomFill: SFSymbol { .init(rawValue: "l1.rectangle.roundedbottom.fill") }
 
     /// 􀨋
     /// Single Localization, 2 Layersets
@@ -5143,7 +5143,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "l2ButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "l2ButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "l2ButtonRoundedtopHorizontal")
-    static let l2RectangleRoundedtop = SFSymbol(rawValue: "l2.rectangle.roundedtop")
+    static var l2RectangleRoundedtop: SFSymbol { .init(rawValue: "l2.rectangle.roundedtop") }
 
     /// 􀨌
     /// Single Localization, 3 Layersets
@@ -5157,14 +5157,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "l2ButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "l2ButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "l2ButtonRoundedtopHorizontalFill")
-    static let l2RectangleRoundedtopFill = SFSymbol(rawValue: "l2.rectangle.roundedtop.fill")
+    static var l2RectangleRoundedtopFill: SFSymbol { .init(rawValue: "l2.rectangle.roundedtop.fill") }
 
     /// 􀯔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ladybug = SFSymbol(rawValue: "ladybug")
+    static var ladybug: SFSymbol { .init(rawValue: "ladybug") }
 
     /// 􀯕
     /// Single Localization, 3 Layersets
@@ -5173,7 +5173,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ladybugFill = SFSymbol(rawValue: "ladybug.fill")
+    static var ladybugFill: SFSymbol { .init(rawValue: "ladybug.fill") }
 
     /// 􀟛
     /// Single Localization, 2 Layersets
@@ -5181,7 +5181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let laptopcomputer = SFSymbol(rawValue: "laptopcomputer")
+    static var laptopcomputer: SFSymbol { .init(rawValue: "laptopcomputer") }
 
     /// 􀬩
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5197,7 +5197,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.1, renamed: "macbookAndIphone")
     @available(watchOS, introduced: 7.0, deprecated: 9.1, renamed: "macbookAndIphone")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "macbookAndIphone")
-    static let laptopcomputerAndIphone = SFSymbol(rawValue: "laptopcomputer.and.iphone")
+    static var laptopcomputerAndIphone: SFSymbol { .init(rawValue: "laptopcomputer.and.iphone") }
 
     /// 􀣳
     /// Single Localization, Single Layerset
@@ -5209,21 +5209,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "lassoAndSparkles")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "lassoAndSparkles")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lassoAndSparkles")
-    static let lassoSparkles = SFSymbol(rawValue: "lasso.sparkles")
+    static var lassoSparkles: SFSymbol { .init(rawValue: "lasso.sparkles") }
 
     /// 􀢟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let latch2Case = SFSymbol(rawValue: "latch.2.case")
+    static var latch2Case: SFSymbol { .init(rawValue: "latch.2.case") }
 
     /// 􀢠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let latch2CaseFill = SFSymbol(rawValue: "latch.2.case.fill")
+    static var latch2CaseFill: SFSymbol { .init(rawValue: "latch.2.case.fill") }
 
     /// 􀨓
     /// Single Localization, 2 Layersets
@@ -5236,7 +5236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "lbButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "lbButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lbButtonRoundedbottomHorizontal")
-    static let lbRectangleRoundedbottom = SFSymbol(rawValue: "lb.rectangle.roundedbottom")
+    static var lbRectangleRoundedbottom: SFSymbol { .init(rawValue: "lb.rectangle.roundedbottom") }
 
     /// 􀨔
     /// Single Localization, 3 Layersets
@@ -5250,7 +5250,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "lbButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "lbButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lbButtonRoundedbottomHorizontalFill")
-    static let lbRectangleRoundedbottomFill = SFSymbol(rawValue: "lb.rectangle.roundedbottom.fill")
+    static var lbRectangleRoundedbottomFill: SFSymbol { .init(rawValue: "lb.rectangle.roundedbottom.fill") }
 
     /// 􀥲
     /// Single Localization, 2 Layersets
@@ -5258,7 +5258,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let leaf = SFSymbol(rawValue: "leaf")
+    static var leaf: SFSymbol { .init(rawValue: "leaf") }
 
     /// 􀙜
     /// Single Localization, 3 Layersets
@@ -5272,7 +5272,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "leafArrowTriangleheadClockwise")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "leafArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "leafArrowTriangleheadClockwise")
-    static let leafArrowTriangleCirclepath = SFSymbol(rawValue: "leaf.arrow.triangle.circlepath")
+    static var leafArrowTriangleCirclepath: SFSymbol { .init(rawValue: "leaf.arrow.triangle.circlepath") }
 
     /// 􀥳
     /// Single Localization, 2 Layersets
@@ -5280,7 +5280,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let leafFill = SFSymbol(rawValue: "leaf.fill")
+    static var leafFill: SFSymbol { .init(rawValue: "leaf.fill") }
 
     /// 􀟂
     /// Single Localization, 3 Layersets
@@ -5289,49 +5289,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let level = SFSymbol(rawValue: "level")
+    static var level: SFSymbol { .init(rawValue: "level") }
 
     /// 􀟃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let levelFill = SFSymbol(rawValue: "level.fill")
+    static var levelFill: SFSymbol { .init(rawValue: "level.fill") }
 
     /// 􀡦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lifepreserver = SFSymbol(rawValue: "lifepreserver")
+    static var lifepreserver: SFSymbol { .init(rawValue: "lifepreserver") }
 
     /// 􀡧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lifepreserverFill = SFSymbol(rawValue: "lifepreserver.fill")
+    static var lifepreserverFill: SFSymbol { .init(rawValue: "lifepreserver.fill") }
 
     /// 􀫎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let line3CrossedSwirlCircle = SFSymbol(rawValue: "line.3.crossed.swirl.circle")
+    static var line3CrossedSwirlCircle: SFSymbol { .init(rawValue: "line.3.crossed.swirl.circle") }
 
     /// 􀫏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let line3CrossedSwirlCircleFill = SFSymbol(rawValue: "line.3.crossed.swirl.circle.fill")
+    static var line3CrossedSwirlCircleFill: SFSymbol { .init(rawValue: "line.3.crossed.swirl.circle.fill") }
 
     /// 􀫰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lineDiagonal = SFSymbol(rawValue: "line.diagonal")
+    static var lineDiagonal: SFSymbol { .init(rawValue: "line.diagonal") }
 
     /// 􀫱
     /// Single Localization, Single Layerset
@@ -5343,7 +5343,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "lineDiagonalTriangleheadUpRight")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "lineDiagonalTriangleheadUpRight")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "lineDiagonalTriangleheadUpRight")
-    static let lineDiagonalArrow = SFSymbol(rawValue: "line.diagonal.arrow")
+    static var lineDiagonalArrow: SFSymbol { .init(rawValue: "line.diagonal.arrow") }
 
     /// 􀘵
     /// Single Localization, 2 Layersets
@@ -5356,7 +5356,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "line2HorizontalDecreaseCircle")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "line2HorizontalDecreaseCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line2HorizontalDecreaseCircle")
-    static let lineHorizontal2DecreaseCircle = SFSymbol(rawValue: "line.horizontal.2.decrease.circle")
+    static var lineHorizontal2DecreaseCircle: SFSymbol { .init(rawValue: "line.horizontal.2.decrease.circle") }
 
     /// 􀘶
     /// Single Localization, 3 Layersets
@@ -5370,7 +5370,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "line2HorizontalDecreaseCircleFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "line2HorizontalDecreaseCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line2HorizontalDecreaseCircleFill")
-    static let lineHorizontal2DecreaseCircleFill = SFSymbol(rawValue: "line.horizontal.2.decrease.circle.fill")
+    static var lineHorizontal2DecreaseCircleFill: SFSymbol { .init(rawValue: "line.horizontal.2.decrease.circle.fill") }
 
     /// 􀧱
     /// Single Localization, 2 Layersets
@@ -5383,7 +5383,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "line3HorizontalCircle")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "line3HorizontalCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3HorizontalCircle")
-    static let lineHorizontal3Circle = SFSymbol(rawValue: "line.horizontal.3.circle")
+    static var lineHorizontal3Circle: SFSymbol { .init(rawValue: "line.horizontal.3.circle") }
 
     /// 􀧲
     /// Single Localization, 3 Layersets
@@ -5397,7 +5397,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "line3HorizontalCircleFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "line3HorizontalCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "line3HorizontalCircleFill")
-    static let lineHorizontal3CircleFill = SFSymbol(rawValue: "line.horizontal.3.circle.fill")
+    static var lineHorizontal3CircleFill: SFSymbol { .init(rawValue: "line.horizontal.3.circle.fill") }
 
     /// 􀑮
     /// Single Localization, 2 Layersets
@@ -5405,14 +5405,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lineHorizontalStarFillLineHorizontal = SFSymbol(rawValue: "line.horizontal.star.fill.line.horizontal")
+    static var lineHorizontalStarFillLineHorizontal: SFSymbol { .init(rawValue: "line.horizontal.star.fill.line.horizontal") }
 
     /// 􀉨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lineweight = SFSymbol(rawValue: "lineweight")
+    static var lineweight: SFSymbol { .init(rawValue: "lineweight") }
 
     /// 􀥕
     /// Single Localization, 3 Layersets
@@ -5421,7 +5421,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let linkBadgePlus = SFSymbol(rawValue: "link.badge.plus")
+    static var linkBadgePlus: SFSymbol { .init(rawValue: "link.badge.plus") }
 
     /// 􀬉
     /// Single Localization, 2 Layersets
@@ -5429,7 +5429,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listAndFilm = SFSymbol(rawValue: "list.and.film")
+    static var listAndFilm: SFSymbol { .init(rawValue: "list.and.film") }
 
     /// 􀩳
     /// Single Localization, 2 Layersets
@@ -5437,7 +5437,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listBulletRectangle = SFSymbol(rawValue: "list.bullet.rectangle")
+    static var listBulletRectangle: SFSymbol { .init(rawValue: "list.bullet.rectangle") }
 
     /// 􀣩
     /// Single Localization, 3 Layersets
@@ -5446,7 +5446,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listStar = SFSymbol(rawValue: "list.star")
+    static var listStar: SFSymbol { .init(rawValue: "list.star") }
 
     /// 􀢽
     /// Single Localization, 3 Layersets
@@ -5455,7 +5455,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let listTriangle = SFSymbol(rawValue: "list.triangle")
+    static var listTriangle: SFSymbol { .init(rawValue: "list.triangle") }
 
     /// 􀙔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5471,7 +5471,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "livephotoBadgeAutomatic")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "livephotoBadgeAutomatic")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "livephotoBadgeAutomatic")
-    static let livephotoBadgeA = SFSymbol(rawValue: "livephoto.badge.a")
+    static var livephotoBadgeA: SFSymbol { .init(rawValue: "livephoto.badge.a") }
 
     /// 􀮄
     /// Single Localization, 2 Layersets
@@ -5479,7 +5479,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationFillViewfinder = SFSymbol(rawValue: "location.fill.viewfinder")
+    static var locationFillViewfinder: SFSymbol { .init(rawValue: "location.fill.viewfinder") }
 
     /// 􀮃
     /// Single Localization, 2 Layersets
@@ -5487,7 +5487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let locationViewfinder = SFSymbol(rawValue: "location.viewfinder")
+    static var locationViewfinder: SFSymbol { .init(rawValue: "location.viewfinder") }
 
     /// 􀢍
     /// Single Localization, 2 Layersets
@@ -5500,7 +5500,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "lockDocument")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "lockDocument")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "lockDocument")
-    static let lockDoc = SFSymbol(rawValue: "lock.doc")
+    static var lockDoc: SFSymbol { .init(rawValue: "lock.doc") }
 
     /// 􀢎
     /// Single Localization, 3 Layersets
@@ -5514,7 +5514,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "lockDocumentFill")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "lockDocumentFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "lockDocumentFill")
-    static let lockDocFill = SFSymbol(rawValue: "lock.doc.fill")
+    static var lockDocFill: SFSymbol { .init(rawValue: "lock.doc.fill") }
 
     /// 􀢈
     /// Single Localization, 3 Layersets
@@ -5523,7 +5523,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockRectangle = SFSymbol(rawValue: "lock.rectangle")
+    static var lockRectangle: SFSymbol { .init(rawValue: "lock.rectangle") }
 
     /// 􀢉
     /// Single Localization, 3 Layersets
@@ -5532,7 +5532,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockRectangleFill = SFSymbol(rawValue: "lock.rectangle.fill")
+    static var lockRectangleFill: SFSymbol { .init(rawValue: "lock.rectangle.fill") }
 
     /// 􀢳
     /// Single Localization, 3 Layersets
@@ -5541,7 +5541,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockRectangleOnRectangle = SFSymbol(rawValue: "lock.rectangle.on.rectangle")
+    static var lockRectangleOnRectangle: SFSymbol { .init(rawValue: "lock.rectangle.on.rectangle") }
 
     /// 􀢴
     /// Single Localization, 3 Layersets
@@ -5550,7 +5550,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockRectangleOnRectangleFill = SFSymbol(rawValue: "lock.rectangle.on.rectangle.fill")
+    static var lockRectangleOnRectangleFill: SFSymbol { .init(rawValue: "lock.rectangle.on.rectangle.fill") }
 
     /// 􀢱
     /// Single Localization, 2 Layersets
@@ -5558,7 +5558,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockRectangleStack = SFSymbol(rawValue: "lock.rectangle.stack")
+    static var lockRectangleStack: SFSymbol { .init(rawValue: "lock.rectangle.stack") }
 
     /// 􀢲
     /// Single Localization, 3 Layersets
@@ -5567,7 +5567,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockRectangleStackFill = SFSymbol(rawValue: "lock.rectangle.stack.fill")
+    static var lockRectangleStackFill: SFSymbol { .init(rawValue: "lock.rectangle.stack.fill") }
 
     /// 􀢵
     /// Single Localization, 3 Layersets
@@ -5576,7 +5576,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockSquare = SFSymbol(rawValue: "lock.square")
+    static var lockSquare: SFSymbol { .init(rawValue: "lock.square") }
 
     /// 􀢶
     /// Single Localization, 3 Layersets
@@ -5585,7 +5585,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockSquareFill = SFSymbol(rawValue: "lock.square.fill")
+    static var lockSquareFill: SFSymbol { .init(rawValue: "lock.square.fill") }
 
     /// 􀡜
     /// Single Localization, 2 Layersets
@@ -5593,7 +5593,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lockSquareStack = SFSymbol(rawValue: "lock.square.stack")
+    static var lockSquareStack: SFSymbol { .init(rawValue: "lock.square.stack") }
 
     /// 􀡝
     /// Single Localization, 3 Layersets
@@ -5602,14 +5602,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lockSquareStackFill = SFSymbol(rawValue: "lock.square.stack.fill")
+    static var lockSquareStackFill: SFSymbol { .init(rawValue: "lock.square.stack.fill") }
 
     /// 􀤎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let loupe = SFSymbol(rawValue: "loupe")
+    static var loupe: SFSymbol { .init(rawValue: "loupe") }
 
     /// 􀨗
     /// Single Localization, 2 Layersets
@@ -5622,7 +5622,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "ltButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "ltButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ltButtonRoundedtopHorizontal")
-    static let ltRectangleRoundedtop = SFSymbol(rawValue: "lt.rectangle.roundedtop")
+    static var ltRectangleRoundedtop: SFSymbol { .init(rawValue: "lt.rectangle.roundedtop") }
 
     /// 􀨘
     /// Single Localization, 3 Layersets
@@ -5636,7 +5636,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "ltButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "ltButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ltButtonRoundedtopHorizontalFill")
-    static let ltRectangleRoundedtopFill = SFSymbol(rawValue: "lt.rectangle.roundedtop.fill")
+    static var ltRectangleRoundedtopFill: SFSymbol { .init(rawValue: "lt.rectangle.roundedtop.fill") }
 
     /// 􀦚
     /// Single Localization, 3 Layersets
@@ -5645,7 +5645,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lungs = SFSymbol(rawValue: "lungs")
+    static var lungs: SFSymbol { .init(rawValue: "lungs") }
 
     /// 􀦛
     /// Single Localization, 3 Layersets
@@ -5654,7 +5654,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let lungsFill = SFSymbol(rawValue: "lungs.fill")
+    static var lungsFill: SFSymbol { .init(rawValue: "lungs.fill") }
 
     /// 􀪯
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5663,7 +5663,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macmini = SFSymbol(rawValue: "macmini")
+    static var macmini: SFSymbol { .init(rawValue: "macmini") }
 
     /// 􀪰
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5672,7 +5672,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiFill = SFSymbol(rawValue: "macmini.fill")
+    static var macminiFill: SFSymbol { .init(rawValue: "macmini.fill") }
 
     /// 􀪲
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5681,7 +5681,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen1 = SFSymbol(rawValue: "macpro.gen1")
+    static var macproGen1: SFSymbol { .init(rawValue: "macpro.gen1") }
 
     /// 􀦱
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5690,7 +5690,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen2 = SFSymbol(rawValue: "macpro.gen2")
+    static var macproGen2: SFSymbol { .init(rawValue: "macpro.gen2") }
 
     /// 􀦮
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5699,7 +5699,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen2Fill = SFSymbol(rawValue: "macpro.gen2.fill")
+    static var macproGen2Fill: SFSymbol { .init(rawValue: "macpro.gen2.fill") }
 
     /// 􀪱
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5708,7 +5708,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen3 = SFSymbol(rawValue: "macpro.gen3")
+    static var macproGen3: SFSymbol { .init(rawValue: "macpro.gen3") }
 
     /// 􀨳
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5717,7 +5717,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen3Server = SFSymbol(rawValue: "macpro.gen3.server")
+    static var macproGen3Server: SFSymbol { .init(rawValue: "macpro.gen3.server") }
 
     /// 􀥃
     /// Single Localization, 3 Layersets
@@ -5726,7 +5726,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let macwindowBadgePlus = SFSymbol(rawValue: "macwindow.badge.plus")
+    static var macwindowBadgePlus: SFSymbol { .init(rawValue: "macwindow.badge.plus") }
 
     /// 􀢌
     /// 2 Localizations, 3 Layersets
@@ -5739,14 +5739,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let macwindowOnRectangle = SymbolWith1Localization<Rtl>(rawValue: "macwindow.on.rectangle")
+    static var macwindowOnRectangle: SymbolWith1Localization<Rtl> { .init(rawValue: "macwindow.on.rectangle") }
 
     /// 􀣪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mail = SFSymbol(rawValue: "mail")
+    static var mail: SFSymbol { .init(rawValue: "mail") }
 
     /// 􀢾
     /// 2 Localizations, 3 Layersets
@@ -5759,7 +5759,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let mailAndTextMagnifyingglass = SymbolWith1Localization<Rtl>(rawValue: "mail.and.text.magnifyingglass")
+    static var mailAndTextMagnifyingglass: SymbolWith1Localization<Rtl> { .init(rawValue: "mail.and.text.magnifyingglass") }
 
     /// 􀣫
     /// Single Localization, 2 Layersets
@@ -5767,42 +5767,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let mailFill = SFSymbol(rawValue: "mail.fill")
+    static var mailFill: SFSymbol { .init(rawValue: "mail.fill") }
 
     /// 􀍝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mailStack = SFSymbol(rawValue: "mail.stack")
+    static var mailStack: SFSymbol { .init(rawValue: "mail.stack") }
 
     /// 􀍞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mailStackFill = SFSymbol(rawValue: "mail.stack.fill")
+    static var mailStackFill: SFSymbol { .init(rawValue: "mail.stack.fill") }
 
     /// 􀬲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let megaphone = SFSymbol(rawValue: "megaphone")
+    static var megaphone: SFSymbol { .init(rawValue: "megaphone") }
 
     /// 􀬳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let megaphoneFill = SFSymbol(rawValue: "megaphone.fill")
+    static var megaphoneFill: SFSymbol { .init(rawValue: "megaphone.fill") }
 
     /// 􀫦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let memorychip = SFSymbol(rawValue: "memorychip")
+    static var memorychip: SFSymbol { .init(rawValue: "memorychip") }
 
     /// 􀤁
     /// Single Localization, 2 Layersets
@@ -5810,7 +5810,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let menubarArrowDownRectangle = SFSymbol(rawValue: "menubar.arrow.down.rectangle")
+    static var menubarArrowDownRectangle: SFSymbol { .init(rawValue: "menubar.arrow.down.rectangle") }
 
     /// 􀤀
     /// Single Localization, 2 Layersets
@@ -5818,7 +5818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let menubarArrowUpRectangle = SFSymbol(rawValue: "menubar.arrow.up.rectangle")
+    static var menubarArrowUpRectangle: SFSymbol { .init(rawValue: "menubar.arrow.up.rectangle") }
 
     /// 􀣰
     /// Single Localization, 2 Layersets
@@ -5826,7 +5826,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let menubarDockRectangle = SFSymbol(rawValue: "menubar.dock.rectangle")
+    static var menubarDockRectangle: SFSymbol { .init(rawValue: "menubar.dock.rectangle") }
 
     /// 􀣑
     /// Single Localization, 2 Layersets
@@ -5834,21 +5834,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let menubarDockRectangleBadgeRecord = SFSymbol(rawValue: "menubar.dock.rectangle.badge.record")
+    static var menubarDockRectangleBadgeRecord: SFSymbol { .init(rawValue: "menubar.dock.rectangle.badge.record") }
 
     /// 􀦍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let menubarRectangle = SFSymbol(rawValue: "menubar.rectangle")
+    static var menubarRectangle: SFSymbol { .init(rawValue: "menubar.rectangle") }
 
     /// 􀠕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let metronomeFill = SFSymbol(rawValue: "metronome.fill")
+    static var metronomeFill: SFSymbol { .init(rawValue: "metronome.fill") }
 
     /// 􀢁
     /// Single Localization, 3 Layersets
@@ -5857,7 +5857,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusDiamond = SFSymbol(rawValue: "minus.diamond")
+    static var minusDiamond: SFSymbol { .init(rawValue: "minus.diamond") }
 
     /// 􀢂
     /// Single Localization, 3 Layersets
@@ -5866,7 +5866,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusDiamondFill = SFSymbol(rawValue: "minus.diamond.fill")
+    static var minusDiamondFill: SFSymbol { .init(rawValue: "minus.diamond.fill") }
 
     /// 􀫬
     /// Single Localization, 3 Layersets
@@ -5875,7 +5875,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblock = SFSymbol(rawValue: "minus.plus.batteryblock")
+    static var minusPlusBatteryblock: SFSymbol { .init(rawValue: "minus.plus.batteryblock") }
 
     /// 􀫭
     /// Single Localization, 3 Layersets
@@ -5884,7 +5884,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let minusPlusBatteryblockFill = SFSymbol(rawValue: "minus.plus.batteryblock.fill")
+    static var minusPlusBatteryblockFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.fill") }
 
     /// 􀡬
     /// Single Localization, 3 Layersets
@@ -5893,7 +5893,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusRectanglePortrait = SFSymbol(rawValue: "minus.rectangle.portrait")
+    static var minusRectanglePortrait: SFSymbol { .init(rawValue: "minus.rectangle.portrait") }
 
     /// 􀡭
     /// Single Localization, 3 Layersets
@@ -5902,56 +5902,56 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let minusRectanglePortraitFill = SFSymbol(rawValue: "minus.rectangle.portrait.fill")
+    static var minusRectanglePortraitFill: SFSymbol { .init(rawValue: "minus.rectangle.portrait.fill") }
 
     /// 􀯫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mosaic = SFSymbol(rawValue: "mosaic")
+    static var mosaic: SFSymbol { .init(rawValue: "mosaic") }
 
     /// 􀯬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mosaicFill = SFSymbol(rawValue: "mosaic.fill")
+    static var mosaicFill: SFSymbol { .init(rawValue: "mosaic.fill") }
 
     /// 􀣊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mount = SFSymbol(rawValue: "mount")
+    static var mount: SFSymbol { .init(rawValue: "mount") }
 
     /// 􀢣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mountFill = SFSymbol(rawValue: "mount.fill")
+    static var mountFill: SFSymbol { .init(rawValue: "mount.fill") }
 
     /// 􀦩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mouth = SFSymbol(rawValue: "mouth")
+    static var mouth: SFSymbol { .init(rawValue: "mouth") }
 
     /// 􀦪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mouthFill = SFSymbol(rawValue: "mouth.fill")
+    static var mouthFill: SFSymbol { .init(rawValue: "mouth.fill") }
 
     /// 􀢅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let move3d = SFSymbol(rawValue: "move.3d")
+    static var move3d: SFSymbol { .init(rawValue: "move.3d") }
 
     /// 􀒼
     /// Single Localization, 2 Layersets
@@ -5959,7 +5959,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let musicNoteHouse = SFSymbol(rawValue: "music.note.house")
+    static var musicNoteHouse: SFSymbol { .init(rawValue: "music.note.house") }
 
     /// 􀒽
     /// Single Localization, 3 Layersets
@@ -5968,28 +5968,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let musicNoteHouseFill = SFSymbol(rawValue: "music.note.house.fill")
+    static var musicNoteHouseFill: SFSymbol { .init(rawValue: "music.note.house.fill") }
 
     /// 􀫀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let musicQuarternote3 = SFSymbol(rawValue: "music.quarternote.3")
+    static var musicQuarternote3: SFSymbol { .init(rawValue: "music.quarternote.3") }
 
     /// 􀥿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mustache = SFSymbol(rawValue: "mustache")
+    static var mustache: SFSymbol { .init(rawValue: "mustache") }
 
     /// 􀦀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mustacheFill = SFSymbol(rawValue: "mustache.fill")
+    static var mustacheFill: SFSymbol { .init(rawValue: "mustache.fill") }
 
     /// 􀤆
     /// Single Localization, 2 Layersets
@@ -5997,14 +5997,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let network = SFSymbol(rawValue: "network")
+    static var network: SFSymbol { .init(rawValue: "network") }
 
     /// 􀤦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let newspaper = SFSymbol(rawValue: "newspaper")
+    static var newspaper: SFSymbol { .init(rawValue: "newspaper") }
 
     /// 􀥅
     /// Single Localization, 2 Layersets
@@ -6012,21 +6012,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let newspaperFill = SFSymbol(rawValue: "newspaper.fill")
+    static var newspaperFill: SFSymbol { .init(rawValue: "newspaper.fill") }
 
     /// 􀨯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let nose = SFSymbol(rawValue: "nose")
+    static var nose: SFSymbol { .init(rawValue: "nose") }
 
     /// 􀨰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let noseFill = SFSymbol(rawValue: "nose.fill")
+    static var noseFill: SFSymbol { .init(rawValue: "nose.fill") }
 
     /// 􀧵
     /// Single Localization, Single Layerset
@@ -6038,7 +6038,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "padHeader")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "padHeader")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "padHeader")
-    static let note = SFSymbol(rawValue: "note")
+    static var note: SFSymbol { .init(rawValue: "note") }
 
     /// 􀓕
     /// Single Localization, 2 Layersets
@@ -6051,7 +6051,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "textPadHeader")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "textPadHeader")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "textPadHeader")
-    static let noteText = SFSymbol(rawValue: "note.text")
+    static var noteText: SFSymbol { .init(rawValue: "note.text") }
 
     /// 􀣙
     /// Single Localization, 3 Layersets
@@ -6065,84 +6065,84 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 26.0, renamed: "textPadHeaderBadgePlus")
     @available(watchOS, introduced: 7.0, deprecated: 26.0, renamed: "textPadHeaderBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "textPadHeaderBadgePlus")
-    static let noteTextBadgePlus = SFSymbol(rawValue: "note.text.badge.plus")
+    static var noteTextBadgePlus: SFSymbol { .init(rawValue: "note.text.badge.plus") }
 
     /// 􀟊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagon = SFSymbol(rawValue: "octagon")
+    static var octagon: SFSymbol { .init(rawValue: "octagon") }
 
     /// 􀟋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagonFill = SFSymbol(rawValue: "octagon.fill")
+    static var octagonFill: SFSymbol { .init(rawValue: "octagon.fill") }
 
     /// 􀢸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let opticaldisc = SFSymbol(rawValue: "opticaldisc")
+    static var opticaldisc: SFSymbol { .init(rawValue: "opticaldisc") }
 
     /// 􀤄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let opticaldiscdrive = SFSymbol(rawValue: "opticaldiscdrive")
+    static var opticaldiscdrive: SFSymbol { .init(rawValue: "opticaldiscdrive") }
 
     /// 􀤅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let opticaldiscdriveFill = SFSymbol(rawValue: "opticaldiscdrive.fill")
+    static var opticaldiscdriveFill: SFSymbol { .init(rawValue: "opticaldiscdrive.fill") }
 
     /// 􀲞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let oval = SFSymbol(rawValue: "oval")
+    static var oval: SFSymbol { .init(rawValue: "oval") }
 
     /// 􀲟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalFill = SFSymbol(rawValue: "oval.fill")
+    static var ovalFill: SFSymbol { .init(rawValue: "oval.fill") }
 
     /// 􀲠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortrait = SFSymbol(rawValue: "oval.portrait")
+    static var ovalPortrait: SFSymbol { .init(rawValue: "oval.portrait") }
 
     /// 􀲡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortraitFill = SFSymbol(rawValue: "oval.portrait.fill")
+    static var ovalPortraitFill: SFSymbol { .init(rawValue: "oval.portrait.fill") }
 
     /// 􀣶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paintbrushPointed = SFSymbol(rawValue: "paintbrush.pointed")
+    static var paintbrushPointed: SFSymbol { .init(rawValue: "paintbrush.pointed") }
 
     /// 􀣷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paintbrushPointedFill = SFSymbol(rawValue: "paintbrush.pointed.fill")
+    static var paintbrushPointedFill: SFSymbol { .init(rawValue: "paintbrush.pointed.fill") }
 
     /// 􀝥
     /// Single Localization, 2 Layersets
@@ -6150,7 +6150,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let paintpalette = SFSymbol(rawValue: "paintpalette")
+    static var paintpalette: SFSymbol { .init(rawValue: "paintpalette") }
 
     /// 􀝦
     /// Single Localization, 3 Layersets
@@ -6159,7 +6159,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let paintpaletteFill = SFSymbol(rawValue: "paintpalette.fill")
+    static var paintpaletteFill: SFSymbol { .init(rawValue: "paintpalette.fill") }
 
     /// 􀢏
     /// Single Localization, 3 Layersets
@@ -6168,7 +6168,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let paperclipBadgeEllipsis = SFSymbol(rawValue: "paperclip.badge.ellipsis")
+    static var paperclipBadgeEllipsis: SFSymbol { .init(rawValue: "paperclip.badge.ellipsis") }
 
     /// 􀈡
     /// Single Localization, 2 Layersets
@@ -6176,7 +6176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let paperplaneCircle = SFSymbol(rawValue: "paperplane.circle")
+    static var paperplaneCircle: SFSymbol { .init(rawValue: "paperplane.circle") }
 
     /// 􀈢
     /// Single Localization, 3 Layersets
@@ -6185,14 +6185,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let paperplaneCircleFill = SFSymbol(rawValue: "paperplane.circle.fill")
+    static var paperplaneCircleFill: SFSymbol { .init(rawValue: "paperplane.circle.fill") }
 
     /// 􀒆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paragraphsign = SFSymbol(rawValue: "paragraphsign")
+    static var paragraphsign: SFSymbol { .init(rawValue: "paragraphsign") }
 
     /// 􀥺
     /// Single Localization, 3 Layersets
@@ -6201,7 +6201,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pc = SFSymbol(rawValue: "pc")
+    static var pc: SFSymbol { .init(rawValue: "pc") }
 
     /// 􀧚
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6212,7 +6212,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgeArrowForward = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.arrow.forward")
+    static var pencilTipCropCircleBadgeArrowForward: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.arrow.forward") }
 
     /// 􀠃
     /// Single Localization, 2 Layersets
@@ -6220,7 +6220,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person2Circle = SFSymbol(rawValue: "person.2.circle")
+    static var person2Circle: SFSymbol { .init(rawValue: "person.2.circle") }
 
     /// 􀠄
     /// Single Localization, 3 Layersets
@@ -6229,7 +6229,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let person2CircleFill = SFSymbol(rawValue: "person.2.circle.fill")
+    static var person2CircleFill: SFSymbol { .init(rawValue: "person.2.circle.fill") }
 
     /// 􀪼
     /// Single Localization, 2 Layersets
@@ -6242,7 +6242,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "personAndArrowLeftAndArrowRightOutward")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "personAndArrowLeftAndArrowRightOutward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "personAndArrowLeftAndArrowRightOutward")
-    static let personAndArrowLeftAndArrowRight = SFSymbol(rawValue: "person.and.arrow.left.and.arrow.right")
+    static var personAndArrowLeftAndArrowRight: SFSymbol { .init(rawValue: "person.and.arrow.left.and.arrow.right") }
 
     /// 􀉷
     /// Single Localization, 3 Layersets
@@ -6251,7 +6251,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgeExclamationmark = SFSymbol(rawValue: "person.crop.circle.badge.exclamationmark")
+    static var personCropCircleBadgeExclamationmark: SFSymbol { .init(rawValue: "person.crop.circle.badge.exclamationmark") }
 
     /// 􀭽
     /// 2 Localizations, 3 Layersets
@@ -6264,7 +6264,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personCropCircleBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "person.crop.circle.badge.questionmark")
+    static var personCropCircleBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "person.crop.circle.badge.questionmark") }
 
     /// 􀉸
     /// Single Localization, 3 Layersets
@@ -6278,7 +6278,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "personCropCircleBadgeExclamationmarkFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "personCropCircleBadgeExclamationmarkFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropCircleBadgeExclamationmarkFill")
-    static let personCropCircleFillBadgeExclamationmark = SFSymbol(rawValue: "person.crop.circle.fill.badge.exclamationmark")
+    static var personCropCircleFillBadgeExclamationmark: SFSymbol { .init(rawValue: "person.crop.circle.fill.badge.exclamationmark") }
 
     /// 􀭾
     /// 2 Localizations, 3 Layersets
@@ -6296,7 +6296,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "personCropCircleBadgeQuestionmarkFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "personCropCircleBadgeQuestionmarkFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropCircleBadgeQuestionmarkFill")
-    static let personCropCircleFillBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "person.crop.circle.fill.badge.questionmark")
+    static var personCropCircleFillBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "person.crop.circle.fill.badge.questionmark") }
 
     /// 􀦎
     /// Single Localization, 2 Layersets
@@ -6309,7 +6309,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "personCropSquareFilledAndAtRectangle")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "personCropSquareFilledAndAtRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "personCropSquareFilledAndAtRectangle")
-    static let personCropSquareFillAndAtRectangle = SFSymbol(rawValue: "person.crop.square.fill.and.at.rectangle")
+    static var personCropSquareFillAndAtRectangle: SFSymbol { .init(rawValue: "person.crop.square.fill.and.at.rectangle") }
 
     /// 􀪽
     /// Single Localization, 2 Layersets
@@ -6322,7 +6322,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.0, renamed: "personFillAndArrowLeftAndArrowRightOutward")
     @available(watchOS, introduced: 7.0, deprecated: 11.0, renamed: "personFillAndArrowLeftAndArrowRightOutward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "personFillAndArrowLeftAndArrowRightOutward")
-    static let personFillAndArrowLeftAndArrowRight = SFSymbol(rawValue: "person.fill.and.arrow.left.and.arrow.right")
+    static var personFillAndArrowLeftAndArrowRight: SFSymbol { .init(rawValue: "person.fill.and.arrow.left.and.arrow.right") }
 
     /// 􀜘
     /// Single Localization, 3 Layersets
@@ -6331,7 +6331,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillBadgeMinus = SFSymbol(rawValue: "person.fill.badge.minus")
+    static var personFillBadgeMinus: SFSymbol { .init(rawValue: "person.fill.badge.minus") }
 
     /// 􀜖
     /// Single Localization, 3 Layersets
@@ -6340,7 +6340,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillBadgePlus = SFSymbol(rawValue: "person.fill.badge.plus")
+    static var personFillBadgePlus: SFSymbol { .init(rawValue: "person.fill.badge.plus") }
 
     /// 􀯧
     /// 2 Localizations, 2 Layersets
@@ -6352,7 +6352,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillCheckmark = SymbolWith1Localization<Rtl>(rawValue: "person.fill.checkmark")
+    static var personFillCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "person.fill.checkmark") }
 
     /// 􀯩
     /// 3 Localizations, 2 Layersets
@@ -6365,28 +6365,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillQuestionmark = SymbolWith2Localizations<Ar, Rtl>(rawValue: "person.fill.questionmark")
+    static var personFillQuestionmark: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "person.fill.questionmark") }
 
     /// 􀯒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personFillTurnDown = SFSymbol(rawValue: "person.fill.turn.down")
+    static var personFillTurnDown: SFSymbol { .init(rawValue: "person.fill.turn.down") }
 
     /// 􀯓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personFillTurnLeft = SFSymbol(rawValue: "person.fill.turn.left")
+    static var personFillTurnLeft: SFSymbol { .init(rawValue: "person.fill.turn.left") }
 
     /// 􀯑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personFillTurnRight = SFSymbol(rawValue: "person.fill.turn.right")
+    static var personFillTurnRight: SFSymbol { .init(rawValue: "person.fill.turn.right") }
 
     /// 􀲏
     /// Single Localization, 2 Layersets
@@ -6394,7 +6394,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillViewfinder = SFSymbol(rawValue: "person.fill.viewfinder")
+    static var personFillViewfinder: SFSymbol { .init(rawValue: "person.fill.viewfinder") }
 
     /// 􀯨
     /// 2 Localizations, 2 Layersets
@@ -6406,7 +6406,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let personFillXmark = SymbolWith1Localization<Rtl>(rawValue: "person.fill.xmark")
+    static var personFillXmark: SymbolWith1Localization<Rtl> { .init(rawValue: "person.fill.xmark") }
 
     /// 􀱮
     /// Single Localization, 2 Layersets
@@ -6419,7 +6419,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "phoneBubble")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "phoneBubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneBubble")
-    static let phoneBubbleLeft = SFSymbol(rawValue: "phone.bubble.left")
+    static var phoneBubbleLeft: SFSymbol { .init(rawValue: "phone.bubble.left") }
 
     /// 􀱯
     /// Single Localization, 3 Layersets
@@ -6433,7 +6433,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "phoneBubbleFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "phoneBubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneBubbleFill")
-    static let phoneBubbleLeftFill = SFSymbol(rawValue: "phone.bubble.left.fill")
+    static var phoneBubbleLeftFill: SFSymbol { .init(rawValue: "phone.bubble.left.fill") }
 
     /// 􀬛
     /// Single Localization, 2 Layersets
@@ -6441,7 +6441,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let phoneConnection = SFSymbol(rawValue: "phone.connection")
+    static var phoneConnection: SFSymbol { .init(rawValue: "phone.connection") }
 
     /// 􀬜
     /// Single Localization, 2 Layersets
@@ -6454,7 +6454,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "phoneConnectionFill")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "phoneConnectionFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneConnectionFill")
-    static let phoneFillConnection = SFSymbol(rawValue: "phone.fill.connection")
+    static var phoneFillConnection: SFSymbol { .init(rawValue: "phone.fill.connection") }
 
     /// 􀣵
     /// Single Localization, 3 Layersets
@@ -6463,21 +6463,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let photoOnRectangleAngled = SFSymbol(rawValue: "photo.on.rectangle.angled")
+    static var photoOnRectangleAngled: SFSymbol { .init(rawValue: "photo.on.rectangle.angled") }
 
     /// 􀎏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pianokeys = SFSymbol(rawValue: "pianokeys")
+    static var pianokeys: SFSymbol { .init(rawValue: "pianokeys") }
 
     /// 􀟽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pianokeysInverse = SFSymbol(rawValue: "pianokeys.inverse")
+    static var pianokeysInverse: SFSymbol { .init(rawValue: "pianokeys.inverse") }
 
     /// 􀠱
     /// Single Localization, 3 Layersets
@@ -6486,7 +6486,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let pills = SFSymbol(rawValue: "pills")
+    static var pills: SFSymbol { .init(rawValue: "pills") }
 
     /// 􀠲
     /// Single Localization, 3 Layersets
@@ -6495,7 +6495,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pillsFill = SFSymbol(rawValue: "pills.fill")
+    static var pillsFill: SFSymbol { .init(rawValue: "pills.fill") }
 
     /// 􀠳
     /// Single Localization, 3 Layersets
@@ -6504,7 +6504,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pip = SFSymbol(rawValue: "pip")
+    static var pip: SFSymbol { .init(rawValue: "pip") }
 
     /// 􀑨
     /// Single Localization, 3 Layersets
@@ -6513,7 +6513,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pipEnter = SFSymbol(rawValue: "pip.enter")
+    static var pipEnter: SFSymbol { .init(rawValue: "pip.enter") }
 
     /// 􀑧
     /// Single Localization, 3 Layersets
@@ -6522,7 +6522,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pipExit = SFSymbol(rawValue: "pip.exit")
+    static var pipExit: SFSymbol { .init(rawValue: "pip.exit") }
 
     /// 􀠴
     /// Single Localization, 2 Layersets
@@ -6530,7 +6530,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let pipFill = SFSymbol(rawValue: "pip.fill")
+    static var pipFill: SFSymbol { .init(rawValue: "pip.fill") }
 
     /// 􀭲
     /// Single Localization, 3 Layersets
@@ -6539,7 +6539,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pipRemove = SFSymbol(rawValue: "pip.remove")
+    static var pipRemove: SFSymbol { .init(rawValue: "pip.remove") }
 
     /// 􀭱
     /// Single Localization, 3 Layersets
@@ -6548,14 +6548,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pipSwap = SFSymbol(rawValue: "pip.swap")
+    static var pipSwap: SFSymbol { .init(rawValue: "pip.swap") }
 
     /// 􀮷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let placeholdertextFill = SFSymbol(rawValue: "placeholdertext.fill")
+    static var placeholdertextFill: SFSymbol { .init(rawValue: "placeholdertext.fill") }
 
     /// 􀪅
     /// Single Localization, 2 Layersets
@@ -6563,7 +6563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playSlash = SFSymbol(rawValue: "play.slash")
+    static var playSlash: SFSymbol { .init(rawValue: "play.slash") }
 
     /// 􀪆
     /// Single Localization, 2 Layersets
@@ -6571,7 +6571,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playSlashFill = SFSymbol(rawValue: "play.slash.fill")
+    static var playSlashFill: SFSymbol { .init(rawValue: "play.slash.fill") }
 
     /// 􀡿
     /// Single Localization, 3 Layersets
@@ -6580,7 +6580,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusDiamond = SFSymbol(rawValue: "plus.diamond")
+    static var plusDiamond: SFSymbol { .init(rawValue: "plus.diamond") }
 
     /// 􀢀
     /// Single Localization, 3 Layersets
@@ -6589,7 +6589,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusDiamondFill = SFSymbol(rawValue: "plus.diamond.fill")
+    static var plusDiamondFill: SFSymbol { .init(rawValue: "plus.diamond.fill") }
 
     /// 􀡙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6599,7 +6599,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let plusMessage = SFSymbol(rawValue: "plus.message")
+    static var plusMessage: SFSymbol { .init(rawValue: "plus.message") }
 
     /// 􀡚
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6610,7 +6610,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let plusMessageFill = SFSymbol(rawValue: "plus.message.fill")
+    static var plusMessageFill: SFSymbol { .init(rawValue: "plus.message.fill") }
 
     /// 􀤱
     /// Single Localization, 2 Layersets
@@ -6623,7 +6623,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "plusRectangleOnFolderFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "plusRectangleOnFolderFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "plusRectangleOnFolderFill")
-    static let plusRectangleFillOnFolderFill = SFSymbol(rawValue: "plus.rectangle.fill.on.folder.fill")
+    static var plusRectangleFillOnFolderFill: SFSymbol { .init(rawValue: "plus.rectangle.fill.on.folder.fill") }
 
     /// 􀤰
     /// Single Localization, 3 Layersets
@@ -6632,7 +6632,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let plusRectangleOnFolder = SFSymbol(rawValue: "plus.rectangle.on.folder")
+    static var plusRectangleOnFolder: SFSymbol { .init(rawValue: "plus.rectangle.on.folder") }
 
     /// 􀡪
     /// Single Localization, 3 Layersets
@@ -6641,7 +6641,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusRectanglePortrait = SFSymbol(rawValue: "plus.rectangle.portrait")
+    static var plusRectanglePortrait: SFSymbol { .init(rawValue: "plus.rectangle.portrait") }
 
     /// 􀡫
     /// Single Localization, 3 Layersets
@@ -6650,7 +6650,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusRectanglePortraitFill = SFSymbol(rawValue: "plus.rectangle.portrait.fill")
+    static var plusRectanglePortraitFill: SFSymbol { .init(rawValue: "plus.rectangle.portrait.fill") }
 
     /// 􀥄
     /// Single Localization, 2 Layersets
@@ -6658,7 +6658,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let plusViewfinder = SFSymbol(rawValue: "plus.viewfinder")
+    static var plusViewfinder: SFSymbol { .init(rawValue: "plus.viewfinder") }
 
     /// 􀬱
     /// Single Localization, Single Layerset
@@ -6670,7 +6670,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "pointTopleftDownCurvedtoPointBottomrightUpFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "pointTopleftDownCurvedtoPointBottomrightUpFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "pointTopleftDownCurvedtoPointBottomrightUpFill")
-    static let pointFillTopleftDownCurvedtoPointFillBottomrightUp = SFSymbol(rawValue: "point.fill.topleft.down.curvedto.point.fill.bottomright.up")
+    static var pointFillTopleftDownCurvedtoPointFillBottomrightUp: SFSymbol { .init(rawValue: "point.fill.topleft.down.curvedto.point.fill.bottomright.up") }
 
     /// 􀣱
     /// Single Localization, 3 Layersets
@@ -6684,42 +6684,42 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "pointTopleftDownToPointBottomrightCurvepath")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "pointTopleftDownToPointBottomrightCurvepath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "pointTopleftDownToPointBottomrightCurvepath")
-    static let pointTopleftDownCurvedtoPointBottomrightUp = SFSymbol(rawValue: "point.topleft.down.curvedto.point.bottomright.up")
+    static var pointTopleftDownCurvedtoPointBottomrightUp: SFSymbol { .init(rawValue: "point.topleft.down.curvedto.point.bottomright.up") }
 
     /// 􀥥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let poweroff = SFSymbol(rawValue: "poweroff")
+    static var poweroff: SFSymbol { .init(rawValue: "poweroff") }
 
     /// 􀥤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let poweron = SFSymbol(rawValue: "poweron")
+    static var poweron: SFSymbol { .init(rawValue: "poweron") }
 
     /// 􀥦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powersleep = SFSymbol(rawValue: "powersleep")
+    static var powersleep: SFSymbol { .init(rawValue: "powersleep") }
 
     /// 􀪞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerDotmatrix = SFSymbol(rawValue: "printer.dotmatrix")
+    static var printerDotmatrix: SFSymbol { .init(rawValue: "printer.dotmatrix") }
 
     /// 􀪟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerDotmatrixFill = SFSymbol(rawValue: "printer.dotmatrix.fill")
+    static var printerDotmatrixFill: SFSymbol { .init(rawValue: "printer.dotmatrix.fill") }
 
     /// 􀪿
     /// Single Localization, Single Layerset
@@ -6731,7 +6731,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "printerDotmatrixFilledAndPaper")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "printerDotmatrixFilledAndPaper")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "printerDotmatrixFilledAndPaper")
-    static let printerDotmatrixFillAndPaperFill = SFSymbol(rawValue: "printer.dotmatrix.fill.and.paper.fill")
+    static var printerDotmatrixFillAndPaperFill: SFSymbol { .init(rawValue: "printer.dotmatrix.fill.and.paper.fill") }
 
     /// 􀪾
     /// Single Localization, Single Layerset
@@ -6743,35 +6743,35 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "printerFilledAndPaper")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "printerFilledAndPaper")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "printerFilledAndPaper")
-    static let printerFillAndPaperFill = SFSymbol(rawValue: "printer.fill.and.paper.fill")
+    static var printerFillAndPaperFill: SFSymbol { .init(rawValue: "printer.fill.and.paper.fill") }
 
     /// 􀤚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let puzzlepiece = SFSymbol(rawValue: "puzzlepiece")
+    static var puzzlepiece: SFSymbol { .init(rawValue: "puzzlepiece") }
 
     /// 􀤛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let puzzlepieceFill = SFSymbol(rawValue: "puzzlepiece.fill")
+    static var puzzlepieceFill: SFSymbol { .init(rawValue: "puzzlepiece.fill") }
 
     /// 􀳋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pyramid = SFSymbol(rawValue: "pyramid")
+    static var pyramid: SFSymbol { .init(rawValue: "pyramid") }
 
     /// 􀳌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pyramidFill = SFSymbol(rawValue: "pyramid.fill")
+    static var pyramidFill: SFSymbol { .init(rawValue: "pyramid.fill") }
 
     /// 􀬔
     /// 2 Localizations, 2 Layersets
@@ -6783,7 +6783,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkFolder = SymbolWith1Localization<Ar>(rawValue: "questionmark.folder")
+    static var questionmarkFolder: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.folder") }
 
     /// 􀬕
     /// 2 Localizations, 3 Layersets
@@ -6796,7 +6796,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let questionmarkFolderFill = SymbolWith1Localization<Ar>(rawValue: "questionmark.folder.fill")
+    static var questionmarkFolderFill: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.folder.fill") }
 
     /// 􀭉
     /// 2 Localizations, 2 Layersets
@@ -6808,7 +6808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let questionmarkSquareDashed = SymbolWith1Localization<Ar>(rawValue: "questionmark.square.dashed")
+    static var questionmarkSquareDashed: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.square.dashed") }
 
     /// 􀦓
     /// Single Localization, 2 Layersets
@@ -6816,7 +6816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rJoystick = SFSymbol(rawValue: "r.joystick")
+    static var rJoystick: SFSymbol { .init(rawValue: "r.joystick") }
 
     /// 􀦕
     /// Single Localization, 2 Layersets
@@ -6829,7 +6829,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rJoystickPressDown")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rJoystickPressDown")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rJoystickPressDown")
-    static let rJoystickDown = SFSymbol(rawValue: "r.joystick.down")
+    static var rJoystickDown: SFSymbol { .init(rawValue: "r.joystick.down") }
 
     /// 􀫄
     /// Single Localization, 3 Layersets
@@ -6843,7 +6843,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rJoystickPressDownFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rJoystickPressDownFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rJoystickPressDownFill")
-    static let rJoystickDownFill = SFSymbol(rawValue: "r.joystick.down.fill")
+    static var rJoystickDownFill: SFSymbol { .init(rawValue: "r.joystick.down.fill") }
 
     /// 􀫂
     /// Single Localization, 3 Layersets
@@ -6852,7 +6852,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rJoystickFill = SFSymbol(rawValue: "r.joystick.fill")
+    static var rJoystickFill: SFSymbol { .init(rawValue: "r.joystick.fill") }
 
     /// 􀨍
     /// Single Localization, 2 Layersets
@@ -6865,7 +6865,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rButtonRoundedbottomHorizontal")
-    static let rRectangleRoundedbottom = SFSymbol(rawValue: "r.rectangle.roundedbottom")
+    static var rRectangleRoundedbottom: SFSymbol { .init(rawValue: "r.rectangle.roundedbottom") }
 
     /// 􀨎
     /// Single Localization, 3 Layersets
@@ -6879,7 +6879,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rButtonRoundedbottomHorizontalFill")
-    static let rRectangleRoundedbottomFill = SFSymbol(rawValue: "r.rectangle.roundedbottom.fill")
+    static var rRectangleRoundedbottomFill: SFSymbol { .init(rawValue: "r.rectangle.roundedbottom.fill") }
 
     /// 􀭙
     /// Single Localization, 3 Layersets
@@ -6893,7 +6893,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rSquareOnSquareFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rSquareOnSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rSquareOnSquareFill")
-    static let rSquareFillOnSquareFill = SFSymbol(rawValue: "r.square.fill.on.square.fill")
+    static var rSquareFillOnSquareFill: SFSymbol { .init(rawValue: "r.square.fill.on.square.fill") }
 
     /// 􀭘
     /// Single Localization, 3 Layersets
@@ -6902,7 +6902,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rSquareOnSquare = SFSymbol(rawValue: "r.square.on.square")
+    static var rSquareOnSquare: SFSymbol { .init(rawValue: "r.square.on.square") }
 
     /// 􀨏
     /// Single Localization, 2 Layersets
@@ -6915,7 +6915,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "r1ButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "r1ButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "r1ButtonRoundedbottomHorizontal")
-    static let r1RectangleRoundedbottom = SFSymbol(rawValue: "r1.rectangle.roundedbottom")
+    static var r1RectangleRoundedbottom: SFSymbol { .init(rawValue: "r1.rectangle.roundedbottom") }
 
     /// 􀨐
     /// Single Localization, 3 Layersets
@@ -6929,7 +6929,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "r1ButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "r1ButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "r1ButtonRoundedbottomHorizontalFill")
-    static let r1RectangleRoundedbottomFill = SFSymbol(rawValue: "r1.rectangle.roundedbottom.fill")
+    static var r1RectangleRoundedbottomFill: SFSymbol { .init(rawValue: "r1.rectangle.roundedbottom.fill") }
 
     /// 􀨑
     /// Single Localization, 2 Layersets
@@ -6942,7 +6942,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "r2ButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "r2ButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "r2ButtonRoundedtopHorizontal")
-    static let r2RectangleRoundedtop = SFSymbol(rawValue: "r2.rectangle.roundedtop")
+    static var r2RectangleRoundedtop: SFSymbol { .init(rawValue: "r2.rectangle.roundedtop") }
 
     /// 􀨒
     /// Single Localization, 3 Layersets
@@ -6956,21 +6956,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "r2ButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "r2ButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "r2ButtonRoundedtopHorizontalFill")
-    static let r2RectangleRoundedtopFill = SFSymbol(rawValue: "r2.rectangle.roundedtop.fill")
+    static var r2RectangleRoundedtopFill: SFSymbol { .init(rawValue: "r2.rectangle.roundedtop.fill") }
 
     /// 􀪔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let radio = SFSymbol(rawValue: "radio")
+    static var radio: SFSymbol { .init(rawValue: "radio") }
 
     /// 􀪕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let radioFill = SFSymbol(rawValue: "radio.fill")
+    static var radioFill: SFSymbol { .init(rawValue: "radio.fill") }
 
     /// 􀨕
     /// Single Localization, 2 Layersets
@@ -6983,7 +6983,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rbButtonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rbButtonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rbButtonRoundedbottomHorizontal")
-    static let rbRectangleRoundedbottom = SFSymbol(rawValue: "rb.rectangle.roundedbottom")
+    static var rbRectangleRoundedbottom: SFSymbol { .init(rawValue: "rb.rectangle.roundedbottom") }
 
     /// 􀨖
     /// Single Localization, 3 Layersets
@@ -6997,7 +6997,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rbButtonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rbButtonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rbButtonRoundedbottomHorizontalFill")
-    static let rbRectangleRoundedbottomFill = SFSymbol(rawValue: "rb.rectangle.roundedbottom.fill")
+    static var rbRectangleRoundedbottomFill: SFSymbol { .init(rawValue: "rb.rectangle.roundedbottom.fill") }
 
     /// 􀢙
     /// Single Localization, 2 Layersets
@@ -7005,7 +7005,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let recordCircle = SFSymbol(rawValue: "record.circle")
+    static var recordCircle: SFSymbol { .init(rawValue: "record.circle") }
 
     /// 􀢚
     /// Single Localization, 3 Layersets
@@ -7014,7 +7014,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let recordCircleFill = SFSymbol(rawValue: "record.circle.fill")
+    static var recordCircleFill: SFSymbol { .init(rawValue: "record.circle.fill") }
 
     /// 􀬄
     /// Single Localization, Single Layerset
@@ -7026,7 +7026,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangle3GroupBubbleLeft")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangle3GroupBubbleLeft")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3GroupBubbleLeft")
-    static let rectangle3OffgridBubbleLeft = SFSymbol(rawValue: "rectangle.3.offgrid.bubble.left")
+    static var rectangle3OffgridBubbleLeft: SFSymbol { .init(rawValue: "rectangle.3.offgrid.bubble.left") }
 
     /// 􀬅
     /// Single Localization, Single Layerset
@@ -7038,7 +7038,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangle3GroupBubbleLeftFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangle3GroupBubbleLeftFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3GroupBubbleLeftFill")
-    static let rectangle3OffgridBubbleLeftFill = SFSymbol(rawValue: "rectangle.3.offgrid.bubble.left.fill")
+    static var rectangle3OffgridBubbleLeftFill: SFSymbol { .init(rawValue: "rectangle.3.offgrid.bubble.left.fill") }
 
     /// 􀈏
     /// 2 Localizations, 3 Layersets
@@ -7051,7 +7051,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleAndPencilAndEllipsis = SymbolWith1Localization<Rtl>(rawValue: "rectangle.and.pencil.and.ellipsis")
+    static var rectangleAndPencilAndEllipsis: SymbolWith1Localization<Rtl> { .init(rawValue: "rectangle.and.pencil.and.ellipsis") }
 
     /// 􀬸
     /// 2 Localizations, 3 Layersets
@@ -7064,7 +7064,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleAndTextMagnifyingglass = SymbolWith1Localization<Rtl>(rawValue: "rectangle.and.text.magnifyingglass")
+    static var rectangleAndTextMagnifyingglass: SymbolWith1Localization<Rtl> { .init(rawValue: "rectangle.and.text.magnifyingglass") }
 
     /// 􀫺
     /// Single Localization, 2 Layersets
@@ -7072,7 +7072,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleArrowtriangle2Inward = SFSymbol(rawValue: "rectangle.arrowtriangle.2.inward")
+    static var rectangleArrowtriangle2Inward: SFSymbol { .init(rawValue: "rectangle.arrowtriangle.2.inward") }
 
     /// 􀫹
     /// Single Localization, 2 Layersets
@@ -7080,7 +7080,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleArrowtriangle2Outward = SFSymbol(rawValue: "rectangle.arrowtriangle.2.outward")
+    static var rectangleArrowtriangle2Outward: SFSymbol { .init(rawValue: "rectangle.arrowtriangle.2.outward") }
 
     /// 􀏓
     /// Single Localization, 3 Layersets
@@ -7089,7 +7089,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleBadgeMinus = SFSymbol(rawValue: "rectangle.badge.minus")
+    static var rectangleBadgeMinus: SFSymbol { .init(rawValue: "rectangle.badge.minus") }
 
     /// 􀏑
     /// Single Localization, 3 Layersets
@@ -7098,7 +7098,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleBadgePlus = SFSymbol(rawValue: "rectangle.badge.plus")
+    static var rectangleBadgePlus: SFSymbol { .init(rawValue: "rectangle.badge.plus") }
 
     /// 􀨨
     /// Single Localization, Single Layerset
@@ -7110,7 +7110,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleBottomthirdInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleBottomthirdInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleBottomthirdInsetFilled")
-    static let rectangleBottomthirdInsetFill = SFSymbol(rawValue: "rectangle.bottomthird.inset.fill")
+    static var rectangleBottomthirdInsetFill: SFSymbol { .init(rawValue: "rectangle.bottomthird.inset.fill") }
 
     /// 􀥝
     /// Single Localization, Single Layerset
@@ -7122,21 +7122,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleCenterInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleCenterInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleCenterInsetFilled")
-    static let rectangleCenterInsetFill = SFSymbol(rawValue: "rectangle.center.inset.fill")
+    static var rectangleCenterInsetFill: SFSymbol { .init(rawValue: "rectangle.center.inset.fill") }
 
     /// 􀩲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleConnectedToLineBelow = SFSymbol(rawValue: "rectangle.connected.to.line.below")
+    static var rectangleConnectedToLineBelow: SFSymbol { .init(rawValue: "rectangle.connected.to.line.below") }
 
     /// 􀥁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleDashed = SFSymbol(rawValue: "rectangle.dashed")
+    static var rectangleDashed: SFSymbol { .init(rawValue: "rectangle.dashed") }
 
     /// 􀥪
     /// Single Localization, 2 Layersets
@@ -7144,7 +7144,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleDashedAndPaperclip = SFSymbol(rawValue: "rectangle.dashed.and.paperclip")
+    static var rectangleDashedAndPaperclip: SFSymbol { .init(rawValue: "rectangle.dashed.and.paperclip") }
 
     /// 􀥂
     /// Single Localization, 2 Layersets
@@ -7152,7 +7152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleDashedBadgeRecord = SFSymbol(rawValue: "rectangle.dashed.badge.record")
+    static var rectangleDashedBadgeRecord: SFSymbol { .init(rawValue: "rectangle.dashed.badge.record") }
 
     /// 􀏔
     /// Single Localization, 3 Layersets
@@ -7161,7 +7161,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillBadgeMinus = SFSymbol(rawValue: "rectangle.fill.badge.minus")
+    static var rectangleFillBadgeMinus: SFSymbol { .init(rawValue: "rectangle.fill.badge.minus") }
 
     /// 􀏒
     /// Single Localization, 3 Layersets
@@ -7170,7 +7170,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleFillBadgePlus = SFSymbol(rawValue: "rectangle.fill.badge.plus")
+    static var rectangleFillBadgePlus: SFSymbol { .init(rawValue: "rectangle.fill.badge.plus") }
 
     /// 􀤽
     /// Single Localization, 2 Layersets
@@ -7183,7 +7183,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleOnRectangleCircle")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleOnRectangleCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleOnRectangleCircle")
-    static let rectangleFillOnRectangleFillCircle = SFSymbol(rawValue: "rectangle.fill.on.rectangle.fill.circle")
+    static var rectangleFillOnRectangleFillCircle: SFSymbol { .init(rawValue: "rectangle.fill.on.rectangle.fill.circle") }
 
     /// 􀤾
     /// Single Localization, 3 Layersets
@@ -7197,7 +7197,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleOnRectangleCircleFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleOnRectangleCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleOnRectangleCircleFill")
-    static let rectangleFillOnRectangleFillCircleFill = SFSymbol(rawValue: "rectangle.fill.on.rectangle.fill.circle.fill")
+    static var rectangleFillOnRectangleFillCircleFill: SFSymbol { .init(rawValue: "rectangle.fill.on.rectangle.fill.circle.fill") }
 
     /// 􀤿
     /// Single Localization, 2 Layersets
@@ -7210,7 +7210,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleOnRectangleSlashFill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleOnRectangleSlashFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleOnRectangleSlashFill")
-    static let rectangleFillOnRectangleFillSlashFill = SFSymbol(rawValue: "rectangle.fill.on.rectangle.fill.slash.fill")
+    static var rectangleFillOnRectangleFillSlashFill: SFSymbol { .init(rawValue: "rectangle.fill.on.rectangle.fill.slash.fill") }
 
     /// 􀭵
     /// Single Localization, Single Layerset
@@ -7222,7 +7222,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleInsetBottomleftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleInsetBottomleftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleInsetBottomleftFilled")
-    static let rectangleInsetBottomleftFill = SFSymbol(rawValue: "rectangle.inset.bottomleft.fill")
+    static var rectangleInsetBottomleftFill: SFSymbol { .init(rawValue: "rectangle.inset.bottomleft.fill") }
 
     /// 􀭶
     /// Single Localization, Single Layerset
@@ -7234,7 +7234,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleInsetBottomrightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleInsetBottomrightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleInsetBottomrightFilled")
-    static let rectangleInsetBottomrightFill = SFSymbol(rawValue: "rectangle.inset.bottomright.fill")
+    static var rectangleInsetBottomrightFill: SFSymbol { .init(rawValue: "rectangle.inset.bottomright.fill") }
 
     /// 􀤳
     /// Single Localization, Single Layerset
@@ -7246,7 +7246,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleInsetFilled")
-    static let rectangleInsetFill = SFSymbol(rawValue: "rectangle.inset.fill")
+    static var rectangleInsetFill: SFSymbol { .init(rawValue: "rectangle.inset.fill") }
 
     /// 􀭳
     /// Single Localization, Single Layerset
@@ -7258,7 +7258,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleInsetTopleftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleInsetTopleftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleInsetTopleftFilled")
-    static let rectangleInsetTopleftFill = SFSymbol(rawValue: "rectangle.inset.topleft.fill")
+    static var rectangleInsetTopleftFill: SFSymbol { .init(rawValue: "rectangle.inset.topleft.fill") }
 
     /// 􀭴
     /// Single Localization, Single Layerset
@@ -7270,7 +7270,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleInsetToprightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleInsetToprightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleInsetToprightFilled")
-    static let rectangleInsetToprightFill = SFSymbol(rawValue: "rectangle.inset.topright.fill")
+    static var rectangleInsetToprightFill: SFSymbol { .init(rawValue: "rectangle.inset.topright.fill") }
 
     /// 􀤶
     /// Single Localization, Single Layerset
@@ -7282,7 +7282,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleLefthalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleLefthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleLefthalfFilled")
-    static let rectangleLefthalfFill = SFSymbol(rawValue: "rectangle.lefthalf.fill")
+    static var rectangleLefthalfFill: SFSymbol { .init(rawValue: "rectangle.lefthalf.fill") }
 
     /// 􀤴
     /// Single Localization, Single Layerset
@@ -7294,7 +7294,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleLefthalfInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleLefthalfInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleLefthalfInsetFilled")
-    static let rectangleLefthalfInsetFill = SFSymbol(rawValue: "rectangle.lefthalf.inset.fill")
+    static var rectangleLefthalfInsetFill: SFSymbol { .init(rawValue: "rectangle.lefthalf.inset.fill") }
 
     /// 􀥞
     /// Single Localization, Single Layerset
@@ -7306,7 +7306,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleLefthalfInsetFilledArrowLeft")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleLefthalfInsetFilledArrowLeft")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleLefthalfInsetFilledArrowLeft")
-    static let rectangleLefthalfInsetFillArrowLeft = SFSymbol(rawValue: "rectangle.lefthalf.inset.fill.arrow.left")
+    static var rectangleLefthalfInsetFillArrowLeft: SFSymbol { .init(rawValue: "rectangle.lefthalf.inset.fill.arrow.left") }
 
     /// 􀨱
     /// Single Localization, Single Layerset
@@ -7318,7 +7318,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleLeftthirdInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleLeftthirdInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleLeftthirdInsetFilled")
-    static let rectangleLeftthirdInsetFill = SFSymbol(rawValue: "rectangle.leftthird.inset.fill")
+    static var rectangleLeftthirdInsetFill: SFSymbol { .init(rawValue: "rectangle.leftthird.inset.fill") }
 
     /// 􀥀
     /// Single Localization, 2 Layersets
@@ -7326,14 +7326,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleOnRectangleSlash = SFSymbol(rawValue: "rectangle.on.rectangle.slash")
+    static var rectangleOnRectangleSlash: SFSymbol { .init(rawValue: "rectangle.on.rectangle.slash") }
 
     /// 􀟏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortrait = SFSymbol(rawValue: "rectangle.portrait")
+    static var rectanglePortrait: SFSymbol { .init(rawValue: "rectangle.portrait") }
 
     /// 􀫼
     /// Single Localization, 2 Layersets
@@ -7341,7 +7341,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectanglePortraitArrowtriangle2Inward = SFSymbol(rawValue: "rectangle.portrait.arrowtriangle.2.inward")
+    static var rectanglePortraitArrowtriangle2Inward: SFSymbol { .init(rawValue: "rectangle.portrait.arrowtriangle.2.inward") }
 
     /// 􀫻
     /// Single Localization, 2 Layersets
@@ -7349,14 +7349,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectanglePortraitArrowtriangle2Outward = SFSymbol(rawValue: "rectangle.portrait.arrowtriangle.2.outward")
+    static var rectanglePortraitArrowtriangle2Outward: SFSymbol { .init(rawValue: "rectangle.portrait.arrowtriangle.2.outward") }
 
     /// 􀟐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitFill = SFSymbol(rawValue: "rectangle.portrait.fill")
+    static var rectanglePortraitFill: SFSymbol { .init(rawValue: "rectangle.portrait.fill") }
 
     /// 􀤷
     /// Single Localization, Single Layerset
@@ -7368,7 +7368,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleRighthalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleRighthalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleRighthalfFilled")
-    static let rectangleRighthalfFill = SFSymbol(rawValue: "rectangle.righthalf.fill")
+    static var rectangleRighthalfFill: SFSymbol { .init(rawValue: "rectangle.righthalf.fill") }
 
     /// 􀤵
     /// Single Localization, Single Layerset
@@ -7380,7 +7380,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleRighthalfInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleRighthalfInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleRighthalfInsetFilled")
-    static let rectangleRighthalfInsetFill = SFSymbol(rawValue: "rectangle.righthalf.inset.fill")
+    static var rectangleRighthalfInsetFill: SFSymbol { .init(rawValue: "rectangle.righthalf.inset.fill") }
 
     /// 􀥟
     /// Single Localization, Single Layerset
@@ -7392,7 +7392,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleRighthalfInsetFilledArrowRight")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleRighthalfInsetFilledArrowRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleRighthalfInsetFilledArrowRight")
-    static let rectangleRighthalfInsetFillArrowRight = SFSymbol(rawValue: "rectangle.righthalf.inset.fill.arrow.right")
+    static var rectangleRighthalfInsetFillArrowRight: SFSymbol { .init(rawValue: "rectangle.righthalf.inset.fill.arrow.right") }
 
     /// 􀨩
     /// Single Localization, Single Layerset
@@ -7404,7 +7404,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "rectangleRightthirdInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "rectangleRightthirdInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleRightthirdInsetFilled")
-    static let rectangleRightthirdInsetFill = SFSymbol(rawValue: "rectangle.rightthird.inset.fill")
+    static var rectangleRightthirdInsetFill: SFSymbol { .init(rawValue: "rectangle.rightthird.inset.fill") }
 
     /// 􀩺
     /// Single Localization, Single Layerset
@@ -7416,7 +7416,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "buttonRoundedbottomHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "buttonRoundedbottomHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "buttonRoundedbottomHorizontal")
-    static let rectangleRoundedbottom = SFSymbol(rawValue: "rectangle.roundedbottom")
+    static var rectangleRoundedbottom: SFSymbol { .init(rawValue: "rectangle.roundedbottom") }
 
     /// 􀩻
     /// Single Localization, Single Layerset
@@ -7428,7 +7428,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "buttonRoundedbottomHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "buttonRoundedbottomHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "buttonRoundedbottomHorizontalFill")
-    static let rectangleRoundedbottomFill = SFSymbol(rawValue: "rectangle.roundedbottom.fill")
+    static var rectangleRoundedbottomFill: SFSymbol { .init(rawValue: "rectangle.roundedbottom.fill") }
 
     /// 􀩸
     /// Single Localization, Single Layerset
@@ -7440,7 +7440,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "buttonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "buttonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "buttonRoundedtopHorizontal")
-    static let rectangleRoundedtop = SFSymbol(rawValue: "rectangle.roundedtop")
+    static var rectangleRoundedtop: SFSymbol { .init(rawValue: "rectangle.roundedtop") }
 
     /// 􀩹
     /// Single Localization, Single Layerset
@@ -7452,7 +7452,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "buttonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "buttonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "buttonRoundedtopHorizontalFill")
-    static let rectangleRoundedtopFill = SFSymbol(rawValue: "rectangle.roundedtop.fill")
+    static var rectangleRoundedtopFill: SFSymbol { .init(rawValue: "rectangle.roundedtop.fill") }
 
     /// 􀣤
     /// Single Localization, 2 Layersets
@@ -7460,7 +7460,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleSlash = SFSymbol(rawValue: "rectangle.slash")
+    static var rectangleSlash: SFSymbol { .init(rawValue: "rectangle.slash") }
 
     /// 􀣥
     /// Single Localization, 2 Layersets
@@ -7468,56 +7468,56 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let rectangleSlashFill = SFSymbol(rawValue: "rectangle.slash.fill")
+    static var rectangleSlashFill: SFSymbol { .init(rawValue: "rectangle.slash.fill") }
 
     /// 􀧊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit1x2 = SFSymbol(rawValue: "rectangle.split.1x2")
+    static var rectangleSplit1x2: SFSymbol { .init(rawValue: "rectangle.split.1x2") }
 
     /// 􀧋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit1x2Fill = SFSymbol(rawValue: "rectangle.split.1x2.fill")
+    static var rectangleSplit1x2Fill: SFSymbol { .init(rawValue: "rectangle.split.1x2.fill") }
 
     /// 􀧈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit2x1 = SFSymbol(rawValue: "rectangle.split.2x1")
+    static var rectangleSplit2x1: SFSymbol { .init(rawValue: "rectangle.split.2x1") }
 
     /// 􀧉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit2x1Fill = SFSymbol(rawValue: "rectangle.split.2x1.fill")
+    static var rectangleSplit2x1Fill: SFSymbol { .init(rawValue: "rectangle.split.2x1.fill") }
 
     /// 􀧌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit2x2 = SFSymbol(rawValue: "rectangle.split.2x2")
+    static var rectangleSplit2x2: SFSymbol { .init(rawValue: "rectangle.split.2x2") }
 
     /// 􀧍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleSplit2x2Fill = SFSymbol(rawValue: "rectangle.split.2x2.fill")
+    static var rectangleSplit2x2Fill: SFSymbol { .init(rawValue: "rectangle.split.2x2.fill") }
 
     /// 􀯆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let restart = SFSymbol(rawValue: "restart")
+    static var restart: SFSymbol { .init(rawValue: "restart") }
 
     /// 􀣨
     /// Single Localization, 2 Layersets
@@ -7525,14 +7525,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let restartCircle = SFSymbol(rawValue: "restart.circle")
+    static var restartCircle: SFSymbol { .init(rawValue: "restart.circle") }
 
     /// 􀢇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rotate3d = SFSymbol(rawValue: "rotate.3d")
+    static var rotate3d: SFSymbol { .init(rawValue: "rotate.3d") }
 
     /// 􀨙
     /// Single Localization, 2 Layersets
@@ -7545,7 +7545,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rtButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rtButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rtButtonRoundedtopHorizontal")
-    static let rtRectangleRoundedtop = SFSymbol(rawValue: "rt.rectangle.roundedtop")
+    static var rtRectangleRoundedtop: SFSymbol { .init(rawValue: "rt.rectangle.roundedtop") }
 
     /// 􀨚
     /// Single Localization, 3 Layersets
@@ -7559,112 +7559,112 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "rtButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "rtButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rtButtonRoundedtopHorizontalFill")
-    static let rtRectangleRoundedtopFill = SFSymbol(rawValue: "rt.rectangle.roundedtop.fill")
+    static var rtRectangleRoundedtopFill: SFSymbol { .init(rawValue: "rt.rectangle.roundedtop.fill") }
 
     /// 􀟀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ruler = SFSymbol(rawValue: "ruler")
+    static var ruler: SFSymbol { .init(rawValue: "ruler") }
 
     /// 􀟁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rulerFill = SFSymbol(rawValue: "ruler.fill")
+    static var rulerFill: SFSymbol { .init(rawValue: "ruler.fill") }
 
     /// 􀢆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scale3d = SFSymbol(rawValue: "scale.3d")
+    static var scale3d: SFSymbol { .init(rawValue: "scale.3d") }
 
     /// 􀭭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scalemass = SFSymbol(rawValue: "scalemass")
+    static var scalemass: SFSymbol { .init(rawValue: "scalemass") }
 
     /// 􀭮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scalemassFill = SFSymbol(rawValue: "scalemass.fill")
+    static var scalemassFill: SFSymbol { .init(rawValue: "scalemass.fill") }
 
     /// 􀪊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scanner = SFSymbol(rawValue: "scanner")
+    static var scanner: SFSymbol { .init(rawValue: "scanner") }
 
     /// 􀪋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scannerFill = SFSymbol(rawValue: "scanner.fill")
+    static var scannerFill: SFSymbol { .init(rawValue: "scanner.fill") }
 
     /// 􀤑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scribbleVariable = SFSymbol(rawValue: "scribble.variable")
+    static var scribbleVariable: SFSymbol { .init(rawValue: "scribble.variable") }
 
     /// 􀤏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scroll = SFSymbol(rawValue: "scroll")
+    static var scroll: SFSymbol { .init(rawValue: "scroll") }
 
     /// 􀤐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scrollFill = SFSymbol(rawValue: "scroll.fill")
+    static var scrollFill: SFSymbol { .init(rawValue: "scroll.fill") }
 
     /// 􀪇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sdcard = SFSymbol(rawValue: "sdcard")
+    static var sdcard: SFSymbol { .init(rawValue: "sdcard") }
 
     /// 􀪈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sdcardFill = SFSymbol(rawValue: "sdcard.fill")
+    static var sdcardFill: SFSymbol { .init(rawValue: "sdcard.fill") }
 
     /// 􀟆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let seal = SFSymbol(rawValue: "seal")
+    static var seal: SFSymbol { .init(rawValue: "seal") }
 
     /// 􀟇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sealFill = SFSymbol(rawValue: "seal.fill")
+    static var sealFill: SFSymbol { .init(rawValue: "seal.fill") }
 
     /// 􀪬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let serverRack = SFSymbol(rawValue: "server.rack")
+    static var serverRack: SFSymbol { .init(rawValue: "server.rack") }
 
     /// 􀨡
     /// Single Localization, 2 Layersets
@@ -7672,7 +7672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shadow = SFSymbol(rawValue: "shadow")
+    static var shadow: SFSymbol { .init(rawValue: "shadow") }
 
     /// 􀗋
     /// Single Localization, 2 Layersets
@@ -7680,7 +7680,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shekelsignCircle = SFSymbol(rawValue: "shekelsign.circle")
+    static var shekelsignCircle: SFSymbol { .init(rawValue: "shekelsign.circle") }
 
     /// 􀗌
     /// Single Localization, 3 Layersets
@@ -7689,7 +7689,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shekelsignCircleFill = SFSymbol(rawValue: "shekelsign.circle.fill")
+    static var shekelsignCircleFill: SFSymbol { .init(rawValue: "shekelsign.circle.fill") }
 
     /// 􀘋
     /// Single Localization, 2 Layersets
@@ -7697,7 +7697,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shekelsignSquare = SFSymbol(rawValue: "shekelsign.square")
+    static var shekelsignSquare: SFSymbol { .init(rawValue: "shekelsign.square") }
 
     /// 􀘌
     /// Single Localization, 3 Layersets
@@ -7706,7 +7706,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shekelsignSquareFill = SFSymbol(rawValue: "shekelsign.square.fill")
+    static var shekelsignSquareFill: SFSymbol { .init(rawValue: "shekelsign.square.fill") }
 
     /// 􀲊
     /// Single Localization, 2 Layersets
@@ -7719,91 +7719,91 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "shieldLefthalfFilledSlash")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "shieldLefthalfFilledSlash")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shieldLefthalfFilledSlash")
-    static let shieldLefthalfFillSlash = SFSymbol(rawValue: "shield.lefthalf.fill.slash")
+    static var shieldLefthalfFillSlash: SFSymbol { .init(rawValue: "shield.lefthalf.fill.slash") }
 
     /// 􀐚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shippingbox = SFSymbol(rawValue: "shippingbox")
+    static var shippingbox: SFSymbol { .init(rawValue: "shippingbox") }
 
     /// 􀐛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shippingboxFill = SFSymbol(rawValue: "shippingbox.fill")
+    static var shippingboxFill: SFSymbol { .init(rawValue: "shippingbox.fill") }
 
     /// 􀰱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarLeading = SFSymbol(rawValue: "sidebar.leading")
+    static var sidebarLeading: SFSymbol { .init(rawValue: "sidebar.leading") }
 
     /// 􀱦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarSquaresLeading = SFSymbol(rawValue: "sidebar.squares.leading")
+    static var sidebarSquaresLeading: SFSymbol { .init(rawValue: "sidebar.squares.leading") }
 
     /// 􀱤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarSquaresLeft = SFSymbol(rawValue: "sidebar.squares.left")
+    static var sidebarSquaresLeft: SFSymbol { .init(rawValue: "sidebar.squares.left") }
 
     /// 􀱥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarSquaresRight = SFSymbol(rawValue: "sidebar.squares.right")
+    static var sidebarSquaresRight: SFSymbol { .init(rawValue: "sidebar.squares.right") }
 
     /// 􀱧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarSquaresTrailing = SFSymbol(rawValue: "sidebar.squares.trailing")
+    static var sidebarSquaresTrailing: SFSymbol { .init(rawValue: "sidebar.squares.trailing") }
 
     /// 􀰲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sidebarTrailing = SFSymbol(rawValue: "sidebar.trailing")
+    static var sidebarTrailing: SFSymbol { .init(rawValue: "sidebar.trailing") }
 
     /// 􀰯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostLeft = SFSymbol(rawValue: "signpost.left")
+    static var signpostLeft: SFSymbol { .init(rawValue: "signpost.left") }
 
     /// 􀰰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostLeftFill = SFSymbol(rawValue: "signpost.left.fill")
+    static var signpostLeftFill: SFSymbol { .init(rawValue: "signpost.left.fill") }
 
     /// 􀯌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostRight = SFSymbol(rawValue: "signpost.right")
+    static var signpostRight: SFSymbol { .init(rawValue: "signpost.right") }
 
     /// 􀯍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostRightFill = SFSymbol(rawValue: "signpost.right.fill")
+    static var signpostRightFill: SFSymbol { .init(rawValue: "signpost.right.fill") }
 
     /// 􀠅
     /// Single Localization, 2 Layersets
@@ -7811,7 +7811,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let simcard = SFSymbol(rawValue: "simcard")
+    static var simcard: SFSymbol { .init(rawValue: "simcard") }
 
     /// 􀡹
     /// Single Localization, 3 Layersets
@@ -7820,7 +7820,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let simcard2 = SFSymbol(rawValue: "simcard.2")
+    static var simcard2: SFSymbol { .init(rawValue: "simcard.2") }
 
     /// 􀡺
     /// Single Localization, 2 Layersets
@@ -7828,7 +7828,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let simcard2Fill = SFSymbol(rawValue: "simcard.2.fill")
+    static var simcard2Fill: SFSymbol { .init(rawValue: "simcard.2.fill") }
 
     /// 􀠆
     /// Single Localization, 3 Layersets
@@ -7837,14 +7837,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let simcardFill = SFSymbol(rawValue: "simcard.fill")
+    static var simcardFill: SFSymbol { .init(rawValue: "simcard.fill") }
 
     /// 􀜚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sleep = SFSymbol(rawValue: "sleep")
+    static var sleep: SFSymbol { .init(rawValue: "sleep") }
 
     /// 􀰗
     /// Single Localization, 2 Layersets
@@ -7857,14 +7857,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "sliderHorizontalBelowSquareFilledAndSquare")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "sliderHorizontalBelowSquareFilledAndSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sliderHorizontalBelowSquareFilledAndSquare")
-    static let sliderHorizontalBelowSquareFillAndSquare = SFSymbol(rawValue: "slider.horizontal.below.square.fill.and.square")
+    static var sliderHorizontalBelowSquareFillAndSquare: SFSymbol { .init(rawValue: "slider.horizontal.below.square.fill.and.square") }
 
     /// 􀟲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sliderVertical3 = SFSymbol(rawValue: "slider.vertical.3")
+    static var sliderVertical3: SFSymbol { .init(rawValue: "slider.vertical.3") }
 
     /// 􀫸
     /// Single Localization, 2 Layersets
@@ -7872,7 +7872,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sparkle = SFSymbol(rawValue: "sparkle")
+    static var sparkle: SFSymbol { .init(rawValue: "sparkle") }
 
     /// 􀲳
     /// Single Localization, 2 Layersets
@@ -7880,7 +7880,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let sparklesRectangleStack = SFSymbol(rawValue: "sparkles.rectangle.stack")
+    static var sparklesRectangleStack: SFSymbol { .init(rawValue: "sparkles.rectangle.stack") }
 
     /// 􀲴
     /// Single Localization, 3 Layersets
@@ -7889,7 +7889,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sparklesRectangleStackFill = SFSymbol(rawValue: "sparkles.rectangle.stack.fill")
+    static var sparklesRectangleStackFill: SFSymbol { .init(rawValue: "sparkles.rectangle.stack.fill") }
 
     /// 􀰙
     /// Single Localization, 3 Layersets
@@ -7903,7 +7903,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "sparklesSquareFilledOnSquare")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "sparklesSquareFilledOnSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sparklesSquareFilledOnSquare")
-    static let sparklesSquareFillOnSquare = SFSymbol(rawValue: "sparkles.square.fill.on.square")
+    static var sparklesSquareFillOnSquare: SFSymbol { .init(rawValue: "sparkles.square.fill.on.square") }
 
     /// 􀫠
     /// 2 Localizations, 2 Layersets
@@ -7915,7 +7915,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerSlashCircle = SymbolWith1Localization<Rtl>(rawValue: "speaker.slash.circle")
+    static var speakerSlashCircle: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.slash.circle") }
 
     /// 􀫡
     /// 2 Localizations, 3 Layersets
@@ -7928,7 +7928,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerSlashCircleFill = SymbolWith1Localization<Rtl>(rawValue: "speaker.slash.circle.fill")
+    static var speakerSlashCircleFill: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.slash.circle.fill") }
 
     /// 􀊤
     /// Single Localization, 3 Layersets
@@ -7937,7 +7937,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave1 = SFSymbol(rawValue: "speaker.wave.1")
+    static var speakerWave1: SFSymbol { .init(rawValue: "speaker.wave.1") }
 
     /// 􀊥
     /// Single Localization, 3 Layersets
@@ -7946,7 +7946,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave1Fill = SFSymbol(rawValue: "speaker.wave.1.fill")
+    static var speakerWave1Fill: SFSymbol { .init(rawValue: "speaker.wave.1.fill") }
 
     /// 􀊦
     /// Single Localization, 3 Layersets
@@ -7955,7 +7955,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave2 = SFSymbol(rawValue: "speaker.wave.2")
+    static var speakerWave2: SFSymbol { .init(rawValue: "speaker.wave.2") }
 
     /// 􀥑
     /// Single Localization, 3 Layersets
@@ -7964,7 +7964,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave2Circle = SFSymbol(rawValue: "speaker.wave.2.circle")
+    static var speakerWave2Circle: SFSymbol { .init(rawValue: "speaker.wave.2.circle") }
 
     /// 􀥒
     /// Single Localization, 3 Layersets
@@ -7973,7 +7973,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let speakerWave2CircleFill = SFSymbol(rawValue: "speaker.wave.2.circle.fill")
+    static var speakerWave2CircleFill: SFSymbol { .init(rawValue: "speaker.wave.2.circle.fill") }
 
     /// 􀊧
     /// Single Localization, 3 Layersets
@@ -7982,7 +7982,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave2Fill = SFSymbol(rawValue: "speaker.wave.2.fill")
+    static var speakerWave2Fill: SFSymbol { .init(rawValue: "speaker.wave.2.fill") }
 
     /// 􀊨
     /// Single Localization, 3 Layersets
@@ -7991,7 +7991,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave3 = SFSymbol(rawValue: "speaker.wave.3")
+    static var speakerWave3: SFSymbol { .init(rawValue: "speaker.wave.3") }
 
     /// 􀊩
     /// Single Localization, 3 Layersets
@@ -8000,7 +8000,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let speakerWave3Fill = SFSymbol(rawValue: "speaker.wave.3.fill")
+    static var speakerWave3Fill: SFSymbol { .init(rawValue: "speaker.wave.3.fill") }
 
     /// 􀯭
     /// Single Localization, 3 Layersets
@@ -8014,7 +8014,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "square2Layers3d")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "square2Layers3d")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square2Layers3d")
-    static let square2Stack3d = SFSymbol(rawValue: "square.2.stack.3d")
+    static var square2Stack3d: SFSymbol { .init(rawValue: "square.2.stack.3d") }
 
     /// 􀯯
     /// Single Localization, Single Layerset
@@ -8026,7 +8026,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "square2Stack3dBottomFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "square2Stack3dBottomFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square2Stack3dBottomFilled")
-    static let square2Stack3dBottomFill = SFSymbol(rawValue: "square.2.stack.3d.bottom.fill")
+    static var square2Stack3dBottomFill: SFSymbol { .init(rawValue: "square.2.stack.3d.bottom.fill") }
 
     /// 􀯮
     /// Single Localization, Single Layerset
@@ -8038,7 +8038,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "square2Stack3dTopFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "square2Stack3dTopFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square2Stack3dTopFilled")
-    static let square2Stack3dTopFill = SFSymbol(rawValue: "square.2.stack.3d.top.fill")
+    static var square2Stack3dTopFill: SFSymbol { .init(rawValue: "square.2.stack.3d.top.fill") }
 
     /// 􀯰
     /// Single Localization, 3 Layersets
@@ -8052,7 +8052,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 16.0, renamed: "square3Layers3d")
     @available(watchOS, introduced: 7.0, deprecated: 9.0, renamed: "square3Layers3d")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Layers3d")
-    static let square3Stack3d = SFSymbol(rawValue: "square.3.stack.3d")
+    static var square3Stack3d: SFSymbol { .init(rawValue: "square.3.stack.3d") }
 
     /// 􀯳
     /// Single Localization, Single Layerset
@@ -8064,7 +8064,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "square3Stack3dBottomFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "square3Stack3dBottomFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Stack3dBottomFilled")
-    static let square3Stack3dBottomFill = SFSymbol(rawValue: "square.3.stack.3d.bottom.fill")
+    static var square3Stack3dBottomFill: SFSymbol { .init(rawValue: "square.3.stack.3d.bottom.fill") }
 
     /// 􀯲
     /// Single Localization, Single Layerset
@@ -8076,7 +8076,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "square3Stack3dMiddleFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "square3Stack3dMiddleFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Stack3dMiddleFilled")
-    static let square3Stack3dMiddleFill = SFSymbol(rawValue: "square.3.stack.3d.middle.fill")
+    static var square3Stack3dMiddleFill: SFSymbol { .init(rawValue: "square.3.stack.3d.middle.fill") }
 
     /// 􀯱
     /// Single Localization, Single Layerset
@@ -8088,7 +8088,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "square3Stack3dTopFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "square3Stack3dTopFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Stack3dTopFilled")
-    static let square3Stack3dTopFill = SFSymbol(rawValue: "square.3.stack.3d.top.fill")
+    static var square3Stack3dTopFill: SFSymbol { .init(rawValue: "square.3.stack.3d.top.fill") }
 
     /// 􀦏
     /// Single Localization, 2 Layersets
@@ -8096,7 +8096,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareAndAtRectangle = SFSymbol(rawValue: "square.and.at.rectangle")
+    static var squareAndAtRectangle: SFSymbol { .init(rawValue: "square.and.at.rectangle") }
 
     /// 􀪚
     /// Single Localization, Single Layerset
@@ -8108,7 +8108,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareBottomhalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareBottomhalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareBottomhalfFilled")
-    static let squareBottomhalfFill = SFSymbol(rawValue: "square.bottomhalf.fill")
+    static var squareBottomhalfFill: SFSymbol { .init(rawValue: "square.bottomhalf.fill") }
 
     /// 􀨃
     /// Single Localization, 2 Layersets
@@ -8116,7 +8116,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareCircle = SFSymbol(rawValue: "square.circle")
+    static var squareCircle: SFSymbol { .init(rawValue: "square.circle") }
 
     /// 􀨄
     /// Single Localization, 3 Layersets
@@ -8125,14 +8125,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareCircleFill = SFSymbol(rawValue: "square.circle.fill")
+    static var squareCircleFill: SFSymbol { .init(rawValue: "square.circle.fill") }
 
     /// 􀓔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareDashed = SFSymbol(rawValue: "square.dashed")
+    static var squareDashed: SFSymbol { .init(rawValue: "square.dashed") }
 
     /// 􀧑
     /// Single Localization, Single Layerset
@@ -8144,7 +8144,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareDashedInsetFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareDashedInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareDashedInsetFilled")
-    static let squareDashedInsetFill = SFSymbol(rawValue: "square.dashed.inset.fill")
+    static var squareDashedInsetFill: SFSymbol { .init(rawValue: "square.dashed.inset.fill") }
 
     /// 􀫝
     /// Single Localization, 3 Layersets
@@ -8158,7 +8158,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareFilledOnSquare")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareFilledOnSquare")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareFilledOnSquare")
-    static let squareFillOnSquare = SFSymbol(rawValue: "square.fill.on.square")
+    static var squareFillOnSquare: SFSymbol { .init(rawValue: "square.fill.on.square") }
 
     /// 􀭞
     /// Single Localization, 2 Layersets
@@ -8166,14 +8166,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareFillTextGrid1x2 = SFSymbol(rawValue: "square.fill.text.grid.1x2")
+    static var squareFillTextGrid1x2: SFSymbol { .init(rawValue: "square.fill.text.grid.1x2") }
 
     /// 􀓙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x1BelowLineGrid1x2 = SFSymbol(rawValue: "square.grid.3x1.below.line.grid.1x2")
+    static var squareGrid3x1BelowLineGrid1x2: SFSymbol { .init(rawValue: "square.grid.3x1.below.line.grid.1x2") }
 
     /// 􀤲
     /// Single Localization, Single Layerset
@@ -8185,7 +8185,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x1BelowLineGrid1x2Fill")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x1BelowLineGrid1x2Fill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x1BelowLineGrid1x2Fill")
-    static let squareGrid3x1FillBelowLineGrid1x2 = SFSymbol(rawValue: "square.grid.3x1.fill.below.line.grid.1x2")
+    static var squareGrid3x1FillBelowLineGrid1x2: SFSymbol { .init(rawValue: "square.grid.3x1.fill.below.line.grid.1x2") }
 
     /// 􀣕
     /// Single Localization, 3 Layersets
@@ -8194,7 +8194,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareGrid3x1FolderBadgePlus = SFSymbol(rawValue: "square.grid.3x1.folder.badge.plus")
+    static var squareGrid3x1FolderBadgePlus: SFSymbol { .init(rawValue: "square.grid.3x1.folder.badge.plus") }
 
     /// 􀣖
     /// Single Localization, 3 Layersets
@@ -8203,14 +8203,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareGrid3x1FolderFillBadgePlus = SFSymbol(rawValue: "square.grid.3x1.folder.fill.badge.plus")
+    static var squareGrid3x1FolderFillBadgePlus: SFSymbol { .init(rawValue: "square.grid.3x1.folder.fill.badge.plus") }
 
     /// 􀦲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x3 = SFSymbol(rawValue: "square.grid.3x3")
+    static var squareGrid3x3: SFSymbol { .init(rawValue: "square.grid.3x3") }
 
     /// 􀦺
     /// Single Localization, 2 Layersets
@@ -8223,7 +8223,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3BottomleftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3BottomleftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3BottomleftFilled")
-    static let squareGrid3x3BottomleftFill = SFSymbol(rawValue: "square.grid.3x3.bottomleft.fill")
+    static var squareGrid3x3BottomleftFill: SFSymbol { .init(rawValue: "square.grid.3x3.bottomleft.fill") }
 
     /// 􀦻
     /// Single Localization, 2 Layersets
@@ -8236,7 +8236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3BottommiddleFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3BottommiddleFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3BottommiddleFilled")
-    static let squareGrid3x3BottommiddleFill = SFSymbol(rawValue: "square.grid.3x3.bottommiddle.fill")
+    static var squareGrid3x3BottommiddleFill: SFSymbol { .init(rawValue: "square.grid.3x3.bottommiddle.fill") }
 
     /// 􀦼
     /// Single Localization, 2 Layersets
@@ -8249,14 +8249,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3BottomrightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3BottomrightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3BottomrightFilled")
-    static let squareGrid3x3BottomrightFill = SFSymbol(rawValue: "square.grid.3x3.bottomright.fill")
+    static var squareGrid3x3BottomrightFill: SFSymbol { .init(rawValue: "square.grid.3x3.bottomright.fill") }
 
     /// 􀦳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x3Fill = SFSymbol(rawValue: "square.grid.3x3.fill")
+    static var squareGrid3x3Fill: SFSymbol { .init(rawValue: "square.grid.3x3.fill") }
 
     /// 􀫐
     /// Single Localization, 2 Layersets
@@ -8269,7 +8269,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3Square")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3Square")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3Square")
-    static let squareGrid3x3FillSquare = SFSymbol(rawValue: "square.grid.3x3.fill.square")
+    static var squareGrid3x3FillSquare: SFSymbol { .init(rawValue: "square.grid.3x3.fill.square") }
 
     /// 􀦸
     /// Single Localization, 2 Layersets
@@ -8282,7 +8282,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3MiddleFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3MiddleFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3MiddleFilled")
-    static let squareGrid3x3MiddleFill = SFSymbol(rawValue: "square.grid.3x3.middle.fill")
+    static var squareGrid3x3MiddleFill: SFSymbol { .init(rawValue: "square.grid.3x3.middle.fill") }
 
     /// 􀦷
     /// Single Localization, 2 Layersets
@@ -8295,7 +8295,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3MiddleleftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3MiddleleftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3MiddleleftFilled")
-    static let squareGrid3x3MiddleleftFill = SFSymbol(rawValue: "square.grid.3x3.middleleft.fill")
+    static var squareGrid3x3MiddleleftFill: SFSymbol { .init(rawValue: "square.grid.3x3.middleleft.fill") }
 
     /// 􀦹
     /// Single Localization, 2 Layersets
@@ -8308,7 +8308,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3MiddlerightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3MiddlerightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3MiddlerightFilled")
-    static let squareGrid3x3MiddlerightFill = SFSymbol(rawValue: "square.grid.3x3.middleright.fill")
+    static var squareGrid3x3MiddlerightFill: SFSymbol { .init(rawValue: "square.grid.3x3.middleright.fill") }
 
     /// 􀦴
     /// Single Localization, 2 Layersets
@@ -8321,7 +8321,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3TopleftFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3TopleftFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3TopleftFilled")
-    static let squareGrid3x3TopleftFill = SFSymbol(rawValue: "square.grid.3x3.topleft.fill")
+    static var squareGrid3x3TopleftFill: SFSymbol { .init(rawValue: "square.grid.3x3.topleft.fill") }
 
     /// 􀦵
     /// Single Localization, 2 Layersets
@@ -8334,7 +8334,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3TopmiddleFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3TopmiddleFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3TopmiddleFilled")
-    static let squareGrid3x3TopmiddleFill = SFSymbol(rawValue: "square.grid.3x3.topmiddle.fill")
+    static var squareGrid3x3TopmiddleFill: SFSymbol { .init(rawValue: "square.grid.3x3.topmiddle.fill") }
 
     /// 􀦶
     /// Single Localization, 2 Layersets
@@ -8347,7 +8347,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareGrid3x3ToprightFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareGrid3x3ToprightFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareGrid3x3ToprightFilled")
-    static let squareGrid3x3ToprightFill = SFSymbol(rawValue: "square.grid.3x3.topright.fill")
+    static var squareGrid3x3ToprightFill: SFSymbol { .init(rawValue: "square.grid.3x3.topright.fill") }
 
     /// 􀯇
     /// Single Localization, 3 Layersets
@@ -8356,7 +8356,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareOnSquareDashed = SFSymbol(rawValue: "square.on.square.dashed")
+    static var squareOnSquareDashed: SFSymbol { .init(rawValue: "square.on.square.dashed") }
 
     /// 􀩶
     /// Single Localization, 3 Layersets
@@ -8365,7 +8365,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareOnSquareSquareshapeControlhandles = SFSymbol(rawValue: "square.on.square.squareshape.controlhandles")
+    static var squareOnSquareSquareshapeControlhandles: SFSymbol { .init(rawValue: "square.on.square.squareshape.controlhandles") }
 
     /// 􀣦
     /// Single Localization, 2 Layersets
@@ -8373,7 +8373,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareSlash = SFSymbol(rawValue: "square.slash")
+    static var squareSlash: SFSymbol { .init(rawValue: "square.slash") }
 
     /// 􀣧
     /// Single Localization, 2 Layersets
@@ -8381,49 +8381,49 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let squareSlashFill = SFSymbol(rawValue: "square.slash.fill")
+    static var squareSlashFill: SFSymbol { .init(rawValue: "square.slash.fill") }
 
     /// 􀟻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitBottomrightquarter = SFSymbol(rawValue: "square.split.bottomrightquarter")
+    static var squareSplitBottomrightquarter: SFSymbol { .init(rawValue: "square.split.bottomrightquarter") }
 
     /// 􀟼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitBottomrightquarterFill = SFSymbol(rawValue: "square.split.bottomrightquarter.fill")
+    static var squareSplitBottomrightquarterFill: SFSymbol { .init(rawValue: "square.split.bottomrightquarter.fill") }
 
     /// 􀡗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitDiagonal = SFSymbol(rawValue: "square.split.diagonal")
+    static var squareSplitDiagonal: SFSymbol { .init(rawValue: "square.split.diagonal") }
 
     /// 􀕲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitDiagonal2x2 = SFSymbol(rawValue: "square.split.diagonal.2x2")
+    static var squareSplitDiagonal2x2: SFSymbol { .init(rawValue: "square.split.diagonal.2x2") }
 
     /// 􀕳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitDiagonal2x2Fill = SFSymbol(rawValue: "square.split.diagonal.2x2.fill")
+    static var squareSplitDiagonal2x2Fill: SFSymbol { .init(rawValue: "square.split.diagonal.2x2.fill") }
 
     /// 􀡘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareSplitDiagonalFill = SFSymbol(rawValue: "square.split.diagonal.fill")
+    static var squareSplitDiagonalFill: SFSymbol { .init(rawValue: "square.split.diagonal.fill") }
 
     /// 􀰳
     /// Single Localization, 3 Layersets
@@ -8432,7 +8432,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dDownForward = SFSymbol(rawValue: "square.stack.3d.down.forward")
+    static var squareStack3dDownForward: SFSymbol { .init(rawValue: "square.stack.3d.down.forward") }
 
     /// 􀰴
     /// Single Localization, 3 Layersets
@@ -8441,7 +8441,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dDownForwardFill = SFSymbol(rawValue: "square.stack.3d.down.forward.fill")
+    static var squareStack3dDownForwardFill: SFSymbol { .init(rawValue: "square.stack.3d.down.forward.fill") }
 
     /// 􀐠
     /// Single Localization, 3 Layersets
@@ -8450,7 +8450,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dForwardDottedline = SFSymbol(rawValue: "square.stack.3d.forward.dottedline")
+    static var squareStack3dForwardDottedline: SFSymbol { .init(rawValue: "square.stack.3d.forward.dottedline") }
 
     /// 􀧏
     /// Single Localization, 3 Layersets
@@ -8459,7 +8459,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareStack3dForwardDottedlineFill = SFSymbol(rawValue: "square.stack.3d.forward.dottedline.fill")
+    static var squareStack3dForwardDottedlineFill: SFSymbol { .init(rawValue: "square.stack.3d.forward.dottedline.fill") }
 
     /// 􀙐
     /// Single Localization, 3 Layersets
@@ -8473,7 +8473,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "squareStack3dUpBadgeAutomatic")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "squareStack3dUpBadgeAutomatic")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareStack3dUpBadgeAutomatic")
-    static let squareStack3dUpBadgeA = SFSymbol(rawValue: "square.stack.3d.up.badge.a")
+    static var squareStack3dUpBadgeA: SFSymbol { .init(rawValue: "square.stack.3d.up.badge.a") }
 
     /// 􀙑
     /// Single Localization, 3 Layersets
@@ -8487,7 +8487,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "squareStack3dUpBadgeAutomaticFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "squareStack3dUpBadgeAutomaticFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareStack3dUpBadgeAutomaticFill")
-    static let squareStack3dUpBadgeAFill = SFSymbol(rawValue: "square.stack.3d.up.badge.a.fill")
+    static var squareStack3dUpBadgeAFill: SFSymbol { .init(rawValue: "square.stack.3d.up.badge.a.fill") }
 
     /// 􀪛
     /// Single Localization, Single Layerset
@@ -8499,14 +8499,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "squareTophalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "squareTophalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareTophalfFilled")
-    static let squareTophalfFill = SFSymbol(rawValue: "square.tophalf.fill")
+    static var squareTophalfFill: SFSymbol { .init(rawValue: "square.tophalf.fill") }
 
     /// 􀣮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshape = SFSymbol(rawValue: "squareshape")
+    static var squareshape: SFSymbol { .init(rawValue: "squareshape") }
 
     /// 􀩷
     /// Single Localization, 3 Layersets
@@ -8515,7 +8515,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareshapeControlhandlesOnSquareshapeControlhandles = SFSymbol(rawValue: "squareshape.controlhandles.on.squareshape.controlhandles")
+    static var squareshapeControlhandlesOnSquareshapeControlhandles: SFSymbol { .init(rawValue: "squareshape.controlhandles.on.squareshape.controlhandles") }
 
     /// 􀩢
     /// Single Localization, 2 Layersets
@@ -8528,21 +8528,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "squareshapeDottedSquareshape")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "squareshapeDottedSquareshape")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareshapeDottedSquareshape")
-    static let squareshapeDashedSquareshape = SFSymbol(rawValue: "squareshape.dashed.squareshape")
+    static var squareshapeDashedSquareshape: SFSymbol { .init(rawValue: "squareshape.dashed.squareshape") }
 
     /// 􀣯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshapeFill = SFSymbol(rawValue: "squareshape.fill")
+    static var squareshapeFill: SFSymbol { .init(rawValue: "squareshape.fill") }
 
     /// 􀮞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshapeSplit2x2 = SFSymbol(rawValue: "squareshape.split.2x2")
+    static var squareshapeSplit2x2: SFSymbol { .init(rawValue: "squareshape.split.2x2") }
 
     /// 􀮌
     /// Single Localization, Single Layerset
@@ -8554,14 +8554,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 18.4, renamed: "squareshapeSplit2x2DottedInside")
     @available(watchOS, introduced: 7.0, deprecated: 11.4, renamed: "squareshapeSplit2x2DottedInside")
     @available(visionOS, introduced: 1.0, deprecated: 2.4, renamed: "squareshapeSplit2x2DottedInside")
-    static let squareshapeSplit2x2Dotted = SFSymbol(rawValue: "squareshape.split.2x2.dotted")
+    static var squareshapeSplit2x2Dotted: SFSymbol { .init(rawValue: "squareshape.split.2x2.dotted") }
 
     /// 􀮟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshapeSplit3x3 = SFSymbol(rawValue: "squareshape.split.3x3")
+    static var squareshapeSplit3x3: SFSymbol { .init(rawValue: "squareshape.split.3x3") }
 
     /// 􀫴
     /// Single Localization, 2 Layersets
@@ -8574,7 +8574,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "squareshapeSquareshapeDotted")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "squareshapeSquareshapeDotted")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "squareshapeSquareshapeDotted")
-    static let squareshapeSquareshapeDashed = SFSymbol(rawValue: "squareshape.squareshape.dashed")
+    static var squareshapeSquareshapeDashed: SFSymbol { .init(rawValue: "squareshape.squareshape.dashed") }
 
     /// 􀋄
     /// Single Localization, 2 Layersets
@@ -8587,7 +8587,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "starLeadinghalfFilled")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "starLeadinghalfFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "starLeadinghalfFilled")
-    static let starLeadinghalfFill = SFSymbol(rawValue: "star.leadinghalf.fill")
+    static var starLeadinghalfFill: SFSymbol { .init(rawValue: "star.leadinghalf.fill") }
 
     /// 􀠧
     /// Single Localization, 3 Layersets
@@ -8596,7 +8596,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let starSquare = SFSymbol(rawValue: "star.square")
+    static var starSquare: SFSymbol { .init(rawValue: "star.square") }
 
     /// 􀠨
     /// Single Localization, 3 Layersets
@@ -8605,7 +8605,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let starSquareFill = SFSymbol(rawValue: "star.square.fill")
+    static var starSquareFill: SFSymbol { .init(rawValue: "star.square.fill") }
 
     /// 􀒺
     /// Single Localization, 2 Layersets
@@ -8613,7 +8613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let staroflifeCircle = SFSymbol(rawValue: "staroflife.circle")
+    static var staroflifeCircle: SFSymbol { .init(rawValue: "staroflife.circle") }
 
     /// 􀒻
     /// Single Localization, 3 Layersets
@@ -8622,7 +8622,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let staroflifeCircleFill = SFSymbol(rawValue: "staroflife.circle.fill")
+    static var staroflifeCircleFill: SFSymbol { .init(rawValue: "staroflife.circle.fill") }
 
     /// 􀝾
     /// Single Localization, 3 Layersets
@@ -8631,7 +8631,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let stethoscope = SFSymbol(rawValue: "stethoscope")
+    static var stethoscope: SFSymbol { .init(rawValue: "stethoscope") }
 
     /// 􀫊
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8640,7 +8640,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Swift programming language.
-    static let swift = SFSymbol(rawValue: "swift")
+    static var swift: SFSymbol { .init(rawValue: "swift") }
 
     /// 􀜊
     /// Single Localization, 2 Layersets
@@ -8648,14 +8648,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let switch2 = SFSymbol(rawValue: "switch.2")
+    static var switch2: SFSymbol { .init(rawValue: "switch.2") }
 
     /// 􀏣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tablecells = SFSymbol(rawValue: "tablecells")
+    static var tablecells: SFSymbol { .init(rawValue: "tablecells") }
 
     /// 􀏥
     /// Single Localization, 3 Layersets
@@ -8664,7 +8664,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let tablecellsBadgeEllipsis = SFSymbol(rawValue: "tablecells.badge.ellipsis")
+    static var tablecellsBadgeEllipsis: SFSymbol { .init(rawValue: "tablecells.badge.ellipsis") }
 
     /// 􀏦
     /// Single Localization, 3 Layersets
@@ -8678,14 +8678,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "tablecellsFillBadgeEllipsis")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "tablecellsFillBadgeEllipsis")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tablecellsFillBadgeEllipsis")
-    static let tablecellsBadgeEllipsisFill = SFSymbol(rawValue: "tablecells.badge.ellipsis.fill")
+    static var tablecellsBadgeEllipsisFill: SFSymbol { .init(rawValue: "tablecells.badge.ellipsis.fill") }
 
     /// 􀏤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tablecellsFill = SFSymbol(rawValue: "tablecells.fill")
+    static var tablecellsFill: SFSymbol { .init(rawValue: "tablecells.fill") }
 
     /// 􀦫
     /// Single Localization, 2 Layersets
@@ -8693,7 +8693,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tagSlash = SFSymbol(rawValue: "tag.slash")
+    static var tagSlash: SFSymbol { .init(rawValue: "tag.slash") }
 
     /// 􀦬
     /// Single Localization, 2 Layersets
@@ -8701,7 +8701,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tagSlashFill = SFSymbol(rawValue: "tag.slash.fill")
+    static var tagSlashFill: SFSymbol { .init(rawValue: "tag.slash.fill") }
 
     /// 􀢊
     /// Single Localization, 3 Layersets
@@ -8710,7 +8710,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let target = SFSymbol(rawValue: "target")
+    static var target: SFSymbol { .init(rawValue: "target") }
 
     /// 􀜅
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8721,7 +8721,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletypeCircle = SFSymbol(rawValue: "teletype.circle")
+    static var teletypeCircle: SFSymbol { .init(rawValue: "teletype.circle") }
 
     /// 􀜆
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8732,7 +8732,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletypeCircleFill = SFSymbol(rawValue: "teletype.circle.fill")
+    static var teletypeCircleFill: SFSymbol { .init(rawValue: "teletype.circle.fill") }
 
     /// 􀩼
     /// Single Localization, 2 Layersets
@@ -8745,7 +8745,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "appleTerminal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "appleTerminal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "appleTerminal")
-    static let terminal = SFSymbol(rawValue: "terminal")
+    static var terminal: SFSymbol { .init(rawValue: "terminal") }
 
     /// 􀪏
     /// Single Localization, 2 Layersets
@@ -8758,14 +8758,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "appleTerminalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "appleTerminalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "appleTerminalFill")
-    static let terminalFill = SFSymbol(rawValue: "terminal.fill")
+    static var terminalFill: SFSymbol { .init(rawValue: "terminal.fill") }
 
     /// 􀣚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textAndCommandMacwindow = SFSymbol(rawValue: "text.and.command.macwindow")
+    static var textAndCommandMacwindow: SFSymbol { .init(rawValue: "text.and.command.macwindow") }
 
     /// 􀲱
     /// 2 Localizations, Single Layerset
@@ -8776,7 +8776,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textBelowPhoto = SymbolWith1Localization<Rtl_v2_1>(rawValue: "text.below.photo")
+    static var textBelowPhoto: SymbolWith1Localization<Rtl_v2_1> { .init(rawValue: "text.below.photo") }
 
     /// 􀲲
     /// 2 Localizations, Single Layerset
@@ -8787,14 +8787,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textBelowPhotoFill = SymbolWith1Localization<Rtl_v2_1>(rawValue: "text.below.photo.fill")
+    static var textBelowPhotoFill: SymbolWith1Localization<Rtl_v2_1> { .init(rawValue: "text.below.photo.fill") }
 
     /// 􀫗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textBookClosed = SFSymbol(rawValue: "text.book.closed")
+    static var textBookClosed: SFSymbol { .init(rawValue: "text.book.closed") }
 
     /// 􀫘
     /// Single Localization, 2 Layersets
@@ -8802,7 +8802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let textBookClosedFill = SFSymbol(rawValue: "text.book.closed.fill")
+    static var textBookClosedFill: SFSymbol { .init(rawValue: "text.book.closed.fill") }
 
     /// 􀭥
     /// 2 Localizations, 2 Layersets
@@ -8814,7 +8814,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let textMagnifyingglass = SymbolWith1Localization<Rtl>(rawValue: "text.magnifyingglass")
+    static var textMagnifyingglass: SymbolWith1Localization<Rtl> { .init(rawValue: "text.magnifyingglass") }
 
     /// 􀧎
     /// Single Localization, 2 Layersets
@@ -8822,7 +8822,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let textRedaction = SFSymbol(rawValue: "text.redaction")
+    static var textRedaction: SFSymbol { .init(rawValue: "text.redaction") }
 
     /// 􀦜
     /// Single Localization, 3 Layersets
@@ -8831,21 +8831,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let thermometerSunFill = SFSymbol(rawValue: "thermometer.sun.fill")
+    static var thermometerSunFill: SFSymbol { .init(rawValue: "thermometer.sun.fill") }
 
     /// 􀪃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ticket = SFSymbol(rawValue: "ticket")
+    static var ticket: SFSymbol { .init(rawValue: "ticket") }
 
     /// 􀪄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ticketFill = SFSymbol(rawValue: "ticket.fill")
+    static var ticketFill: SFSymbol { .init(rawValue: "ticket.fill") }
 
     /// 􀣂
     /// Single Localization, 2 Layersets
@@ -8853,7 +8853,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let timelineSelection = SFSymbol(rawValue: "timeline.selection")
+    static var timelineSelection: SFSymbol { .init(rawValue: "timeline.selection") }
 
     /// 􀭄
     /// Single Localization, 2 Layersets
@@ -8861,7 +8861,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let timerSquare = SFSymbol(rawValue: "timer.square")
+    static var timerSquare: SFSymbol { .init(rawValue: "timer.square") }
 
     /// 􀥣
     /// Single Localization, 2 Layersets
@@ -8869,7 +8869,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let togglepower = SFSymbol(rawValue: "togglepower")
+    static var togglepower: SFSymbol { .init(rawValue: "togglepower") }
 
     /// 􀟒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8880,14 +8880,14 @@ public extension SFSymbol {
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Touch ID feature.
-    static let touchid = SFSymbol(rawValue: "touchid")
+    static var touchid: SFSymbol { .init(rawValue: "touchid") }
 
     /// 􀝆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tram = SFSymbol(rawValue: "tram")
+    static var tram: SFSymbol { .init(rawValue: "tram") }
 
     /// 􀲛
     /// Single Localization, 2 Layersets
@@ -8895,7 +8895,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tramCircle = SFSymbol(rawValue: "tram.circle")
+    static var tramCircle: SFSymbol { .init(rawValue: "tram.circle") }
 
     /// 􀲜
     /// Single Localization, 3 Layersets
@@ -8904,7 +8904,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tramCircleFill = SFSymbol(rawValue: "tram.circle.fill")
+    static var tramCircleFill: SFSymbol { .init(rawValue: "tram.circle.fill") }
 
     /// 􀜝
     /// Single Localization, Single Layerset
@@ -8916,7 +8916,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 15.0, renamed: "tramFillTunnel")
     @available(watchOS, introduced: 7.0, deprecated: 8.0, renamed: "tramFillTunnel")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "tramFillTunnel")
-    static let tramTunnelFill = SFSymbol(rawValue: "tram.tunnel.fill")
+    static var tramTunnelFill: SFSymbol { .init(rawValue: "tram.tunnel.fill") }
 
     /// 􀒌
     /// Single Localization, 2 Layersets
@@ -8924,7 +8924,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayCircle = SFSymbol(rawValue: "tray.circle")
+    static var trayCircle: SFSymbol { .init(rawValue: "tray.circle") }
 
     /// 􀒍
     /// Single Localization, 3 Layersets
@@ -8933,7 +8933,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let trayCircleFill = SFSymbol(rawValue: "tray.circle.fill")
+    static var trayCircleFill: SFSymbol { .init(rawValue: "tray.circle.fill") }
 
     /// 􀨅
     /// Single Localization, 2 Layersets
@@ -8941,7 +8941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let triangleCircle = SFSymbol(rawValue: "triangle.circle")
+    static var triangleCircle: SFSymbol { .init(rawValue: "triangle.circle") }
 
     /// 􀨆
     /// Single Localization, 3 Layersets
@@ -8950,7 +8950,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let triangleCircleFill = SFSymbol(rawValue: "triangle.circle.fill")
+    static var triangleCircleFill: SFSymbol { .init(rawValue: "triangle.circle.fill") }
 
     /// 􀫑
     /// Single Localization, 2 Layersets
@@ -8958,7 +8958,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tvAndHifispeakerFill = SFSymbol(rawValue: "tv.and.hifispeaker.fill")
+    static var tvAndHifispeakerFill: SFSymbol { .init(rawValue: "tv.and.hifispeaker.fill") }
 
     /// 􀮺
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8969,7 +8969,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBadgeCheckmark = SFSymbol(rawValue: "video.badge.checkmark")
+    static var videoBadgeCheckmark: SFSymbol { .init(rawValue: "video.badge.checkmark") }
 
     /// 􀱰
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8984,7 +8984,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "videoBubble")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "videoBubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "videoBubble")
-    static let videoBubbleLeft = SFSymbol(rawValue: "video.bubble.left")
+    static var videoBubbleLeft: SFSymbol { .init(rawValue: "video.bubble.left") }
 
     /// 􀱱
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9000,7 +9000,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "videoBubbleFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "videoBubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "videoBubbleFill")
-    static let videoBubbleLeftFill = SFSymbol(rawValue: "video.bubble.left.fill")
+    static var videoBubbleLeftFill: SFSymbol { .init(rawValue: "video.bubble.left.fill") }
 
     /// 􀮻
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9011,7 +9011,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoFillBadgeCheckmark = SFSymbol(rawValue: "video.fill.badge.checkmark")
+    static var videoFillBadgeCheckmark: SFSymbol { .init(rawValue: "video.fill.badge.checkmark") }
 
     /// 􀜯
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -9022,21 +9022,21 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoFillBadgePlus = SFSymbol(rawValue: "video.fill.badge.plus")
+    static var videoFillBadgePlus: SFSymbol { .init(rawValue: "video.fill.badge.plus") }
 
     /// 􀪒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wake = SFSymbol(rawValue: "wake")
+    static var wake: SFSymbol { .init(rawValue: "wake") }
 
     /// 􀟾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let walletPass = SFSymbol(rawValue: "wallet.pass")
+    static var walletPass: SFSymbol { .init(rawValue: "wallet.pass") }
 
     /// 􀟿
     /// Single Localization, 2 Layersets
@@ -9044,7 +9044,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let walletPassFill = SFSymbol(rawValue: "wallet.pass.fill")
+    static var walletPassFill: SFSymbol { .init(rawValue: "wallet.pass.fill") }
 
     /// 􀱘
     /// Single Localization, 3 Layersets
@@ -9053,7 +9053,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3Backward = SFSymbol(rawValue: "wave.3.backward")
+    static var wave3Backward: SFSymbol { .init(rawValue: "wave.3.backward") }
 
     /// 􀱙
     /// Single Localization, 3 Layersets
@@ -9062,7 +9062,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3BackwardCircle = SFSymbol(rawValue: "wave.3.backward.circle")
+    static var wave3BackwardCircle: SFSymbol { .init(rawValue: "wave.3.backward.circle") }
 
     /// 􀱚
     /// Single Localization, 3 Layersets
@@ -9071,7 +9071,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wave3BackwardCircleFill = SFSymbol(rawValue: "wave.3.backward.circle.fill")
+    static var wave3BackwardCircleFill: SFSymbol { .init(rawValue: "wave.3.backward.circle.fill") }
 
     /// 􀱛
     /// Single Localization, 2 Layersets
@@ -9079,7 +9079,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3Forward = SFSymbol(rawValue: "wave.3.forward")
+    static var wave3Forward: SFSymbol { .init(rawValue: "wave.3.forward") }
 
     /// 􀱜
     /// Single Localization, 3 Layersets
@@ -9088,7 +9088,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3ForwardCircle = SFSymbol(rawValue: "wave.3.forward.circle")
+    static var wave3ForwardCircle: SFSymbol { .init(rawValue: "wave.3.forward.circle") }
 
     /// 􀱝
     /// Single Localization, 3 Layersets
@@ -9097,7 +9097,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wave3ForwardCircleFill = SFSymbol(rawValue: "wave.3.forward.circle.fill")
+    static var wave3ForwardCircleFill: SFSymbol { .init(rawValue: "wave.3.forward.circle.fill") }
 
     /// 􀙱
     /// Single Localization, 3 Layersets
@@ -9106,7 +9106,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3Left = SFSymbol(rawValue: "wave.3.left")
+    static var wave3Left: SFSymbol { .init(rawValue: "wave.3.left") }
 
     /// 􀭷
     /// Single Localization, 3 Layersets
@@ -9115,7 +9115,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3LeftCircle = SFSymbol(rawValue: "wave.3.left.circle")
+    static var wave3LeftCircle: SFSymbol { .init(rawValue: "wave.3.left.circle") }
 
     /// 􀭸
     /// Single Localization, 3 Layersets
@@ -9124,7 +9124,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wave3LeftCircleFill = SFSymbol(rawValue: "wave.3.left.circle.fill")
+    static var wave3LeftCircleFill: SFSymbol { .init(rawValue: "wave.3.left.circle.fill") }
 
     /// 􀙲
     /// Single Localization, 3 Layersets
@@ -9133,7 +9133,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3Right = SFSymbol(rawValue: "wave.3.right")
+    static var wave3Right: SFSymbol { .init(rawValue: "wave.3.right") }
 
     /// 􀭹
     /// Single Localization, 3 Layersets
@@ -9142,7 +9142,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wave3RightCircle = SFSymbol(rawValue: "wave.3.right.circle")
+    static var wave3RightCircle: SFSymbol { .init(rawValue: "wave.3.right.circle") }
 
     /// 􀭺
     /// Single Localization, 3 Layersets
@@ -9151,7 +9151,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let wave3RightCircleFill = SFSymbol(rawValue: "wave.3.right.circle.fill")
+    static var wave3RightCircleFill: SFSymbol { .init(rawValue: "wave.3.right.circle.fill") }
 
     /// 􀟪
     /// Single Localization, 3 Layersets
@@ -9160,14 +9160,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let waveformPathEcgRectangle = SFSymbol(rawValue: "waveform.path.ecg.rectangle")
+    static var waveformPathEcgRectangle: SFSymbol { .init(rawValue: "waveform.path.ecg.rectangle") }
 
     /// 􀟫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformPathEcgRectangleFill = SFSymbol(rawValue: "waveform.path.ecg.rectangle.fill")
+    static var waveformPathEcgRectangleFill: SFSymbol { .init(rawValue: "waveform.path.ecg.rectangle.fill") }
 
     /// 􀤊
     /// Single Localization, 3 Layersets
@@ -9176,7 +9176,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wrenchAndScrewdriver = SFSymbol(rawValue: "wrench.and.screwdriver")
+    static var wrenchAndScrewdriver: SFSymbol { .init(rawValue: "wrench.and.screwdriver") }
 
     /// 􀤋
     /// Single Localization, 3 Layersets
@@ -9185,7 +9185,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wrenchAndScrewdriverFill = SFSymbol(rawValue: "wrench.and.screwdriver.fill")
+    static var wrenchAndScrewdriverFill: SFSymbol { .init(rawValue: "wrench.and.screwdriver.fill") }
 
     /// 􀈱
     /// Single Localization, 2 Layersets
@@ -9193,7 +9193,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkBin = SFSymbol(rawValue: "xmark.bin")
+    static var xmarkBin: SFSymbol { .init(rawValue: "xmark.bin") }
 
     /// 􀈳
     /// Single Localization, 2 Layersets
@@ -9201,7 +9201,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkBinCircle = SFSymbol(rawValue: "xmark.bin.circle")
+    static var xmarkBinCircle: SFSymbol { .init(rawValue: "xmark.bin.circle") }
 
     /// 􀈴
     /// Single Localization, 3 Layersets
@@ -9210,7 +9210,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let xmarkBinCircleFill = SFSymbol(rawValue: "xmark.bin.circle.fill")
+    static var xmarkBinCircleFill: SFSymbol { .init(rawValue: "xmark.bin.circle.fill") }
 
     /// 􀈲
     /// Single Localization, 3 Layersets
@@ -9219,7 +9219,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkBinFill = SFSymbol(rawValue: "xmark.bin.fill")
+    static var xmarkBinFill: SFSymbol { .init(rawValue: "xmark.bin.fill") }
 
     /// 􀢃
     /// Single Localization, 3 Layersets
@@ -9228,7 +9228,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkDiamond = SFSymbol(rawValue: "xmark.diamond")
+    static var xmarkDiamond: SFSymbol { .init(rawValue: "xmark.diamond") }
 
     /// 􀢄
     /// Single Localization, 3 Layersets
@@ -9237,7 +9237,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkDiamondFill = SFSymbol(rawValue: "xmark.diamond.fill")
+    static var xmarkDiamondFill: SFSymbol { .init(rawValue: "xmark.diamond.fill") }
 
     /// 􀡰
     /// Single Localization, 3 Layersets
@@ -9246,7 +9246,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkRectanglePortrait = SFSymbol(rawValue: "xmark.rectangle.portrait")
+    static var xmarkRectanglePortrait: SFSymbol { .init(rawValue: "xmark.rectangle.portrait") }
 
     /// 􀡱
     /// Single Localization, 3 Layersets
@@ -9255,7 +9255,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkRectanglePortraitFill = SFSymbol(rawValue: "xmark.rectangle.portrait.fill")
+    static var xmarkRectanglePortraitFill: SFSymbol { .init(rawValue: "xmark.rectangle.portrait.fill") }
 
     /// 􀧘
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -9264,7 +9264,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Xserve.
-    static let xserve = SFSymbol(rawValue: "xserve")
+    static var xserve: SFSymbol { .init(rawValue: "xserve") }
 
     /// 􀨛
     /// Single Localization, 2 Layersets
@@ -9277,7 +9277,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "zlButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "zlButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "zlButtonRoundedtopHorizontal")
-    static let zlRectangleRoundedtop = SFSymbol(rawValue: "zl.rectangle.roundedtop")
+    static var zlRectangleRoundedtop: SFSymbol { .init(rawValue: "zl.rectangle.roundedtop") }
 
     /// 􀨜
     /// Single Localization, 3 Layersets
@@ -9291,7 +9291,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "zlButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "zlButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "zlButtonRoundedtopHorizontalFill")
-    static let zlRectangleRoundedtopFill = SFSymbol(rawValue: "zl.rectangle.roundedtop.fill")
+    static var zlRectangleRoundedtopFill: SFSymbol { .init(rawValue: "zl.rectangle.roundedtop.fill") }
 
     /// 􀨝
     /// Single Localization, 2 Layersets
@@ -9304,7 +9304,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "zrButtonRoundedtopHorizontal")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "zrButtonRoundedtopHorizontal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "zrButtonRoundedtopHorizontal")
-    static let zrRectangleRoundedtop = SFSymbol(rawValue: "zr.rectangle.roundedtop")
+    static var zrRectangleRoundedtop: SFSymbol { .init(rawValue: "zr.rectangle.roundedtop") }
 
     /// 􀨞
     /// Single Localization, 3 Layersets
@@ -9318,5 +9318,5 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.0, deprecated: 17.0, renamed: "zrButtonRoundedtopHorizontalFill")
     @available(watchOS, introduced: 7.0, deprecated: 10.0, renamed: "zrButtonRoundedtopHorizontalFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "zrButtonRoundedtopHorizontalFill")
-    static let zrRectangleRoundedtopFill = SFSymbol(rawValue: "zr.rectangle.roundedtop.fill")
+    static var zrRectangleRoundedtopFill: SFSymbol { .init(rawValue: "zr.rectangle.roundedtop.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+2.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+2.1.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let aqiHigh = SFSymbol(rawValue: "aqi.high")
+    static var aqiHigh: SFSymbol { .init(rawValue: "aqi.high") }
 
     /// 􀴾
     /// Single Localization, 3 Layersets
@@ -19,7 +19,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let aqiLow = SFSymbol(rawValue: "aqi.low")
+    static var aqiLow: SFSymbol { .init(rawValue: "aqi.low") }
 
     /// 􀴿
     /// Single Localization, 3 Layersets
@@ -28,7 +28,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let aqiMedium = SFSymbol(rawValue: "aqi.medium")
+    static var aqiMedium: SFSymbol { .init(rawValue: "aqi.medium") }
 
     /// 􀮰
     /// Single Localization, 2 Layersets
@@ -36,7 +36,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let brazilianrealsignCircle = SFSymbol(rawValue: "brazilianrealsign.circle")
+    static var brazilianrealsignCircle: SFSymbol { .init(rawValue: "brazilianrealsign.circle") }
 
     /// 􀮱
     /// Single Localization, 3 Layersets
@@ -45,7 +45,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let brazilianrealsignCircleFill = SFSymbol(rawValue: "brazilianrealsign.circle.fill")
+    static var brazilianrealsignCircleFill: SFSymbol { .init(rawValue: "brazilianrealsign.circle.fill") }
 
     /// 􀮲
     /// Single Localization, 2 Layersets
@@ -53,7 +53,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let brazilianrealsignSquare = SFSymbol(rawValue: "brazilianrealsign.square")
+    static var brazilianrealsignSquare: SFSymbol { .init(rawValue: "brazilianrealsign.square") }
 
     /// 􀮳
     /// Single Localization, 3 Layersets
@@ -62,7 +62,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let brazilianrealsignSquareFill = SFSymbol(rawValue: "brazilianrealsign.square.fill")
+    static var brazilianrealsignSquareFill: SFSymbol { .init(rawValue: "brazilianrealsign.square.fill") }
 
     /// 􀒭
     /// Single Localization, 2 Layersets
@@ -70,7 +70,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartCircle = SFSymbol(rawValue: "cart.circle")
+    static var cartCircle: SFSymbol { .init(rawValue: "cart.circle") }
 
     /// 􀒮
     /// Single Localization, 3 Layersets
@@ -79,7 +79,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let cartCircleFill = SFSymbol(rawValue: "cart.circle.fill")
+    static var cartCircleFill: SFSymbol { .init(rawValue: "cart.circle.fill") }
 
     /// 􀅏
     /// 20 Localizations, Single Layerset
@@ -108,7 +108,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let character = SymbolWith19Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Si_v6, Ta_v6, Te_v6, Th, Zh>(rawValue: "character")
+    static var character: SymbolWith19Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Si_v6, Ta_v6, Te_v6, Th, Zh> { .init(rawValue: "character") }
 
     /// 􀫕
     /// 20 Localizations, Single Layerset
@@ -137,7 +137,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let characterBookClosed = SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi, Ja, Kn_v7, Ko, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th, Zh>(rawValue: "character.book.closed")
+    static var characterBookClosed: SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi, Ja, Kn_v7, Ko, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th, Zh> { .init(rawValue: "character.book.closed") }
 
     /// 􀫖
     /// 20 Localizations, Single Layerset
@@ -166,7 +166,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let characterBookClosedFill = SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi, Ja, Kn_v7, Ko, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th, Zh>(rawValue: "character.book.closed.fill")
+    static var characterBookClosedFill: SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi, Ja, Kn_v7, Ko, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th, Zh> { .init(rawValue: "character.book.closed.fill") }
 
     /// 􀯛
     /// Single Localization, 2 Layersets
@@ -179,14 +179,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 18.0, renamed: "clockArrowTrianglehead2CounterclockwiseRotate90")
     @available(watchOS, introduced: 7.1, deprecated: 11.0, renamed: "clockArrowTrianglehead2CounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "clockArrowTrianglehead2CounterclockwiseRotate90")
-    static let clockArrow2Circlepath = SFSymbol(rawValue: "clock.arrow.2.circlepath")
+    static var clockArrow2Circlepath: SFSymbol { .init(rawValue: "clock.arrow.2.circlepath") }
 
     /// 􀯝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let directcurrent = SFSymbol(rawValue: "directcurrent")
+    static var directcurrent: SFSymbol { .init(rawValue: "directcurrent") }
 
     /// 􀵄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -196,7 +196,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let exclamationmarkApplewatch = SFSymbol(rawValue: "exclamationmark.applewatch")
+    static var exclamationmarkApplewatch: SFSymbol { .init(rawValue: "exclamationmark.applewatch") }
 
     /// 􀵏
     /// Single Localization, 2 Layersets
@@ -204,7 +204,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let infinityCircle = SFSymbol(rawValue: "infinity.circle")
+    static var infinityCircle: SFSymbol { .init(rawValue: "infinity.circle") }
 
     /// 􀵐
     /// Single Localization, 3 Layersets
@@ -213,7 +213,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let infinityCircleFill = SFSymbol(rawValue: "infinity.circle.fill")
+    static var infinityCircleFill: SFSymbol { .init(rawValue: "infinity.circle.fill") }
 
     /// 􀴓
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -224,7 +224,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadBadgePlay = SFSymbol(rawValue: "ipad.badge.play")
+    static var ipadBadgePlay: SFSymbol { .init(rawValue: "ipad.badge.play") }
 
     /// 􀴒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -240,7 +240,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 16.1, renamed: "ipadGen1BadgePlay")
     @available(watchOS, introduced: 7.1, deprecated: 9.1, renamed: "ipadGen1BadgePlay")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ipadGen1BadgePlay")
-    static let ipadHomebuttonBadgePlay = SFSymbol(rawValue: "ipad.homebutton.badge.play")
+    static var ipadHomebuttonBadgePlay: SFSymbol { .init(rawValue: "ipad.homebutton.badge.play") }
 
     /// 􀵑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -256,7 +256,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 16.1, renamed: "ipadGen1LandscapeBadgePlay")
     @available(watchOS, introduced: 7.1, deprecated: 9.1, renamed: "ipadGen1LandscapeBadgePlay")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "ipadGen1LandscapeBadgePlay")
-    static let ipadHomebuttonLandscapeBadgePlay = SFSymbol(rawValue: "ipad.homebutton.landscape.badge.play")
+    static var ipadHomebuttonLandscapeBadgePlay: SFSymbol { .init(rawValue: "ipad.homebutton.landscape.badge.play") }
 
     /// 􀵒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -267,7 +267,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadLandscapeBadgePlay = SFSymbol(rawValue: "ipad.landscape.badge.play")
+    static var ipadLandscapeBadgePlay: SFSymbol { .init(rawValue: "ipad.landscape.badge.play") }
 
     /// 􀴑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -278,7 +278,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneBadgePlay = SFSymbol(rawValue: "iphone.badge.play")
+    static var iphoneBadgePlay: SFSymbol { .init(rawValue: "iphone.badge.play") }
 
     /// 􀐶
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -294,7 +294,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 16.1, renamed: "iphoneGen1BadgePlay")
     @available(watchOS, introduced: 7.1, deprecated: 9.1, renamed: "iphoneGen1BadgePlay")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1BadgePlay")
-    static let iphoneHomebuttonBadgePlay = SFSymbol(rawValue: "iphone.homebutton.badge.play")
+    static var iphoneHomebuttonBadgePlay: SFSymbol { .init(rawValue: "iphone.homebutton.badge.play") }
 
     /// 􀴎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -309,7 +309,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 16.1, renamed: "iphoneGen1Landscape")
     @available(watchOS, introduced: 7.1, deprecated: 9.1, renamed: "iphoneGen1Landscape")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1Landscape")
-    static let iphoneHomebuttonLandscape = SFSymbol(rawValue: "iphone.homebutton.landscape")
+    static var iphoneHomebuttonLandscape: SFSymbol { .init(rawValue: "iphone.homebutton.landscape") }
 
     /// 􀴏
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -319,7 +319,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneLandscape = SFSymbol(rawValue: "iphone.landscape")
+    static var iphoneLandscape: SFSymbol { .init(rawValue: "iphone.landscape") }
 
     /// 􀴐
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -334,7 +334,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 18.0, renamed: "ipodTouchLandscape")
     @available(watchOS, introduced: 7.1, deprecated: 11.0, renamed: "ipodTouchLandscape")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodTouchLandscape")
-    static let ipodtouchLandscape = SFSymbol(rawValue: "ipodtouch.landscape")
+    static var ipodtouchLandscape: SFSymbol { .init(rawValue: "ipodtouch.landscape") }
 
     /// 􀵅
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -344,14 +344,14 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let lockApplewatch = SFSymbol(rawValue: "lock.applewatch")
+    static var lockApplewatch: SFSymbol { .init(rawValue: "lock.applewatch") }
 
     /// 􀵪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let photoTv = SFSymbol(rawValue: "photo.tv")
+    static var photoTv: SFSymbol { .init(rawValue: "photo.tv") }
 
     /// 􀵨
     /// Single Localization, 2 Layersets
@@ -359,7 +359,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let playTv = SFSymbol(rawValue: "play.tv")
+    static var playTv: SFSymbol { .init(rawValue: "play.tv") }
 
     /// 􀵩
     /// Single Localization, 3 Layersets
@@ -368,7 +368,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playTvFill = SFSymbol(rawValue: "play.tv.fill")
+    static var playTvFill: SFSymbol { .init(rawValue: "play.tv.fill") }
 
     /// 􀵚
     /// Single Localization, 3 Layersets
@@ -377,7 +377,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleBadgePersonCrop = SFSymbol(rawValue: "rectangle.badge.person.crop")
+    static var rectangleBadgePersonCrop: SFSymbol { .init(rawValue: "rectangle.badge.person.crop") }
 
     /// 􀵛
     /// Single Localization, 3 Layersets
@@ -386,7 +386,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleFillBadgePersonCrop = SFSymbol(rawValue: "rectangle.fill.badge.person.crop")
+    static var rectangleFillBadgePersonCrop: SFSymbol { .init(rawValue: "rectangle.fill.badge.person.crop") }
 
     /// 􀴊
     /// Single Localization, Single Layerset
@@ -398,7 +398,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 14.5, renamed: "rectangleTopthirdInsetFill")
     @available(watchOS, introduced: 7.1, deprecated: 7.4, renamed: "rectangleTopthirdInsetFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleTopthirdInsetFill")
-    static let rectangleTopthirdInset = SFSymbol(rawValue: "rectangle.topthird.inset")
+    static var rectangleTopthirdInset: SFSymbol { .init(rawValue: "rectangle.topthird.inset") }
 
     /// 􀵍
     /// 3 Localizations, 2 Layersets
@@ -411,7 +411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let repeat1Circle = SymbolWith2Localizations<Ar_v3, Hi_v3>(rawValue: "repeat.1.circle")
+    static var repeat1Circle: SymbolWith2Localizations<Ar_v3, Hi_v3> { .init(rawValue: "repeat.1.circle") }
 
     /// 􀵎
     /// 3 Localizations, 3 Layersets
@@ -425,7 +425,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let repeat1CircleFill = SymbolWith2Localizations<Ar_v3, Hi_v3>(rawValue: "repeat.1.circle.fill")
+    static var repeat1CircleFill: SymbolWith2Localizations<Ar_v3, Hi_v3> { .init(rawValue: "repeat.1.circle.fill") }
 
     /// 􀵋
     /// Single Localization, 2 Layersets
@@ -433,7 +433,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let repeatCircle = SFSymbol(rawValue: "repeat.circle")
+    static var repeatCircle: SFSymbol { .init(rawValue: "repeat.circle") }
 
     /// 􀵌
     /// Single Localization, 3 Layersets
@@ -442,7 +442,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let repeatCircleFill = SFSymbol(rawValue: "repeat.circle.fill")
+    static var repeatCircleFill: SFSymbol { .init(rawValue: "repeat.circle.fill") }
 
     /// 􀵔
     /// Single Localization, Single Layerset
@@ -454,7 +454,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.2, deprecated: 15.0, renamed: "checkerboardShield")
     @available(watchOS, introduced: 7.1, deprecated: 8.0, renamed: "checkerboardShield")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "checkerboardShield")
-    static let shieldCheckerboard = SFSymbol(rawValue: "shield.checkerboard")
+    static var shieldCheckerboard: SFSymbol { .init(rawValue: "shield.checkerboard") }
 
     /// 􀵉
     /// Single Localization, 2 Layersets
@@ -462,7 +462,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shuffleCircle = SFSymbol(rawValue: "shuffle.circle")
+    static var shuffleCircle: SFSymbol { .init(rawValue: "shuffle.circle") }
 
     /// 􀵊
     /// Single Localization, 3 Layersets
@@ -471,7 +471,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let shuffleCircleFill = SFSymbol(rawValue: "shuffle.circle.fill")
+    static var shuffleCircleFill: SFSymbol { .init(rawValue: "shuffle.circle.fill") }
 
     /// 􀵿
     /// 19 Localizations, Single Layerset
@@ -499,7 +499,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatSizeLarger = SymbolWith18Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th, Zh>(rawValue: "textformat.size.larger")
+    static var textformatSizeLarger: SymbolWith18Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th, Zh> { .init(rawValue: "textformat.size.larger") }
 
     /// 􀵷
     /// 19 Localizations, Single Layerset
@@ -527,14 +527,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatSizeSmaller = SymbolWith18Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th, Zh>(rawValue: "textformat.size.smaller")
+    static var textformatSizeSmaller: SymbolWith18Localizations<Ar, Bn_v6, Gu_v6, He, Hi, Ja, Kn_v6, Ko, Ml_v6, Mni_v6, Mr_v6, Or_v6, Pa_v6, Sat_v6, Ta_v6, Te_v6, Th, Zh> { .init(rawValue: "textformat.size.smaller") }
 
     /// 􀴌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let torus = SFSymbol(rawValue: "torus")
+    static var torus: SFSymbol { .init(rawValue: "torus") }
 
     /// 􀲰
     /// Single Localization, 2 Layersets
@@ -542,5 +542,5 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let tvAndMediabox = SFSymbol(rawValue: "tv.and.mediabox")
+    static var tvAndMediabox: SFSymbol { .init(rawValue: "tv.and.mediabox") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+2.2.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+2.2.swift
@@ -16,7 +16,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "airpodsMax")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "airpodsMax")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsMax")
-    static let airpodsmax = SFSymbol(rawValue: "airpodsmax")
+    static var airpodsmax: SFSymbol { .init(rawValue: "airpodsmax") }
 
     /// 􀸎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -26,7 +26,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchSideRight = SFSymbol(rawValue: "applewatch.side.right")
+    static var applewatchSideRight: SFSymbol { .init(rawValue: "applewatch.side.right") }
 
     /// 􀌰
     /// 20 Localizations, 2 Layersets
@@ -56,7 +56,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let characterBubble = SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi_v3, Ja_v3, Kn_v7, Ko_v3, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th_v3, Zh_v3>(rawValue: "character.bubble")
+    static var characterBubble: SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi_v3, Ja_v3, Kn_v7, Ko_v3, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th_v3, Zh_v3> { .init(rawValue: "character.bubble") }
 
     /// 􀌱
     /// 20 Localizations, 3 Layersets
@@ -87,7 +87,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let characterBubbleFill = SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi_v3, Ja_v3, Kn_v7, Ko_v3, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th_v3, Zh_v3>(rawValue: "character.bubble.fill")
+    static var characterBubbleFill: SymbolWith19Localizations<Ar, Bn_v7, Gu_v7, He, Hi_v3, Ja_v3, Kn_v7, Ko_v3, Ml_v7, Mni_v7, Mr_v7, Or_v7, Pa_v7, Sat_v7, Si_v7, Ta_v7, Te_v7, Th_v3, Zh_v3> { .init(rawValue: "character.bubble.fill") }
 
     /// 􀅫
     /// 20 Localizations, 2 Layersets
@@ -117,7 +117,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let characterCursorIbeam = SymbolWith19Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh>(rawValue: "character.cursor.ibeam")
+    static var characterCursorIbeam: SymbolWith19Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh> { .init(rawValue: "character.cursor.ibeam") }
 
     /// 􀅶
     /// 19 Localizations, 2 Layersets
@@ -146,7 +146,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0)
-    static let characterTextbox = SymbolWith18Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Th, Zh>(rawValue: "character.textbox")
+    static var characterTextbox: SymbolWith18Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Th, Zh> { .init(rawValue: "character.textbox") }
 
     /// 􀷭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -161,7 +161,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "hifispeakerAndHomepodMini")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "hifispeakerAndHomepodMini")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "hifispeakerAndHomepodMini")
-    static let hifispeakerAndHomepodmini = SFSymbol(rawValue: "hifispeaker.and.homepodmini")
+    static var hifispeakerAndHomepodmini: SFSymbol { .init(rawValue: "hifispeaker.and.homepodmini") }
 
     /// 􀷮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -176,7 +176,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "hifispeakerAndHomepodMiniFill")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "hifispeakerAndHomepodMiniFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "hifispeakerAndHomepodMiniFill")
-    static let hifispeakerAndHomepodminiFill = SFSymbol(rawValue: "hifispeaker.and.homepodmini.fill")
+    static var hifispeakerAndHomepodminiFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepodmini.fill") }
 
     /// 􀷫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -191,7 +191,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodAndHomepodMini")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodAndHomepodMini")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodAndHomepodMini")
-    static let homepodAndHomepodmini = SFSymbol(rawValue: "homepod.and.homepodmini")
+    static var homepodAndHomepodmini: SFSymbol { .init(rawValue: "homepod.and.homepodmini") }
 
     /// 􀷬
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -206,7 +206,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodAndHomepodMiniFill")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodAndHomepodMiniFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodAndHomepodMiniFill")
-    static let homepodAndHomepodminiFill = SFSymbol(rawValue: "homepod.and.homepodmini.fill")
+    static var homepodAndHomepodminiFill: SFSymbol { .init(rawValue: "homepod.and.homepodmini.fill") }
 
     /// 􀷧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -221,7 +221,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodMini")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodMini")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodMini")
-    static let homepodmini = SFSymbol(rawValue: "homepodmini")
+    static var homepodmini: SFSymbol { .init(rawValue: "homepodmini") }
 
     /// 􀷩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -236,7 +236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodMini2")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodMini2")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodMini2")
-    static let homepodmini2 = SFSymbol(rawValue: "homepodmini.2")
+    static var homepodmini2: SFSymbol { .init(rawValue: "homepodmini.2") }
 
     /// 􀷪
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -251,7 +251,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodMini2Fill")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodMini2Fill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodMini2Fill")
-    static let homepodmini2Fill = SFSymbol(rawValue: "homepodmini.2.fill")
+    static var homepodmini2Fill: SFSymbol { .init(rawValue: "homepodmini.2.fill") }
 
     /// 􀷨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -266,7 +266,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 18.0, renamed: "homepodMiniFill")
     @available(watchOS, introduced: 7.4, deprecated: 11.0, renamed: "homepodMiniFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "homepodMiniFill")
-    static let homepodminiFill = SFSymbol(rawValue: "homepodmini.fill")
+    static var homepodminiFill: SFSymbol { .init(rawValue: "homepodmini.fill") }
 
     /// 􀴊
     /// Single Localization, Single Layerset
@@ -278,5 +278,5 @@ public extension SFSymbol {
     @available(tvOS, introduced: 14.5, deprecated: 15.0, renamed: "rectangleTopthirdInsetFilled")
     @available(watchOS, introduced: 7.4, deprecated: 8.0, renamed: "rectangleTopthirdInsetFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangleTopthirdInsetFilled")
-    static let rectangleTopthirdInsetFill = SFSymbol(rawValue: "rectangle.topthird.inset.fill")
+    static var rectangleTopthirdInsetFill: SFSymbol { .init(rawValue: "rectangle.topthird.inset.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+3.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+3.0.swift
@@ -19,7 +19,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "numbersRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "numbersRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "numbersRectangle")
-    static let _123Rectangle = SymbolWith2Localizations<Ar, Hi>(rawValue: "123.rectangle")
+    static var _123Rectangle: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "123.rectangle") }
 
     /// 􁂸
     /// 3 Localizations, 3 Layersets
@@ -38,7 +38,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "numbersRectangleFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "numbersRectangleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "numbersRectangleFill")
-    static let _123RectangleFill = SymbolWith2Localizations<Ar, Hi>(rawValue: "123.rectangle.fill")
+    static var _123RectangleFill: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "123.rectangle.fill") }
 
     /// 􀷯
     /// Single Localization, 2 Layersets
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneArrival = SFSymbol(rawValue: "airplane.arrival")
+    static var airplaneArrival: SFSymbol { .init(rawValue: "airplane.arrival") }
 
     /// 􀷰
     /// Single Localization, 2 Layersets
@@ -54,7 +54,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneDeparture = SFSymbol(rawValue: "airplane.departure")
+    static var airplaneDeparture: SFSymbol { .init(rawValue: "airplane.departure") }
 
     /// 􀱫
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -70,7 +70,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayAudioBadgeExclamationmark")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayAudioBadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayAudioBadgeExclamationmark")
-    static let airplayaudioBadgeExclamationmark = SFSymbol(rawValue: "airplayaudio.badge.exclamationmark")
+    static var airplayaudioBadgeExclamationmark: SFSymbol { .init(rawValue: "airplayaudio.badge.exclamationmark") }
 
     /// 􀾧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -86,7 +86,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayAudioCircle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayAudioCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayAudioCircle")
-    static let airplayaudioCircle = SFSymbol(rawValue: "airplayaudio.circle")
+    static var airplayaudioCircle: SFSymbol { .init(rawValue: "airplayaudio.circle") }
 
     /// 􀾨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -102,7 +102,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayAudioCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayAudioCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayAudioCircleFill")
-    static let airplayaudioCircleFill = SFSymbol(rawValue: "airplayaudio.circle.fill")
+    static var airplayaudioCircleFill: SFSymbol { .init(rawValue: "airplayaudio.circle.fill") }
 
     /// 􀱪
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -118,7 +118,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayVideoBadgeExclamationmark")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayVideoBadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayVideoBadgeExclamationmark")
-    static let airplayvideoBadgeExclamationmark = SFSymbol(rawValue: "airplayvideo.badge.exclamationmark")
+    static var airplayvideoBadgeExclamationmark: SFSymbol { .init(rawValue: "airplayvideo.badge.exclamationmark") }
 
     /// 􀾑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -133,7 +133,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayVideoCircle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayVideoCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayVideoCircle")
-    static let airplayvideoCircle = SFSymbol(rawValue: "airplayvideo.circle")
+    static var airplayvideoCircle: SFSymbol { .init(rawValue: "airplayvideo.circle") }
 
     /// 􀾒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -149,7 +149,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airplayVideoCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airplayVideoCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airplayVideoCircleFill")
-    static let airplayvideoCircleFill = SFSymbol(rawValue: "airplayvideo.circle.fill")
+    static var airplayvideoCircleFill: SFSymbol { .init(rawValue: "airplayvideo.circle.fill") }
 
     /// 􀹧
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -158,7 +158,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsChargingcase = SFSymbol(rawValue: "airpods.chargingcase")
+    static var airpodsChargingcase: SFSymbol { .init(rawValue: "airpods.chargingcase") }
 
     /// 􀹨
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -167,7 +167,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsChargingcaseFill = SFSymbol(rawValue: "airpods.chargingcase.fill")
+    static var airpodsChargingcaseFill: SFSymbol { .init(rawValue: "airpods.chargingcase.fill") }
 
     /// 􀹩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -176,7 +176,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsChargingcaseWireless = SFSymbol(rawValue: "airpods.chargingcase.wireless")
+    static var airpodsChargingcaseWireless: SFSymbol { .init(rawValue: "airpods.chargingcase.wireless") }
 
     /// 􀹪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -185,7 +185,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsChargingcaseWirelessFill = SFSymbol(rawValue: "airpods.chargingcase.wireless.fill")
+    static var airpodsChargingcaseWirelessFill: SFSymbol { .init(rawValue: "airpods.chargingcase.wireless.fill") }
 
     /// 􀹫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -199,7 +199,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airpodsProChargingcaseWireless")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airpodsProChargingcaseWireless")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProChargingcaseWireless")
-    static let airpodsproChargingcaseWireless = SFSymbol(rawValue: "airpodspro.chargingcase.wireless")
+    static var airpodsproChargingcaseWireless: SFSymbol { .init(rawValue: "airpodspro.chargingcase.wireless") }
 
     /// 􀹬
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -213,7 +213,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "airpodsProChargingcaseWirelessFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "airpodsProChargingcaseWirelessFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProChargingcaseWirelessFill")
-    static let airpodsproChargingcaseWirelessFill = SFSymbol(rawValue: "airpodspro.chargingcase.wireless.fill")
+    static var airpodsproChargingcaseWirelessFill: SFSymbol { .init(rawValue: "airpodspro.chargingcase.wireless.fill") }
 
     /// 􁄾
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -222,7 +222,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirTag.
-    static let airtag = SFSymbol(rawValue: "airtag")
+    static var airtag: SFSymbol { .init(rawValue: "airtag") }
 
     /// 􁄿
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -231,7 +231,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirTag.
-    static let airtagFill = SFSymbol(rawValue: "airtag.fill")
+    static var airtagFill: SFSymbol { .init(rawValue: "airtag.fill") }
 
     /// 􁄼
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -246,7 +246,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirTag.
-    static let airtagRadiowavesForward = SymbolWith1Localization<Rtl>(rawValue: "airtag.radiowaves.forward")
+    static var airtagRadiowavesForward: SymbolWith1Localization<Rtl> { .init(rawValue: "airtag.radiowaves.forward") }
 
     /// 􁄽
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -261,7 +261,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirTag.
-    static let airtagRadiowavesForwardFill = SymbolWith1Localization<Rtl>(rawValue: "airtag.radiowaves.forward.fill")
+    static var airtagRadiowavesForwardFill: SymbolWith1Localization<Rtl> { .init(rawValue: "airtag.radiowaves.forward.fill") }
 
     /// 􀩉
     /// Single Localization, 3 Layersets
@@ -270,7 +270,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let alignHorizontalCenter = SFSymbol(rawValue: "align.horizontal.center")
+    static var alignHorizontalCenter: SFSymbol { .init(rawValue: "align.horizontal.center") }
 
     /// 􀥗
     /// Single Localization, 3 Layersets
@@ -279,7 +279,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let alignHorizontalCenterFill = SFSymbol(rawValue: "align.horizontal.center.fill")
+    static var alignHorizontalCenterFill: SFSymbol { .init(rawValue: "align.horizontal.center.fill") }
 
     /// 􀩈
     /// Single Localization, 2 Layersets
@@ -287,7 +287,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignHorizontalLeft = SFSymbol(rawValue: "align.horizontal.left")
+    static var alignHorizontalLeft: SFSymbol { .init(rawValue: "align.horizontal.left") }
 
     /// 􀥖
     /// Single Localization, 2 Layersets
@@ -295,7 +295,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignHorizontalLeftFill = SFSymbol(rawValue: "align.horizontal.left.fill")
+    static var alignHorizontalLeftFill: SFSymbol { .init(rawValue: "align.horizontal.left.fill") }
 
     /// 􀩊
     /// Single Localization, 2 Layersets
@@ -303,7 +303,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignHorizontalRight = SFSymbol(rawValue: "align.horizontal.right")
+    static var alignHorizontalRight: SFSymbol { .init(rawValue: "align.horizontal.right") }
 
     /// 􀥘
     /// Single Localization, 2 Layersets
@@ -311,7 +311,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignHorizontalRightFill = SFSymbol(rawValue: "align.horizontal.right.fill")
+    static var alignHorizontalRightFill: SFSymbol { .init(rawValue: "align.horizontal.right.fill") }
 
     /// 􀩍
     /// Single Localization, 2 Layersets
@@ -319,7 +319,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignVerticalBottom = SFSymbol(rawValue: "align.vertical.bottom")
+    static var alignVerticalBottom: SFSymbol { .init(rawValue: "align.vertical.bottom") }
 
     /// 􀥛
     /// Single Localization, 2 Layersets
@@ -327,7 +327,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignVerticalBottomFill = SFSymbol(rawValue: "align.vertical.bottom.fill")
+    static var alignVerticalBottomFill: SFSymbol { .init(rawValue: "align.vertical.bottom.fill") }
 
     /// 􀩌
     /// Single Localization, 3 Layersets
@@ -336,7 +336,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let alignVerticalCenter = SFSymbol(rawValue: "align.vertical.center")
+    static var alignVerticalCenter: SFSymbol { .init(rawValue: "align.vertical.center") }
 
     /// 􀥚
     /// Single Localization, 3 Layersets
@@ -345,7 +345,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let alignVerticalCenterFill = SFSymbol(rawValue: "align.vertical.center.fill")
+    static var alignVerticalCenterFill: SFSymbol { .init(rawValue: "align.vertical.center.fill") }
 
     /// 􀩋
     /// Single Localization, 2 Layersets
@@ -353,7 +353,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignVerticalTop = SFSymbol(rawValue: "align.vertical.top")
+    static var alignVerticalTop: SFSymbol { .init(rawValue: "align.vertical.top") }
 
     /// 􀥙
     /// Single Localization, 2 Layersets
@@ -361,7 +361,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let alignVerticalTopFill = SFSymbol(rawValue: "align.vertical.top.fill")
+    static var alignVerticalTopFill: SFSymbol { .init(rawValue: "align.vertical.top.fill") }
 
     /// 􀬭
     /// Single Localization, 3 Layersets
@@ -370,14 +370,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let allergens = SFSymbol(rawValue: "allergens")
+    static var allergens: SFSymbol { .init(rawValue: "allergens") }
 
     /// 􁆭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let alternatingcurrent = SFSymbol(rawValue: "alternatingcurrent")
+    static var alternatingcurrent: SFSymbol { .init(rawValue: "alternatingcurrent") }
 
     /// 􀷈
     /// Single Localization, 3 Layersets
@@ -386,7 +386,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let antennaRadiowavesLeftAndRightCircle = SFSymbol(rawValue: "antenna.radiowaves.left.and.right.circle")
+    static var antennaRadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right.circle") }
 
     /// 􀷉
     /// Single Localization, 3 Layersets
@@ -395,7 +395,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let antennaRadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "antenna.radiowaves.left.and.right.circle.fill")
+    static var antennaRadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right.circle.fill") }
 
     /// 􁅒
     /// Single Localization, 3 Layersets
@@ -404,7 +404,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let antennaRadiowavesLeftAndRightSlash = SFSymbol(rawValue: "antenna.radiowaves.left.and.right.slash")
+    static var antennaRadiowavesLeftAndRightSlash: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right.slash") }
 
     /// 􁂠
     /// Single Localization, 3 Layersets
@@ -413,7 +413,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appBadgeCheckmark = SFSymbol(rawValue: "app.badge.checkmark")
+    static var appBadgeCheckmark: SFSymbol { .init(rawValue: "app.badge.checkmark") }
 
     /// 􁂡
     /// Single Localization, 3 Layersets
@@ -422,7 +422,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appBadgeCheckmarkFill = SFSymbol(rawValue: "app.badge.checkmark.fill")
+    static var appBadgeCheckmarkFill: SFSymbol { .init(rawValue: "app.badge.checkmark.fill") }
 
     /// 􁀘
     /// Single Localization, 3 Layersets
@@ -431,14 +431,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let appConnectedToAppBelowFill = SFSymbol(rawValue: "app.connected.to.app.below.fill")
+    static var appConnectedToAppBelowFill: SFSymbol { .init(rawValue: "app.connected.to.app.below.fill") }
 
     /// 􀿫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appDashed = SFSymbol(rawValue: "app.dashed")
+    static var appDashed: SFSymbol { .init(rawValue: "app.dashed") }
 
     /// 􀺮
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -447,7 +447,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencil = SFSymbol(rawValue: "applepencil")
+    static var applepencil: SFSymbol { .init(rawValue: "applepencil") }
 
     /// 􀼩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -456,7 +456,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen1 = SFSymbol(rawValue: "appletvremote.gen1")
+    static var appletvremoteGen1: SFSymbol { .init(rawValue: "appletvremote.gen1") }
 
     /// 􀼪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -465,7 +465,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen1Fill = SFSymbol(rawValue: "appletvremote.gen1.fill")
+    static var appletvremoteGen1Fill: SFSymbol { .init(rawValue: "appletvremote.gen1.fill") }
 
     /// 􀼫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -474,7 +474,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen2 = SFSymbol(rawValue: "appletvremote.gen2")
+    static var appletvremoteGen2: SFSymbol { .init(rawValue: "appletvremote.gen2") }
 
     /// 􀼬
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -483,7 +483,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen2Fill = SFSymbol(rawValue: "appletvremote.gen2.fill")
+    static var appletvremoteGen2Fill: SFSymbol { .init(rawValue: "appletvremote.gen2.fill") }
 
     /// 􀝩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -492,7 +492,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen3 = SFSymbol(rawValue: "appletvremote.gen3")
+    static var appletvremoteGen3: SFSymbol { .init(rawValue: "appletvremote.gen3") }
 
     /// 􀝪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -501,7 +501,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen3Fill = SFSymbol(rawValue: "appletvremote.gen3.fill")
+    static var appletvremoteGen3Fill: SFSymbol { .init(rawValue: "appletvremote.gen3.fill") }
 
     /// 􀼧
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -510,7 +510,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen4 = SFSymbol(rawValue: "appletvremote.gen4")
+    static var appletvremoteGen4: SFSymbol { .init(rawValue: "appletvremote.gen4") }
 
     /// 􀼨
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -519,7 +519,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvremoteGen4Fill = SFSymbol(rawValue: "appletvremote.gen4.fill")
+    static var appletvremoteGen4Fill: SFSymbol { .init(rawValue: "appletvremote.gen4.fill") }
 
     /// 􀴪
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -534,7 +534,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledApplewatchCase")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledApplewatchCase")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledApplewatchCase")
-    static let applewatchCaseInsetFilled = SFSymbol(rawValue: "applewatch.case.inset.filled")
+    static var applewatchCaseInsetFilled: SFSymbol { .init(rawValue: "applewatch.case.inset.filled") }
 
     /// 􁀒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -545,14 +545,14 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s ARKit.
-    static let arkitBadgeXmark = SFSymbol(rawValue: "arkit.badge.xmark")
+    static var arkitBadgeXmark: SFSymbol { .init(rawValue: "arkit.badge.xmark") }
 
     /// 􁂊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowBackwardToLine = SFSymbol(rawValue: "arrow.backward.to.line")
+    static var arrowBackwardToLine: SFSymbol { .init(rawValue: "arrow.backward.to.line") }
 
     /// 􁂌
     /// Single Localization, 2 Layersets
@@ -560,7 +560,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowBackwardToLineCircle = SFSymbol(rawValue: "arrow.backward.to.line.circle")
+    static var arrowBackwardToLineCircle: SFSymbol { .init(rawValue: "arrow.backward.to.line.circle") }
 
     /// 􁂍
     /// Single Localization, 3 Layersets
@@ -569,7 +569,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowBackwardToLineCircleFill = SFSymbol(rawValue: "arrow.backward.to.line.circle.fill")
+    static var arrowBackwardToLineCircleFill: SFSymbol { .init(rawValue: "arrow.backward.to.line.circle.fill") }
 
     /// 􀓈
     /// Single Localization, 2 Layersets
@@ -577,7 +577,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownToLineCircle = SFSymbol(rawValue: "arrow.down.to.line.circle")
+    static var arrowDownToLineCircle: SFSymbol { .init(rawValue: "arrow.down.to.line.circle") }
 
     /// 􀓉
     /// Single Localization, 3 Layersets
@@ -586,21 +586,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownToLineCircleFill = SFSymbol(rawValue: "arrow.down.to.line.circle.fill")
+    static var arrowDownToLineCircleFill: SFSymbol { .init(rawValue: "arrow.down.to.line.circle.fill") }
 
     /// 􀅄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownToLineCompact = SFSymbol(rawValue: "arrow.down.to.line.compact")
+    static var arrowDownToLineCompact: SFSymbol { .init(rawValue: "arrow.down.to.line.compact") }
 
     /// 􁂎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowForwardToLine = SFSymbol(rawValue: "arrow.forward.to.line")
+    static var arrowForwardToLine: SFSymbol { .init(rawValue: "arrow.forward.to.line") }
 
     /// 􁂐
     /// Single Localization, 2 Layersets
@@ -608,7 +608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowForwardToLineCircle = SFSymbol(rawValue: "arrow.forward.to.line.circle")
+    static var arrowForwardToLineCircle: SFSymbol { .init(rawValue: "arrow.forward.to.line.circle") }
 
     /// 􁂑
     /// Single Localization, 3 Layersets
@@ -617,7 +617,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowForwardToLineCircleFill = SFSymbol(rawValue: "arrow.forward.to.line.circle.fill")
+    static var arrowForwardToLineCircleFill: SFSymbol { .init(rawValue: "arrow.forward.to.line.circle.fill") }
 
     /// 􀓊
     /// Single Localization, 2 Layersets
@@ -625,7 +625,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowLeftToLineCircle = SFSymbol(rawValue: "arrow.left.to.line.circle")
+    static var arrowLeftToLineCircle: SFSymbol { .init(rawValue: "arrow.left.to.line.circle") }
 
     /// 􀓋
     /// Single Localization, 3 Layersets
@@ -634,14 +634,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowLeftToLineCircleFill = SFSymbol(rawValue: "arrow.left.to.line.circle.fill")
+    static var arrowLeftToLineCircleFill: SFSymbol { .init(rawValue: "arrow.left.to.line.circle.fill") }
 
     /// 􀅅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowLeftToLineCompact = SFSymbol(rawValue: "arrow.left.to.line.compact")
+    static var arrowLeftToLineCompact: SFSymbol { .init(rawValue: "arrow.left.to.line.compact") }
 
     /// 􀓌
     /// Single Localization, 2 Layersets
@@ -649,7 +649,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowRightToLineCircle = SFSymbol(rawValue: "arrow.right.to.line.circle")
+    static var arrowRightToLineCircle: SFSymbol { .init(rawValue: "arrow.right.to.line.circle") }
 
     /// 􀓍
     /// Single Localization, 3 Layersets
@@ -658,14 +658,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowRightToLineCircleFill = SFSymbol(rawValue: "arrow.right.to.line.circle.fill")
+    static var arrowRightToLineCircleFill: SFSymbol { .init(rawValue: "arrow.right.to.line.circle.fill") }
 
     /// 􀅆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowRightToLineCompact = SFSymbol(rawValue: "arrow.right.to.line.compact")
+    static var arrowRightToLineCompact: SFSymbol { .init(rawValue: "arrow.right.to.line.compact") }
 
     /// 􀟩
     /// Single Localization, 2 Layersets
@@ -678,7 +678,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill")
-    static let arrowUpAndDownRighttriangleUpRighttriangleDownFill = SFSymbol(rawValue: "arrow.up.and.down.righttriangle.up.righttriangle.down.fill")
+    static var arrowUpAndDownRighttriangleUpRighttriangleDownFill: SFSymbol { .init(rawValue: "arrow.up.and.down.righttriangle.up.righttriangle.down.fill") }
 
     /// 􀓆
     /// Single Localization, 2 Layersets
@@ -686,7 +686,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpToLineCircle = SFSymbol(rawValue: "arrow.up.to.line.circle")
+    static var arrowUpToLineCircle: SFSymbol { .init(rawValue: "arrow.up.to.line.circle") }
 
     /// 􀓇
     /// Single Localization, 3 Layersets
@@ -695,35 +695,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpToLineCircleFill = SFSymbol(rawValue: "arrow.up.to.line.circle.fill")
+    static var arrowUpToLineCircleFill: SFSymbol { .init(rawValue: "arrow.up.to.line.circle.fill") }
 
     /// 􀅃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpToLineCompact = SFSymbol(rawValue: "arrow.up.to.line.compact")
+    static var arrowUpToLineCompact: SFSymbol { .init(rawValue: "arrow.up.to.line.compact") }
 
     /// 􀟦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill = SFSymbol(rawValue: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right.fill")
+    static var arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill: SFSymbol { .init(rawValue: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right.fill") }
 
     /// 􀟧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill = SFSymbol(rawValue: "arrowtriangle.right.and.line.vertical.and.arrowtriangle.left.fill")
+    static var arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill: SFSymbol { .init(rawValue: "arrowtriangle.right.and.line.vertical.and.arrowtriangle.left.fill") }
 
     /// 􀸓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let asterisk = SFSymbol(rawValue: "asterisk")
+    static var asterisk: SFSymbol { .init(rawValue: "asterisk") }
 
     /// 􀺃
     /// Single Localization, 2 Layersets
@@ -731,7 +731,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let backwardCircle = SFSymbol(rawValue: "backward.circle")
+    static var backwardCircle: SFSymbol { .init(rawValue: "backward.circle") }
 
     /// 􀺄
     /// Single Localization, 3 Layersets
@@ -740,7 +740,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let backwardCircleFill = SFSymbol(rawValue: "backward.circle.fill")
+    static var backwardCircleFill: SFSymbol { .init(rawValue: "backward.circle.fill") }
 
     /// 􀺶
     /// Single Localization, 3 Layersets
@@ -754,7 +754,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "battery50percent")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "battery50percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery50percent")
-    static let battery50 = SFSymbol(rawValue: "battery.50")
+    static var battery50: SFSymbol { .init(rawValue: "battery.50") }
 
     /// 􀺸
     /// Single Localization, 3 Layersets
@@ -768,7 +768,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "battery75percent")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "battery75percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery75percent")
-    static let battery75 = SFSymbol(rawValue: "battery.75")
+    static var battery75: SFSymbol { .init(rawValue: "battery.75") }
 
     /// 􀺒
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -778,7 +778,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats earphones.
-    static let beatsEarphones = SFSymbol(rawValue: "beats.earphones")
+    static var beatsEarphones: SFSymbol { .init(rawValue: "beats.earphones") }
 
     /// 􀺭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -788,7 +788,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats headphones.
-    static let beatsHeadphones = SFSymbol(rawValue: "beats.headphones")
+    static var beatsHeadphones: SFSymbol { .init(rawValue: "beats.headphones") }
 
     /// 􀻔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -798,7 +798,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats.
-    static let beatsPowerbeats = SFSymbol(rawValue: "beats.powerbeats")
+    static var beatsPowerbeats: SFSymbol { .init(rawValue: "beats.powerbeats") }
 
     /// 􀺯
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -808,7 +808,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats3.
-    static let beatsPowerbeats3 = SFSymbol(rawValue: "beats.powerbeats3")
+    static var beatsPowerbeats3: SFSymbol { .init(rawValue: "beats.powerbeats3") }
 
     /// 􀹭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -823,7 +823,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsPowerbeatsPro")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsPowerbeatsPro")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsPowerbeatsPro")
-    static let beatsPowerbeatspro = SFSymbol(rawValue: "beats.powerbeatspro")
+    static var beatsPowerbeatspro: SFSymbol { .init(rawValue: "beats.powerbeatspro") }
 
     /// 􀹰
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -837,7 +837,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsPowerbeatsProChargingcase")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsPowerbeatsProChargingcase")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsPowerbeatsProChargingcase")
-    static let beatsPowerbeatsproChargingcase = SFSymbol(rawValue: "beats.powerbeatspro.chargingcase")
+    static var beatsPowerbeatsproChargingcase: SFSymbol { .init(rawValue: "beats.powerbeatspro.chargingcase") }
 
     /// 􀹱
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -851,7 +851,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsPowerbeatsProChargingcaseFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsPowerbeatsProChargingcaseFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsPowerbeatsProChargingcaseFill")
-    static let beatsPowerbeatsproChargingcaseFill = SFSymbol(rawValue: "beats.powerbeatspro.chargingcase.fill")
+    static var beatsPowerbeatsproChargingcaseFill: SFSymbol { .init(rawValue: "beats.powerbeatspro.chargingcase.fill") }
 
     /// 􀹯
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -866,7 +866,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsPowerbeatsProLeft")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsPowerbeatsProLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsPowerbeatsProLeft")
-    static let beatsPowerbeatsproLeft = SFSymbol(rawValue: "beats.powerbeatspro.left")
+    static var beatsPowerbeatsproLeft: SFSymbol { .init(rawValue: "beats.powerbeatspro.left") }
 
     /// 􀹮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -881,7 +881,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsPowerbeatsProRight")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsPowerbeatsProRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsPowerbeatsProRight")
-    static let beatsPowerbeatsproRight = SFSymbol(rawValue: "beats.powerbeatspro.right")
+    static var beatsPowerbeatsproRight: SFSymbol { .init(rawValue: "beats.powerbeatspro.right") }
 
     /// 􀾣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -896,7 +896,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsStudiobudsLeft")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsStudiobudsLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsLeft")
-    static let beatsStudiobudLeft = SFSymbol(rawValue: "beats.studiobud.left")
+    static var beatsStudiobudLeft: SFSymbol { .init(rawValue: "beats.studiobud.left") }
 
     /// 􀾤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -911,7 +911,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "beatsStudiobudsRight")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "beatsStudiobudsRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsRight")
-    static let beatsStudiobudRight = SFSymbol(rawValue: "beats.studiobud.right")
+    static var beatsStudiobudRight: SFSymbol { .init(rawValue: "beats.studiobud.right") }
 
     /// 􀾢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -921,7 +921,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds.
-    static let beatsStudiobuds = SFSymbol(rawValue: "beats.studiobuds")
+    static var beatsStudiobuds: SFSymbol { .init(rawValue: "beats.studiobuds") }
 
     /// 􀾥
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -930,7 +930,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds case.
-    static let beatsStudiobudsChargingcase = SFSymbol(rawValue: "beats.studiobuds.chargingcase")
+    static var beatsStudiobudsChargingcase: SFSymbol { .init(rawValue: "beats.studiobuds.chargingcase") }
 
     /// 􀾦
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -939,7 +939,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds case.
-    static let beatsStudiobudsChargingcaseFill = SFSymbol(rawValue: "beats.studiobuds.chargingcase.fill")
+    static var beatsStudiobudsChargingcaseFill: SFSymbol { .init(rawValue: "beats.studiobuds.chargingcase.fill") }
 
     /// 􁁏
     /// Single Localization, 3 Layersets
@@ -948,7 +948,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bedDoubleCircle = SFSymbol(rawValue: "bed.double.circle")
+    static var bedDoubleCircle: SFSymbol { .init(rawValue: "bed.double.circle") }
 
     /// 􁁐
     /// Single Localization, 3 Layersets
@@ -957,7 +957,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bedDoubleCircleFill = SFSymbol(rawValue: "bed.double.circle.fill")
+    static var bedDoubleCircleFill: SFSymbol { .init(rawValue: "bed.double.circle.fill") }
 
     /// 􀻿
     /// Single Localization, 3 Layersets
@@ -971,7 +971,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "bellBadgeWaveform")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "bellBadgeWaveform")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "bellBadgeWaveform")
-    static let bellAndWaveform = SFSymbol(rawValue: "bell.and.waveform")
+    static var bellAndWaveform: SFSymbol { .init(rawValue: "bell.and.waveform") }
 
     /// 􀼀
     /// Single Localization, 3 Layersets
@@ -985,7 +985,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "bellBadgeWaveformFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "bellBadgeWaveformFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "bellBadgeWaveformFill")
-    static let bellAndWaveformFill = SFSymbol(rawValue: "bell.and.waveform.fill")
+    static var bellAndWaveformFill: SFSymbol { .init(rawValue: "bell.and.waveform.fill") }
 
     /// 􀰷
     /// Single Localization, 3 Layersets
@@ -994,7 +994,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellBadgeCircle = SFSymbol(rawValue: "bell.badge.circle")
+    static var bellBadgeCircle: SFSymbol { .init(rawValue: "bell.badge.circle") }
 
     /// 􀰸
     /// Single Localization, 3 Layersets
@@ -1003,7 +1003,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellBadgeCircleFill = SFSymbol(rawValue: "bell.badge.circle.fill")
+    static var bellBadgeCircleFill: SFSymbol { .init(rawValue: "bell.badge.circle.fill") }
 
     /// 􀼷
     /// Single Localization, 3 Layersets
@@ -1012,7 +1012,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellSquare = SFSymbol(rawValue: "bell.square")
+    static var bellSquare: SFSymbol { .init(rawValue: "bell.square") }
 
     /// 􀼸
     /// Single Localization, 3 Layersets
@@ -1021,7 +1021,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellSquareFill = SFSymbol(rawValue: "bell.square.fill")
+    static var bellSquareFill: SFSymbol { .init(rawValue: "bell.square.fill") }
 
     /// 􀫮
     /// Single Localization, 2 Layersets
@@ -1029,7 +1029,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let boltBatteryblock = SFSymbol(rawValue: "bolt.batteryblock")
+    static var boltBatteryblock: SFSymbol { .init(rawValue: "bolt.batteryblock") }
 
     /// 􀫯
     /// Single Localization, 3 Layersets
@@ -1038,7 +1038,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let boltBatteryblockFill = SFSymbol(rawValue: "bolt.batteryblock.fill")
+    static var boltBatteryblockFill: SFSymbol { .init(rawValue: "bolt.batteryblock.fill") }
 
     /// 􁄲
     /// Single Localization, 3 Layersets
@@ -1047,7 +1047,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltCarCircle = SFSymbol(rawValue: "bolt.car.circle")
+    static var boltCarCircle: SFSymbol { .init(rawValue: "bolt.car.circle") }
 
     /// 􁄳
     /// Single Localization, 3 Layersets
@@ -1056,7 +1056,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltCarCircleFill = SFSymbol(rawValue: "bolt.car.circle.fill")
+    static var boltCarCircleFill: SFSymbol { .init(rawValue: "bolt.car.circle.fill") }
 
     /// 􁃗
     /// Single Localization, 2 Layersets
@@ -1064,7 +1064,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let boltShield = SFSymbol(rawValue: "bolt.shield")
+    static var boltShield: SFSymbol { .init(rawValue: "bolt.shield") }
 
     /// 􁃘
     /// Single Localization, 3 Layersets
@@ -1073,7 +1073,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let boltShieldFill = SFSymbol(rawValue: "bolt.shield.fill")
+    static var boltShieldFill: SFSymbol { .init(rawValue: "bolt.shield.fill") }
 
     /// 􀼵
     /// Single Localization, 3 Layersets
@@ -1082,7 +1082,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltSquare = SFSymbol(rawValue: "bolt.square")
+    static var boltSquare: SFSymbol { .init(rawValue: "bolt.square") }
 
     /// 􀼶
     /// Single Localization, 3 Layersets
@@ -1091,7 +1091,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltSquareFill = SFSymbol(rawValue: "bolt.square.fill")
+    static var boltSquareFill: SFSymbol { .init(rawValue: "bolt.square.fill") }
 
     /// 􁇣
     /// Single Localization, 2 Layersets
@@ -1099,7 +1099,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bookClosedCircle = SFSymbol(rawValue: "book.closed.circle")
+    static var bookClosedCircle: SFSymbol { .init(rawValue: "book.closed.circle") }
 
     /// 􁇤
     /// Single Localization, 3 Layersets
@@ -1108,7 +1108,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bookClosedCircleFill = SFSymbol(rawValue: "book.closed.circle.fill")
+    static var bookClosedCircleFill: SFSymbol { .init(rawValue: "book.closed.circle.fill") }
 
     /// 􀼹
     /// Single Localization, 3 Layersets
@@ -1117,7 +1117,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bookmarkSquare = SFSymbol(rawValue: "bookmark.square")
+    static var bookmarkSquare: SFSymbol { .init(rawValue: "bookmark.square") }
 
     /// 􀼺
     /// Single Localization, 3 Layersets
@@ -1126,7 +1126,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bookmarkSquareFill = SFSymbol(rawValue: "bookmark.square.fill")
+    static var bookmarkSquareFill: SFSymbol { .init(rawValue: "bookmark.square.fill") }
 
     /// 􁆼
     /// Single Localization, 2 Layersets
@@ -1134,7 +1134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let booksVerticalCircle = SFSymbol(rawValue: "books.vertical.circle")
+    static var booksVerticalCircle: SFSymbol { .init(rawValue: "books.vertical.circle") }
 
     /// 􁆽
     /// Single Localization, 3 Layersets
@@ -1143,14 +1143,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let booksVerticalCircleFill = SFSymbol(rawValue: "books.vertical.circle.fill")
+    static var booksVerticalCircleFill: SFSymbol { .init(rawValue: "books.vertical.circle.fill") }
 
     /// 􀯐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let brain = SFSymbol(rawValue: "brain")
+    static var brain: SFSymbol { .init(rawValue: "brain") }
 
     /// 􀯏
     /// Single Localization, 2 Layersets
@@ -1158,7 +1158,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brainHeadProfile = SFSymbol(rawValue: "brain.head.profile")
+    static var brainHeadProfile: SFSymbol { .init(rawValue: "brain.head.profile") }
 
     /// 􀷡
     /// Single Localization, 3 Layersets
@@ -1167,7 +1167,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let briefcaseCircle = SFSymbol(rawValue: "briefcase.circle")
+    static var briefcaseCircle: SFSymbol { .init(rawValue: "briefcase.circle") }
 
     /// 􀷢
     /// Single Localization, 3 Layersets
@@ -1176,7 +1176,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let briefcaseCircleFill = SFSymbol(rawValue: "briefcase.circle.fill")
+    static var briefcaseCircleFill: SFSymbol { .init(rawValue: "briefcase.circle.fill") }
 
     /// 􁃒
     /// Single Localization, 3 Layersets
@@ -1185,7 +1185,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bubbleLeftAndExclamationmarkBubbleRight = SFSymbol(rawValue: "bubble.left.and.exclamationmark.bubble.right")
+    static var bubbleLeftAndExclamationmarkBubbleRight: SFSymbol { .init(rawValue: "bubble.left.and.exclamationmark.bubble.right") }
 
     /// 􁃓
     /// Single Localization, 3 Layersets
@@ -1194,7 +1194,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bubbleLeftAndExclamationmarkBubbleRightFill = SFSymbol(rawValue: "bubble.left.and.exclamationmark.bubble.right.fill")
+    static var bubbleLeftAndExclamationmarkBubbleRightFill: SFSymbol { .init(rawValue: "bubble.left.and.exclamationmark.bubble.right.fill") }
 
     /// 􁇐
     /// Single Localization, 2 Layersets
@@ -1202,7 +1202,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleLeftCircle = SFSymbol(rawValue: "bubble.left.circle")
+    static var bubbleLeftCircle: SFSymbol { .init(rawValue: "bubble.left.circle") }
 
     /// 􁇑
     /// Single Localization, 3 Layersets
@@ -1211,7 +1211,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bubbleLeftCircleFill = SFSymbol(rawValue: "bubble.left.circle.fill")
+    static var bubbleLeftCircleFill: SFSymbol { .init(rawValue: "bubble.left.circle.fill") }
 
     /// 􁇎
     /// Single Localization, 2 Layersets
@@ -1219,7 +1219,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleRightCircle = SFSymbol(rawValue: "bubble.right.circle")
+    static var bubbleRightCircle: SFSymbol { .init(rawValue: "bubble.right.circle") }
 
     /// 􁇏
     /// Single Localization, 3 Layersets
@@ -1228,7 +1228,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let bubbleRightCircleFill = SFSymbol(rawValue: "bubble.right.circle.fill")
+    static var bubbleRightCircleFill: SFSymbol { .init(rawValue: "bubble.right.circle.fill") }
 
     /// 􁇆
     /// Single Localization, 2 Layersets
@@ -1236,7 +1236,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buildingColumnsCircle = SFSymbol(rawValue: "building.columns.circle")
+    static var buildingColumnsCircle: SFSymbol { .init(rawValue: "building.columns.circle") }
 
     /// 􁇇
     /// Single Localization, 3 Layersets
@@ -1245,7 +1245,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let buildingColumnsCircleFill = SFSymbol(rawValue: "building.columns.circle.fill")
+    static var buildingColumnsCircleFill: SFSymbol { .init(rawValue: "building.columns.circle.fill") }
 
     /// 􀺦
     /// Single Localization, 2 Layersets
@@ -1253,7 +1253,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cableConnector = SFSymbol(rawValue: "cable.connector")
+    static var cableConnector: SFSymbol { .init(rawValue: "cable.connector") }
 
     /// 􀴞
     /// Single Localization, 2 Layersets
@@ -1261,21 +1261,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cableConnectorHorizontal = SFSymbol(rawValue: "cable.connector.horizontal")
+    static var cableConnectorHorizontal: SFSymbol { .init(rawValue: "cable.connector.horizontal") }
 
     /// 􀷶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cablecar = SFSymbol(rawValue: "cablecar")
+    static var cablecar: SFSymbol { .init(rawValue: "cablecar") }
 
     /// 􀷷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cablecarFill = SFSymbol(rawValue: "cablecar.fill")
+    static var cablecarFill: SFSymbol { .init(rawValue: "cablecar.fill") }
 
     /// 􁁃
     /// Single Localization, 3 Layersets
@@ -1284,7 +1284,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineLeading = SFSymbol(rawValue: "calendar.day.timeline.leading")
+    static var calendarDayTimelineLeading: SFSymbol { .init(rawValue: "calendar.day.timeline.leading") }
 
     /// 􀻤
     /// Single Localization, 3 Layersets
@@ -1293,7 +1293,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineLeft = SFSymbol(rawValue: "calendar.day.timeline.left")
+    static var calendarDayTimelineLeft: SFSymbol { .init(rawValue: "calendar.day.timeline.left") }
 
     /// 􀻣
     /// Single Localization, 3 Layersets
@@ -1302,7 +1302,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineRight = SFSymbol(rawValue: "calendar.day.timeline.right")
+    static var calendarDayTimelineRight: SFSymbol { .init(rawValue: "calendar.day.timeline.right") }
 
     /// 􁁂
     /// Single Localization, 3 Layersets
@@ -1311,7 +1311,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineTrailing = SFSymbol(rawValue: "calendar.day.timeline.trailing")
+    static var calendarDayTimelineTrailing: SFSymbol { .init(rawValue: "calendar.day.timeline.trailing") }
 
     /// 􀹺
     /// Single Localization, 2 Layersets
@@ -1319,7 +1319,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraShutterButton = SFSymbol(rawValue: "camera.shutter.button")
+    static var cameraShutterButton: SFSymbol { .init(rawValue: "camera.shutter.button") }
 
     /// 􀹻
     /// Single Localization, 2 Layersets
@@ -1327,14 +1327,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraShutterButtonFill = SFSymbol(rawValue: "camera.shutter.button.fill")
+    static var cameraShutterButtonFill: SFSymbol { .init(rawValue: "camera.shutter.button.fill") }
 
     /// 􀿶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsuleBottomhalfFilled = SFSymbol(rawValue: "capsule.bottomhalf.filled")
+    static var capsuleBottomhalfFilled: SFSymbol { .init(rawValue: "capsule.bottomhalf.filled") }
 
     /// 􀾚
     /// Single Localization, 2 Layersets
@@ -1347,21 +1347,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCapsule")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCapsule")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCapsule")
-    static let capsuleInsetFilled = SFSymbol(rawValue: "capsule.inset.filled")
+    static var capsuleInsetFilled: SFSymbol { .init(rawValue: "capsule.inset.filled") }
 
     /// 􀿳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsuleLefthalfFilled = SFSymbol(rawValue: "capsule.lefthalf.filled")
+    static var capsuleLefthalfFilled: SFSymbol { .init(rawValue: "capsule.lefthalf.filled") }
 
     /// 􀿺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortraitBottomhalfFilled = SFSymbol(rawValue: "capsule.portrait.bottomhalf.filled")
+    static var capsulePortraitBottomhalfFilled: SFSymbol { .init(rawValue: "capsule.portrait.bottomhalf.filled") }
 
     /// 􀾛
     /// Single Localization, 2 Layersets
@@ -1374,56 +1374,56 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCapsulePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCapsulePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCapsulePortrait")
-    static let capsulePortraitInsetFilled = SFSymbol(rawValue: "capsule.portrait.inset.filled")
+    static var capsulePortraitInsetFilled: SFSymbol { .init(rawValue: "capsule.portrait.inset.filled") }
 
     /// 􀿷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortraitLefthalfFilled = SFSymbol(rawValue: "capsule.portrait.lefthalf.filled")
+    static var capsulePortraitLefthalfFilled: SFSymbol { .init(rawValue: "capsule.portrait.lefthalf.filled") }
 
     /// 􀿸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortraitRighthalfFilled = SFSymbol(rawValue: "capsule.portrait.righthalf.filled")
+    static var capsulePortraitRighthalfFilled: SFSymbol { .init(rawValue: "capsule.portrait.righthalf.filled") }
 
     /// 􀿹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsulePortraitTophalfFilled = SFSymbol(rawValue: "capsule.portrait.tophalf.filled")
+    static var capsulePortraitTophalfFilled: SFSymbol { .init(rawValue: "capsule.portrait.tophalf.filled") }
 
     /// 􀿴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsuleRighthalfFilled = SFSymbol(rawValue: "capsule.righthalf.filled")
+    static var capsuleRighthalfFilled: SFSymbol { .init(rawValue: "capsule.righthalf.filled") }
 
     /// 􀿵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let capsuleTophalfFilled = SFSymbol(rawValue: "capsule.tophalf.filled")
+    static var capsuleTophalfFilled: SFSymbol { .init(rawValue: "capsule.tophalf.filled") }
 
     /// 􀸌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carFerry = SFSymbol(rawValue: "car.ferry")
+    static var carFerry: SFSymbol { .init(rawValue: "car.ferry") }
 
     /// 􀸍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carFerryFill = SFSymbol(rawValue: "car.ferry.fill")
+    static var carFerryFill: SFSymbol { .init(rawValue: "car.ferry.fill") }
 
     /// 􀑁
     /// Single Localization, 3 Layersets
@@ -1432,7 +1432,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartLineUptrendXyaxis = SFSymbol(rawValue: "chart.line.uptrend.xyaxis")
+    static var chartLineUptrendXyaxis: SFSymbol { .init(rawValue: "chart.line.uptrend.xyaxis") }
 
     /// 􀴚
     /// Single Localization, 2 Layersets
@@ -1440,7 +1440,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartLineUptrendXyaxisCircle = SFSymbol(rawValue: "chart.line.uptrend.xyaxis.circle")
+    static var chartLineUptrendXyaxisCircle: SFSymbol { .init(rawValue: "chart.line.uptrend.xyaxis.circle") }
 
     /// 􀴛
     /// Single Localization, 3 Layersets
@@ -1449,7 +1449,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartLineUptrendXyaxisCircleFill = SFSymbol(rawValue: "chart.line.uptrend.xyaxis.circle.fill")
+    static var chartLineUptrendXyaxisCircleFill: SFSymbol { .init(rawValue: "chart.line.uptrend.xyaxis.circle.fill") }
 
     /// 􁂥
     /// Single Localization, 3 Layersets
@@ -1458,7 +1458,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let chartXyaxisLine = SFSymbol(rawValue: "chart.xyaxis.line")
+    static var chartXyaxisLine: SFSymbol { .init(rawValue: "chart.xyaxis.line") }
 
     /// 􀵔
     /// Single Localization, Single Layerset
@@ -1470,7 +1470,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "shieldCheckered")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "shieldCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "shieldCheckered")
-    static let checkerboardShield = SFSymbol(rawValue: "checkerboard.shield")
+    static var checkerboardShield: SFSymbol { .init(rawValue: "checkerboard.shield") }
 
     /// 􀷾
     /// 2 Localizations, 2 Layersets
@@ -1482,7 +1482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checklist = SymbolWith1Localization<Rtl>(rawValue: "checklist")
+    static var checklist: SymbolWith1Localization<Rtl> { .init(rawValue: "checklist") }
 
     /// 􀿋
     /// 2 Localizations, 2 Layersets
@@ -1494,7 +1494,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkBubble = SymbolWith1Localization<Rtl_v5>(rawValue: "checkmark.bubble")
+    static var checkmarkBubble: SymbolWith1Localization<Rtl_v5> { .init(rawValue: "checkmark.bubble") }
 
     /// 􀿌
     /// 2 Localizations, 3 Layersets
@@ -1507,7 +1507,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkBubbleFill = SymbolWith1Localization<Rtl_v5>(rawValue: "checkmark.bubble.fill")
+    static var checkmarkBubbleFill: SymbolWith1Localization<Rtl_v5> { .init(rawValue: "checkmark.bubble.fill") }
 
     /// 􁃎
     /// Single Localization, 3 Layersets
@@ -1516,7 +1516,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleTrianglebadgeExclamationmark = SFSymbol(rawValue: "checkmark.circle.trianglebadge.exclamationmark")
+    static var checkmarkCircleTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "checkmark.circle.trianglebadge.exclamationmark") }
 
     /// 􁁚
     /// Single Localization, 3 Layersets
@@ -1525,7 +1525,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkDiamond = SFSymbol(rawValue: "checkmark.diamond")
+    static var checkmarkDiamond: SFSymbol { .init(rawValue: "checkmark.diamond") }
 
     /// 􁁛
     /// Single Localization, 3 Layersets
@@ -1534,14 +1534,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let checkmarkDiamondFill = SFSymbol(rawValue: "checkmark.diamond.fill")
+    static var checkmarkDiamondFill: SFSymbol { .init(rawValue: "checkmark.diamond.fill") }
 
     /// 􀙚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeftForwardslashChevronRight = SFSymbol(rawValue: "chevron.left.forwardslash.chevron.right")
+    static var chevronLeftForwardslashChevronRight: SFSymbol { .init(rawValue: "chevron.left.forwardslash.chevron.right") }
 
     /// 􀠌
     /// Single Localization, 2 Layersets
@@ -1549,21 +1549,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let circleAndLineHorizontal = SFSymbol(rawValue: "circle.and.line.horizontal")
+    static var circleAndLineHorizontal: SFSymbol { .init(rawValue: "circle.and.line.horizontal") }
 
     /// 􀞍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleAndLineHorizontalFill = SFSymbol(rawValue: "circle.and.line.horizontal.fill")
+    static var circleAndLineHorizontalFill: SFSymbol { .init(rawValue: "circle.and.line.horizontal.fill") }
 
     /// 􀪖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleBottomhalfFilled = SFSymbol(rawValue: "circle.bottomhalf.filled")
+    static var circleBottomhalfFilled: SFSymbol { .init(rawValue: "circle.bottomhalf.filled") }
 
     /// 􀧒
     /// Single Localization, 2 Layersets
@@ -1576,28 +1576,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCircleDashed")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCircleDashed")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCircleDashed")
-    static let circleDashedInsetFilled = SFSymbol(rawValue: "circle.dashed.inset.filled")
+    static var circleDashedInsetFilled: SFSymbol { .init(rawValue: "circle.dashed.inset.filled") }
 
     /// 􁅃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleDotted = SFSymbol(rawValue: "circle.dotted")
+    static var circleDotted: SFSymbol { .init(rawValue: "circle.dotted") }
 
     /// 􀺇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid2x1 = SFSymbol(rawValue: "circle.grid.2x1")
+    static var circleGrid2x1: SFSymbol { .init(rawValue: "circle.grid.2x1") }
 
     /// 􀺈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleGrid2x1Fill = SFSymbol(rawValue: "circle.grid.2x1.fill")
+    static var circleGrid2x1Fill: SFSymbol { .init(rawValue: "circle.grid.2x1.fill") }
 
     /// 􀺉
     /// Single Localization, 2 Layersets
@@ -1605,7 +1605,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGrid2x1LeftFilled = SFSymbol(rawValue: "circle.grid.2x1.left.filled")
+    static var circleGrid2x1LeftFilled: SFSymbol { .init(rawValue: "circle.grid.2x1.left.filled") }
 
     /// 􀺊
     /// Single Localization, 2 Layersets
@@ -1613,7 +1613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGrid2x1RightFilled = SFSymbol(rawValue: "circle.grid.2x1.right.filled")
+    static var circleGrid2x1RightFilled: SFSymbol { .init(rawValue: "circle.grid.2x1.right.filled") }
 
     /// 􀺲
     /// Single Localization, 2 Layersets
@@ -1621,7 +1621,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGrid3x3Circle = SFSymbol(rawValue: "circle.grid.3x3.circle")
+    static var circleGrid3x3Circle: SFSymbol { .init(rawValue: "circle.grid.3x3.circle") }
 
     /// 􀺳
     /// Single Localization, 3 Layersets
@@ -1630,7 +1630,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleGrid3x3CircleFill = SFSymbol(rawValue: "circle.grid.3x3.circle.fill")
+    static var circleGrid3x3CircleFill: SFSymbol { .init(rawValue: "circle.grid.3x3.circle.fill") }
 
     /// 􀩇
     /// Single Localization, 2 Layersets
@@ -1638,7 +1638,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGridCrossDownFilled = SFSymbol(rawValue: "circle.grid.cross.down.filled")
+    static var circleGridCrossDownFilled: SFSymbol { .init(rawValue: "circle.grid.cross.down.filled") }
 
     /// 􀩄
     /// Single Localization, 2 Layersets
@@ -1646,7 +1646,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGridCrossLeftFilled = SFSymbol(rawValue: "circle.grid.cross.left.filled")
+    static var circleGridCrossLeftFilled: SFSymbol { .init(rawValue: "circle.grid.cross.left.filled") }
 
     /// 􀩆
     /// Single Localization, 2 Layersets
@@ -1654,7 +1654,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGridCrossRightFilled = SFSymbol(rawValue: "circle.grid.cross.right.filled")
+    static var circleGridCrossRightFilled: SFSymbol { .init(rawValue: "circle.grid.cross.right.filled") }
 
     /// 􀩅
     /// Single Localization, 2 Layersets
@@ -1662,14 +1662,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleGridCrossUpFilled = SFSymbol(rawValue: "circle.grid.cross.up.filled")
+    static var circleGridCrossUpFilled: SFSymbol { .init(rawValue: "circle.grid.cross.up.filled") }
 
     /// 􀙢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleHexagongrid = SFSymbol(rawValue: "circle.hexagongrid")
+    static var circleHexagongrid: SFSymbol { .init(rawValue: "circle.hexagongrid") }
 
     /// 􀷙
     /// Single Localization, 2 Layersets
@@ -1677,7 +1677,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleHexagongridCircle = SFSymbol(rawValue: "circle.hexagongrid.circle")
+    static var circleHexagongridCircle: SFSymbol { .init(rawValue: "circle.hexagongrid.circle") }
 
     /// 􀷚
     /// Single Localization, 3 Layersets
@@ -1686,7 +1686,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleHexagongridCircleFill = SFSymbol(rawValue: "circle.hexagongrid.circle.fill")
+    static var circleHexagongridCircleFill: SFSymbol { .init(rawValue: "circle.hexagongrid.circle.fill") }
 
     /// 􀙣
     /// Single Localization, 2 Layersets
@@ -1694,21 +1694,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let circleHexagongridFill = SFSymbol(rawValue: "circle.hexagongrid.fill")
+    static var circleHexagongridFill: SFSymbol { .init(rawValue: "circle.hexagongrid.fill") }
 
     /// 􀬎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleHexagonpath = SFSymbol(rawValue: "circle.hexagonpath")
+    static var circleHexagonpath: SFSymbol { .init(rawValue: "circle.hexagonpath") }
 
     /// 􀬏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleHexagonpathFill = SFSymbol(rawValue: "circle.hexagonpath.fill")
+    static var circleHexagonpathFill: SFSymbol { .init(rawValue: "circle.hexagonpath.fill") }
 
     /// 􀝜
     /// Single Localization, 2 Layersets
@@ -1721,21 +1721,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCircle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCircle")
-    static let circleInsetFilled = SFSymbol(rawValue: "circle.inset.filled")
+    static var circleInsetFilled: SFSymbol { .init(rawValue: "circle.inset.filled") }
 
     /// 􀀂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfFilled = SFSymbol(rawValue: "circle.lefthalf.filled")
+    static var circleLefthalfFilled: SFSymbol { .init(rawValue: "circle.lefthalf.filled") }
 
     /// 􀀃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleRighthalfFilled = SFSymbol(rawValue: "circle.righthalf.filled")
+    static var circleRighthalfFilled: SFSymbol { .init(rawValue: "circle.righthalf.filled") }
 
     /// 􀻃
     /// Single Localization, 2 Layersets
@@ -1743,7 +1743,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleSlash = SFSymbol(rawValue: "circle.slash")
+    static var circleSlash: SFSymbol { .init(rawValue: "circle.slash") }
 
     /// 􀻄
     /// Single Localization, 2 Layersets
@@ -1751,7 +1751,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleSlashFill = SFSymbol(rawValue: "circle.slash.fill")
+    static var circleSlashFill: SFSymbol { .init(rawValue: "circle.slash.fill") }
 
     /// 􀧻
     /// Single Localization, 3 Layersets
@@ -1760,14 +1760,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let circleSquareFill = SFSymbol(rawValue: "circle.square.fill")
+    static var circleSquareFill: SFSymbol { .init(rawValue: "circle.square.fill") }
 
     /// 􀪗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleTophalfFilled = SFSymbol(rawValue: "circle.tophalf.filled")
+    static var circleTophalfFilled: SFSymbol { .init(rawValue: "circle.tophalf.filled") }
 
     /// 􀹴
     /// Single Localization, 3 Layersets
@@ -1776,7 +1776,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeCheckmark = SFSymbol(rawValue: "clock.badge.checkmark")
+    static var clockBadgeCheckmark: SFSymbol { .init(rawValue: "clock.badge.checkmark") }
 
     /// 􀹵
     /// Single Localization, 3 Layersets
@@ -1785,7 +1785,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeCheckmarkFill = SFSymbol(rawValue: "clock.badge.checkmark.fill")
+    static var clockBadgeCheckmarkFill: SFSymbol { .init(rawValue: "clock.badge.checkmark.fill") }
 
     /// 􀹶
     /// Single Localization, 3 Layersets
@@ -1794,7 +1794,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeExclamationmark = SFSymbol(rawValue: "clock.badge.exclamationmark")
+    static var clockBadgeExclamationmark: SFSymbol { .init(rawValue: "clock.badge.exclamationmark") }
 
     /// 􀹷
     /// Single Localization, 3 Layersets
@@ -1803,7 +1803,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeExclamationmarkFill = SFSymbol(rawValue: "clock.badge.exclamationmark.fill")
+    static var clockBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "clock.badge.exclamationmark.fill") }
 
     /// 􁆸
     /// Single Localization, 2 Layersets
@@ -1811,7 +1811,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockCircle = SFSymbol(rawValue: "clock.circle")
+    static var clockCircle: SFSymbol { .init(rawValue: "clock.circle") }
 
     /// 􁆹
     /// Single Localization, 3 Layersets
@@ -1820,28 +1820,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let clockCircleFill = SFSymbol(rawValue: "clock.circle.fill")
+    static var clockCircleFill: SFSymbol { .init(rawValue: "clock.circle.fill") }
 
     /// 􀺣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let computermouse = SFSymbol(rawValue: "computermouse")
+    static var computermouse: SFSymbol { .init(rawValue: "computermouse") }
 
     /// 􀺤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let computermouseFill = SFSymbol(rawValue: "computermouse.fill")
+    static var computermouseFill: SFSymbol { .init(rawValue: "computermouse.fill") }
 
     /// 􀧓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cpuFill = SFSymbol(rawValue: "cpu.fill")
+    static var cpuFill: SFSymbol { .init(rawValue: "cpu.fill") }
 
     /// 􁂨
     /// Single Localization, 2 Layersets
@@ -1854,7 +1854,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 26.0, renamed: "creditcardAndNumbers")
     @available(watchOS, introduced: 8.0, deprecated: 26.0, renamed: "creditcardAndNumbers")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "creditcardAndNumbers")
-    static let creditcardAnd123 = SFSymbol(rawValue: "creditcard.and.123")
+    static var creditcardAnd123: SFSymbol { .init(rawValue: "creditcard.and.123") }
 
     /// 􁄭
     /// Single Localization, 3 Layersets
@@ -1863,7 +1863,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let creditcardTrianglebadgeExclamationmark = SFSymbol(rawValue: "creditcard.trianglebadge.exclamationmark")
+    static var creditcardTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "creditcard.trianglebadge.exclamationmark") }
 
     /// 􀼘
     /// Single Localization, 3 Layersets
@@ -1872,7 +1872,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let crossVial = SFSymbol(rawValue: "cross.vial")
+    static var crossVial: SFSymbol { .init(rawValue: "cross.vial") }
 
     /// 􀼙
     /// Single Localization, 3 Layersets
@@ -1881,21 +1881,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let crossVialFill = SFSymbol(rawValue: "cross.vial.fill")
+    static var crossVialFill: SFSymbol { .init(rawValue: "cross.vial.fill") }
 
     /// 􀸘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cupAndSaucer = SFSymbol(rawValue: "cup.and.saucer")
+    static var cupAndSaucer: SFSymbol { .init(rawValue: "cup.and.saucer") }
 
     /// 􀸙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cupAndSaucerFill = SFSymbol(rawValue: "cup.and.saucer.fill")
+    static var cupAndSaucerFill: SFSymbol { .init(rawValue: "cup.and.saucer.fill") }
 
     /// 􁂈
     /// Single Localization, 3 Layersets
@@ -1904,7 +1904,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let deleteBackward = SFSymbol(rawValue: "delete.backward")
+    static var deleteBackward: SFSymbol { .init(rawValue: "delete.backward") }
 
     /// 􁂉
     /// Single Localization, 3 Layersets
@@ -1913,7 +1913,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let deleteBackwardFill = SFSymbol(rawValue: "delete.backward.fill")
+    static var deleteBackwardFill: SFSymbol { .init(rawValue: "delete.backward.fill") }
 
     /// 􁂒
     /// Single Localization, 3 Layersets
@@ -1922,7 +1922,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let deleteForward = SFSymbol(rawValue: "delete.forward")
+    static var deleteForward: SFSymbol { .init(rawValue: "delete.forward") }
 
     /// 􁂓
     /// Single Localization, 3 Layersets
@@ -1931,7 +1931,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let deleteForwardFill = SFSymbol(rawValue: "delete.forward.fill")
+    static var deleteForwardFill: SFSymbol { .init(rawValue: "delete.forward.fill") }
 
     /// 􀶾
     /// Single Localization, 2 Layersets
@@ -1939,7 +1939,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let desktopcomputerAndArrowDown = SFSymbol(rawValue: "desktopcomputer.and.arrow.down")
+    static var desktopcomputerAndArrowDown: SFSymbol { .init(rawValue: "desktopcomputer.and.arrow.down") }
 
     /// 􁃃
     /// Single Localization, 3 Layersets
@@ -1948,14 +1948,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let desktopcomputerTrianglebadgeExclamationmark = SFSymbol(rawValue: "desktopcomputer.trianglebadge.exclamationmark")
+    static var desktopcomputerTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "desktopcomputer.trianglebadge.exclamationmark") }
 
     /// 􁀆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamondBottomhalfFilled = SFSymbol(rawValue: "diamond.bottomhalf.filled")
+    static var diamondBottomhalfFilled: SFSymbol { .init(rawValue: "diamond.bottomhalf.filled") }
 
     /// 􁇡
     /// Single Localization, 2 Layersets
@@ -1963,7 +1963,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let diamondCircle = SFSymbol(rawValue: "diamond.circle")
+    static var diamondCircle: SFSymbol { .init(rawValue: "diamond.circle") }
 
     /// 􁇢
     /// Single Localization, 3 Layersets
@@ -1972,7 +1972,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let diamondCircleFill = SFSymbol(rawValue: "diamond.circle.fill")
+    static var diamondCircleFill: SFSymbol { .init(rawValue: "diamond.circle.fill") }
 
     /// 􀾗
     /// Single Localization, 2 Layersets
@@ -1985,28 +1985,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledDiamond")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledDiamond")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledDiamond")
-    static let diamondInsetFilled = SFSymbol(rawValue: "diamond.inset.filled")
+    static var diamondInsetFilled: SFSymbol { .init(rawValue: "diamond.inset.filled") }
 
     /// 􁀃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamondLefthalfFilled = SFSymbol(rawValue: "diamond.lefthalf.filled")
+    static var diamondLefthalfFilled: SFSymbol { .init(rawValue: "diamond.lefthalf.filled") }
 
     /// 􁀄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamondRighthalfFilled = SFSymbol(rawValue: "diamond.righthalf.filled")
+    static var diamondRighthalfFilled: SFSymbol { .init(rawValue: "diamond.righthalf.filled") }
 
     /// 􁀅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let diamondTophalfFilled = SFSymbol(rawValue: "diamond.tophalf.filled")
+    static var diamondTophalfFilled: SFSymbol { .init(rawValue: "diamond.tophalf.filled") }
 
     /// 􀺴
     /// Single Localization, 3 Layersets
@@ -2015,7 +2015,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dice = SFSymbol(rawValue: "dice")
+    static var dice: SFSymbol { .init(rawValue: "dice") }
 
     /// 􀺵
     /// Single Localization, 3 Layersets
@@ -2024,7 +2024,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let diceFill = SFSymbol(rawValue: "dice.fill")
+    static var diceFill: SFSymbol { .init(rawValue: "dice.fill") }
 
     /// 􀻖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2034,7 +2034,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownArrowClockwise = SFSymbol(rawValue: "digitalcrown.arrow.clockwise")
+    static var digitalcrownArrowClockwise: SFSymbol { .init(rawValue: "digitalcrown.arrow.clockwise") }
 
     /// 􀻗
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2044,7 +2044,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownArrowClockwiseFill = SFSymbol(rawValue: "digitalcrown.arrow.clockwise.fill")
+    static var digitalcrownArrowClockwiseFill: SFSymbol { .init(rawValue: "digitalcrown.arrow.clockwise.fill") }
 
     /// 􀻘
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2054,7 +2054,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownArrowCounterclockwise = SFSymbol(rawValue: "digitalcrown.arrow.counterclockwise")
+    static var digitalcrownArrowCounterclockwise: SFSymbol { .init(rawValue: "digitalcrown.arrow.counterclockwise") }
 
     /// 􀻙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2064,7 +2064,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownArrowCounterclockwiseFill = SFSymbol(rawValue: "digitalcrown.arrow.counterclockwise.fill")
+    static var digitalcrownArrowCounterclockwiseFill: SFSymbol { .init(rawValue: "digitalcrown.arrow.counterclockwise.fill") }
 
     /// 􀻱
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2074,7 +2074,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalArrowClockwise = SFSymbol(rawValue: "digitalcrown.horizontal.arrow.clockwise")
+    static var digitalcrownHorizontalArrowClockwise: SFSymbol { .init(rawValue: "digitalcrown.horizontal.arrow.clockwise") }
 
     /// 􀻲
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2084,7 +2084,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalArrowClockwiseFill = SFSymbol(rawValue: "digitalcrown.horizontal.arrow.clockwise.fill")
+    static var digitalcrownHorizontalArrowClockwiseFill: SFSymbol { .init(rawValue: "digitalcrown.horizontal.arrow.clockwise.fill") }
 
     /// 􀻳
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2094,7 +2094,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalArrowCounterclockwise = SFSymbol(rawValue: "digitalcrown.horizontal.arrow.counterclockwise")
+    static var digitalcrownHorizontalArrowCounterclockwise: SFSymbol { .init(rawValue: "digitalcrown.horizontal.arrow.counterclockwise") }
 
     /// 􀻴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2104,7 +2104,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalArrowCounterclockwiseFill = SFSymbol(rawValue: "digitalcrown.horizontal.arrow.counterclockwise.fill")
+    static var digitalcrownHorizontalArrowCounterclockwiseFill: SFSymbol { .init(rawValue: "digitalcrown.horizontal.arrow.counterclockwise.fill") }
 
     /// 􀴣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2114,7 +2114,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalPress = SFSymbol(rawValue: "digitalcrown.horizontal.press")
+    static var digitalcrownHorizontalPress: SFSymbol { .init(rawValue: "digitalcrown.horizontal.press") }
 
     /// 􀴤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2124,7 +2124,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownHorizontalPressFill = SFSymbol(rawValue: "digitalcrown.horizontal.press.fill")
+    static var digitalcrownHorizontalPressFill: SFSymbol { .init(rawValue: "digitalcrown.horizontal.press.fill") }
 
     /// 􀴡
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2134,7 +2134,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownPress = SFSymbol(rawValue: "digitalcrown.press")
+    static var digitalcrownPress: SFSymbol { .init(rawValue: "digitalcrown.press") }
 
     /// 􀴢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2144,7 +2144,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
-    static let digitalcrownPressFill = SFSymbol(rawValue: "digitalcrown.press.fill")
+    static var digitalcrownPressFill: SFSymbol { .init(rawValue: "digitalcrown.press.fill") }
 
     /// 􀶽
     /// Single Localization, 2 Layersets
@@ -2152,7 +2152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let displayAndArrowDown = SFSymbol(rawValue: "display.and.arrow.down")
+    static var displayAndArrowDown: SFSymbol { .init(rawValue: "display.and.arrow.down") }
 
     /// 􀩽
     /// Single Localization, Single Layerset
@@ -2164,7 +2164,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "textRectanglePage")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "textRectanglePage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textRectanglePage")
-    static let docTextImage = SFSymbol(rawValue: "doc.text.image")
+    static var docTextImage: SFSymbol { .init(rawValue: "doc.text.image") }
 
     /// 􀩾
     /// Single Localization, 2 Layersets
@@ -2177,7 +2177,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "textRectanglePageFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "textRectanglePageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textRectanglePageFill")
-    static let docTextImageFill = SFSymbol(rawValue: "doc.text.image.fill")
+    static var docTextImageFill: SFSymbol { .init(rawValue: "doc.text.image.fill") }
 
     /// 􀎾
     /// Single Localization, 2 Layersets
@@ -2190,7 +2190,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "documentViewfinder")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "documentViewfinder")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentViewfinder")
-    static let docViewfinder = SFSymbol(rawValue: "doc.viewfinder")
+    static var docViewfinder: SFSymbol { .init(rawValue: "doc.viewfinder") }
 
     /// 􀡢
     /// Single Localization, 2 Layersets
@@ -2203,7 +2203,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "documentViewfinderFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "documentViewfinderFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentViewfinderFill")
-    static let docViewfinderFill = SFSymbol(rawValue: "doc.viewfinder.fill")
+    static var docViewfinderFill: SFSymbol { .init(rawValue: "doc.viewfinder.fill") }
 
     /// 􀺪
     /// Single Localization, 2 Layersets
@@ -2211,7 +2211,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCircleAndHandPointUpLeftFill = SFSymbol(rawValue: "dot.circle.and.hand.point.up.left.fill")
+    static var dotCircleAndHandPointUpLeftFill: SFSymbol { .init(rawValue: "dot.circle.and.hand.point.up.left.fill") }
 
     /// 􁇞
     /// Single Localization, 2 Layersets
@@ -2219,7 +2219,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCircleViewfinder = SFSymbol(rawValue: "dot.circle.viewfinder")
+    static var dotCircleViewfinder: SFSymbol { .init(rawValue: "dot.circle.viewfinder") }
 
     /// 􀼗
     /// Single Localization, 3 Layersets
@@ -2228,7 +2228,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dotRadiowavesUpForward = SFSymbol(rawValue: "dot.radiowaves.up.forward")
+    static var dotRadiowavesUpForward: SFSymbol { .init(rawValue: "dot.radiowaves.up.forward") }
 
     /// 􁇝
     /// Single Localization, 2 Layersets
@@ -2236,7 +2236,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotViewfinder = SFSymbol(rawValue: "dot.viewfinder")
+    static var dotViewfinder: SFSymbol { .init(rawValue: "dot.viewfinder") }
 
     /// 􀨀
     /// Single Localization, 2 Layersets
@@ -2244,7 +2244,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dpadDownFilled = SFSymbol(rawValue: "dpad.down.filled")
+    static var dpadDownFilled: SFSymbol { .init(rawValue: "dpad.down.filled") }
 
     /// 􀧽
     /// Single Localization, 2 Layersets
@@ -2252,7 +2252,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dpadLeftFilled = SFSymbol(rawValue: "dpad.left.filled")
+    static var dpadLeftFilled: SFSymbol { .init(rawValue: "dpad.left.filled") }
 
     /// 􀧿
     /// Single Localization, 2 Layersets
@@ -2260,7 +2260,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dpadRightFilled = SFSymbol(rawValue: "dpad.right.filled")
+    static var dpadRightFilled: SFSymbol { .init(rawValue: "dpad.right.filled") }
 
     /// 􀧾
     /// Single Localization, 2 Layersets
@@ -2268,7 +2268,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dpadUpFilled = SFSymbol(rawValue: "dpad.up.filled")
+    static var dpadUpFilled: SFSymbol { .init(rawValue: "dpad.up.filled") }
 
     /// 􁇊
     /// Single Localization, 2 Layersets
@@ -2276,7 +2276,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dropCircle = SFSymbol(rawValue: "drop.circle")
+    static var dropCircle: SFSymbol { .init(rawValue: "drop.circle") }
 
     /// 􁇋
     /// Single Localization, 3 Layersets
@@ -2285,7 +2285,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let dropCircleFill = SFSymbol(rawValue: "drop.circle.fill")
+    static var dropCircleFill: SFSymbol { .init(rawValue: "drop.circle.fill") }
 
     /// 􀵣
     /// Single Localization, 3 Layersets
@@ -2299,7 +2299,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "earBadgeWaveform")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "earBadgeWaveform")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "earBadgeWaveform")
-    static let earAndWaveform = SFSymbol(rawValue: "ear.and.waveform")
+    static var earAndWaveform: SFSymbol { .init(rawValue: "ear.and.waveform") }
 
     /// 􀸸
     /// Single Localization, 2 Layersets
@@ -2307,21 +2307,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbuds = SFSymbol(rawValue: "earbuds")
+    static var earbuds: SFSymbol { .init(rawValue: "earbuds") }
 
     /// 􀹥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let earbudsCase = SFSymbol(rawValue: "earbuds.case")
+    static var earbudsCase: SFSymbol { .init(rawValue: "earbuds.case") }
 
     /// 􀹦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let earbudsCaseFill = SFSymbol(rawValue: "earbuds.case.fill")
+    static var earbudsCaseFill: SFSymbol { .init(rawValue: "earbuds.case.fill") }
 
     /// 􁇵
     /// Single Localization, 3 Layersets
@@ -2330,7 +2330,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisCurlybraces = SFSymbol(rawValue: "ellipsis.curlybraces")
+    static var ellipsisCurlybraces: SFSymbol { .init(rawValue: "ellipsis.curlybraces") }
 
     /// 􁁟
     /// Single Localization, 3 Layersets
@@ -2339,7 +2339,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisVerticalBubble = SFSymbol(rawValue: "ellipsis.vertical.bubble")
+    static var ellipsisVerticalBubble: SFSymbol { .init(rawValue: "ellipsis.vertical.bubble") }
 
     /// 􁁠
     /// Single Localization, 3 Layersets
@@ -2348,7 +2348,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ellipsisVerticalBubbleFill = SFSymbol(rawValue: "ellipsis.vertical.bubble.fill")
+    static var ellipsisVerticalBubbleFill: SFSymbol { .init(rawValue: "ellipsis.vertical.bubble.fill") }
 
     /// 􀫙
     /// Single Localization, 2 Layersets
@@ -2356,7 +2356,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeBadgeShieldHalfFilled = SFSymbol(rawValue: "envelope.badge.shield.half.filled")
+    static var envelopeBadgeShieldHalfFilled: SFSymbol { .init(rawValue: "envelope.badge.shield.half.filled") }
 
     /// 􀫚
     /// Single Localization, 2 Layersets
@@ -2364,7 +2364,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeBadgeShieldHalfFilledFill = SFSymbol(rawValue: "envelope.badge.shield.half.filled.fill")
+    static var envelopeBadgeShieldHalfFilledFill: SFSymbol { .init(rawValue: "envelope.badge.shield.half.filled.fill") }
 
     /// 􁆶
     /// Single Localization, 2 Layersets
@@ -2372,7 +2372,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let exclamationmarkBubbleCircle = SFSymbol(rawValue: "exclamationmark.bubble.circle")
+    static var exclamationmarkBubbleCircle: SFSymbol { .init(rawValue: "exclamationmark.bubble.circle") }
 
     /// 􁆷
     /// Single Localization, 3 Layersets
@@ -2381,7 +2381,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let exclamationmarkBubbleCircleFill = SFSymbol(rawValue: "exclamationmark.bubble.circle.fill")
+    static var exclamationmarkBubbleCircleFill: SFSymbol { .init(rawValue: "exclamationmark.bubble.circle.fill") }
 
     /// 􀜁
     /// Single Localization, 2 Layersets
@@ -2389,7 +2389,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eyeSlashCircle = SFSymbol(rawValue: "eye.slash.circle")
+    static var eyeSlashCircle: SFSymbol { .init(rawValue: "eye.slash.circle") }
 
     /// 􀜂
     /// Single Localization, 3 Layersets
@@ -2398,7 +2398,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eyeSlashCircleFill = SFSymbol(rawValue: "eye.slash.circle.fill")
+    static var eyeSlashCircleFill: SFSymbol { .init(rawValue: "eye.slash.circle.fill") }
 
     /// 􀽇
     /// Single Localization, 2 Layersets
@@ -2406,7 +2406,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eyeSquare = SFSymbol(rawValue: "eye.square")
+    static var eyeSquare: SFSymbol { .init(rawValue: "eye.square") }
 
     /// 􀽈
     /// Single Localization, 3 Layersets
@@ -2415,7 +2415,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let eyeSquareFill = SFSymbol(rawValue: "eye.square.fill")
+    static var eyeSquareFill: SFSymbol { .init(rawValue: "eye.square.fill") }
 
     /// 􁂔
     /// Single Localization, 3 Layersets
@@ -2424,7 +2424,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eyeTrianglebadgeExclamationmark = SFSymbol(rawValue: "eye.trianglebadge.exclamationmark")
+    static var eyeTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "eye.trianglebadge.exclamationmark") }
 
     /// 􁂕
     /// Single Localization, 3 Layersets
@@ -2433,7 +2433,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eyeTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "eye.trianglebadge.exclamationmark.fill")
+    static var eyeTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "eye.trianglebadge.exclamationmark.fill") }
 
     /// 􁃌
     /// Single Localization, 3 Layersets
@@ -2442,7 +2442,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let facemask = SFSymbol(rawValue: "facemask")
+    static var facemask: SFSymbol { .init(rawValue: "facemask") }
 
     /// 􁃍
     /// Single Localization, 3 Layersets
@@ -2451,7 +2451,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let facemaskFill = SFSymbol(rawValue: "facemask.fill")
+    static var facemaskFill: SFSymbol { .init(rawValue: "facemask.fill") }
 
     /// 􁁋
     /// Single Localization, Single Layerset
@@ -2463,7 +2463,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "fan")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "fan")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "fan")
-    static let fanblades = SFSymbol(rawValue: "fanblades")
+    static var fanblades: SFSymbol { .init(rawValue: "fanblades") }
 
     /// 􁁌
     /// Single Localization, Single Layerset
@@ -2475,35 +2475,35 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "fanFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "fanFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "fanFill")
-    static let fanbladesFill = SFSymbol(rawValue: "fanblades.fill")
+    static var fanbladesFill: SFSymbol { .init(rawValue: "fanblades.fill") }
 
     /// 􀸅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ferry = SFSymbol(rawValue: "ferry")
+    static var ferry: SFSymbol { .init(rawValue: "ferry") }
 
     /// 􀸆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ferryFill = SFSymbol(rawValue: "ferry.fill")
+    static var ferryFill: SFSymbol { .init(rawValue: "ferry.fill") }
 
     /// 􀥢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fibrechannel = SFSymbol(rawValue: "fibrechannel")
+    static var fibrechannel: SFSymbol { .init(rawValue: "fibrechannel") }
 
     /// 􁈑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRoll = SFSymbol(rawValue: "figure.roll")
+    static var figureRoll: SFSymbol { .init(rawValue: "figure.roll") }
 
     /// 􀸊
     /// Single Localization, 2 Layersets
@@ -2511,7 +2511,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let filmCircle = SFSymbol(rawValue: "film.circle")
+    static var filmCircle: SFSymbol { .init(rawValue: "film.circle") }
 
     /// 􀸋
     /// Single Localization, 3 Layersets
@@ -2520,7 +2520,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let filmCircleFill = SFSymbol(rawValue: "film.circle.fill")
+    static var filmCircleFill: SFSymbol { .init(rawValue: "film.circle.fill") }
 
     /// 􀶶
     /// Single Localization, 2 Layersets
@@ -2528,7 +2528,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flag2Crossed = SFSymbol(rawValue: "flag.2.crossed")
+    static var flag2Crossed: SFSymbol { .init(rawValue: "flag.2.crossed") }
 
     /// 􀶷
     /// Single Localization, 2 Layersets
@@ -2536,7 +2536,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flag2CrossedFill = SFSymbol(rawValue: "flag.2.crossed.fill")
+    static var flag2CrossedFill: SFSymbol { .init(rawValue: "flag.2.crossed.fill") }
 
     /// 􁁜
     /// Single Localization, 2 Layersets
@@ -2544,7 +2544,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flagAndFlagFilledCrossed = SFSymbol(rawValue: "flag.and.flag.filled.crossed")
+    static var flagAndFlagFilledCrossed: SFSymbol { .init(rawValue: "flag.and.flag.filled.crossed") }
 
     /// 􀶸
     /// Single Localization, 2 Layersets
@@ -2552,7 +2552,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flagFilledAndFlagCrossed = SFSymbol(rawValue: "flag.filled.and.flag.crossed")
+    static var flagFilledAndFlagCrossed: SFSymbol { .init(rawValue: "flag.filled.and.flag.crossed") }
 
     /// 􀼳
     /// Single Localization, 3 Layersets
@@ -2561,7 +2561,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flagSquare = SFSymbol(rawValue: "flag.square")
+    static var flagSquare: SFSymbol { .init(rawValue: "flag.square") }
 
     /// 􀼴
     /// Single Localization, 3 Layersets
@@ -2570,7 +2570,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flagSquareFill = SFSymbol(rawValue: "flag.square.fill")
+    static var flagSquareFill: SFSymbol { .init(rawValue: "flag.square.fill") }
 
     /// 􁇒
     /// Single Localization, 2 Layersets
@@ -2578,7 +2578,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flameCircle = SFSymbol(rawValue: "flame.circle")
+    static var flameCircle: SFSymbol { .init(rawValue: "flame.circle") }
 
     /// 􁇓
     /// Single Localization, 3 Layersets
@@ -2587,7 +2587,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let flameCircleFill = SFSymbol(rawValue: "flame.circle.fill")
+    static var flameCircleFill: SFSymbol { .init(rawValue: "flame.circle.fill") }
 
     /// 􀣍
     /// Single Localization, 2 Layersets
@@ -2595,7 +2595,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let folderBadgeGearshape = SFSymbol(rawValue: "folder.badge.gearshape")
+    static var folderBadgeGearshape: SFSymbol { .init(rawValue: "folder.badge.gearshape") }
 
     /// 􀣎
     /// Single Localization, 2 Layersets
@@ -2603,7 +2603,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let folderFillBadgeGearshape = SFSymbol(rawValue: "folder.fill.badge.gearshape")
+    static var folderFillBadgeGearshape: SFSymbol { .init(rawValue: "folder.fill.badge.gearshape") }
 
     /// 􀸩
     /// Single Localization, 2 Layersets
@@ -2611,7 +2611,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let forkKnife = SFSymbol(rawValue: "fork.knife")
+    static var forkKnife: SFSymbol { .init(rawValue: "fork.knife") }
 
     /// 􀸹
     /// Single Localization, 3 Layersets
@@ -2620,7 +2620,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let forkKnifeCircle = SFSymbol(rawValue: "fork.knife.circle")
+    static var forkKnifeCircle: SFSymbol { .init(rawValue: "fork.knife.circle") }
 
     /// 􀸺
     /// Single Localization, 3 Layersets
@@ -2629,7 +2629,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let forkKnifeCircleFill = SFSymbol(rawValue: "fork.knife.circle.fill")
+    static var forkKnifeCircleFill: SFSymbol { .init(rawValue: "fork.knife.circle.fill") }
 
     /// 􀺅
     /// Single Localization, 2 Layersets
@@ -2637,7 +2637,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let forwardCircle = SFSymbol(rawValue: "forward.circle")
+    static var forwardCircle: SFSymbol { .init(rawValue: "forward.circle") }
 
     /// 􀺆
     /// Single Localization, 3 Layersets
@@ -2646,14 +2646,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let forwardCircleFill = SFSymbol(rawValue: "forward.circle.fill")
+    static var forwardCircleFill: SFSymbol { .init(rawValue: "forward.circle.fill") }
 
     /// 􀵞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelpump = SFSymbol(rawValue: "fuelpump")
+    static var fuelpump: SFSymbol { .init(rawValue: "fuelpump") }
 
     /// 􀵠
     /// Single Localization, 2 Layersets
@@ -2661,7 +2661,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpCircle = SFSymbol(rawValue: "fuelpump.circle")
+    static var fuelpumpCircle: SFSymbol { .init(rawValue: "fuelpump.circle") }
 
     /// 􀵡
     /// Single Localization, 3 Layersets
@@ -2670,14 +2670,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fuelpumpCircleFill = SFSymbol(rawValue: "fuelpump.circle.fill")
+    static var fuelpumpCircleFill: SFSymbol { .init(rawValue: "fuelpump.circle.fill") }
 
     /// 􀵟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelpumpFill = SFSymbol(rawValue: "fuelpump.fill")
+    static var fuelpumpFill: SFSymbol { .init(rawValue: "fuelpump.fill") }
 
     /// 􁅦
     /// Single Localization, 3 Layersets
@@ -2686,7 +2686,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 15.2, macOS 12.1, tvOS 15.2, watchOS 8.3)
-    static let gearBadgeCheckmark = SFSymbol(rawValue: "gear.badge.checkmark")
+    static var gearBadgeCheckmark: SFSymbol { .init(rawValue: "gear.badge.checkmark") }
 
     /// 􁅨
     /// Single Localization, 3 Layersets
@@ -2695,7 +2695,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearBadgeQuestionmark = SFSymbol(rawValue: "gear.badge.questionmark")
+    static var gearBadgeQuestionmark: SFSymbol { .init(rawValue: "gear.badge.questionmark") }
 
     /// 􁅧
     /// Single Localization, 3 Layersets
@@ -2704,7 +2704,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearBadgeXmark = SFSymbol(rawValue: "gear.badge.xmark")
+    static var gearBadgeXmark: SFSymbol { .init(rawValue: "gear.badge.xmark") }
 
     /// 􀺺
     /// Single Localization, 3 Layersets
@@ -2713,7 +2713,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearCircle = SFSymbol(rawValue: "gear.circle")
+    static var gearCircle: SFSymbol { .init(rawValue: "gear.circle") }
 
     /// 􀺻
     /// Single Localization, 3 Layersets
@@ -2722,7 +2722,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearCircleFill = SFSymbol(rawValue: "gear.circle.fill")
+    static var gearCircleFill: SFSymbol { .init(rawValue: "gear.circle.fill") }
 
     /// 􀺼
     /// Single Localization, 2 Layersets
@@ -2730,7 +2730,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gearshapeCircle = SFSymbol(rawValue: "gearshape.circle")
+    static var gearshapeCircle: SFSymbol { .init(rawValue: "gearshape.circle") }
 
     /// 􀺽
     /// Single Localization, 3 Layersets
@@ -2739,35 +2739,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearshapeCircleFill = SFSymbol(rawValue: "gearshape.circle.fill")
+    static var gearshapeCircleFill: SFSymbol { .init(rawValue: "gearshape.circle.fill") }
 
     /// 􀵱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeAmericas = SFSymbol(rawValue: "globe.americas")
+    static var globeAmericas: SFSymbol { .init(rawValue: "globe.americas") }
 
     /// 􀵲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeAmericasFill = SFSymbol(rawValue: "globe.americas.fill")
+    static var globeAmericasFill: SFSymbol { .init(rawValue: "globe.americas.fill") }
 
     /// 􀵵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeAsiaAustralia = SFSymbol(rawValue: "globe.asia.australia")
+    static var globeAsiaAustralia: SFSymbol { .init(rawValue: "globe.asia.australia") }
 
     /// 􀵶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeAsiaAustraliaFill = SFSymbol(rawValue: "globe.asia.australia.fill")
+    static var globeAsiaAustraliaFill: SFSymbol { .init(rawValue: "globe.asia.australia.fill") }
 
     /// 􁅍
     /// Single Localization, 3 Layersets
@@ -2776,21 +2776,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let globeBadgeChevronBackward = SFSymbol(rawValue: "globe.badge.chevron.backward")
+    static var globeBadgeChevronBackward: SFSymbol { .init(rawValue: "globe.badge.chevron.backward") }
 
     /// 􀵳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeEuropeAfrica = SFSymbol(rawValue: "globe.europe.africa")
+    static var globeEuropeAfrica: SFSymbol { .init(rawValue: "globe.europe.africa") }
 
     /// 􀵴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeEuropeAfricaFill = SFSymbol(rawValue: "globe.europe.africa.fill")
+    static var globeEuropeAfricaFill: SFSymbol { .init(rawValue: "globe.europe.africa.fill") }
 
     /// 􀶱
     /// 3 Localizations, 2 Layersets
@@ -2808,7 +2808,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "_5ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "_5ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_5ArrowTriangleheadCounterclockwise")
-    static let gobackward5 = SymbolWith2Localizations<Ar, Hi>(rawValue: "gobackward.5")
+    static var gobackward5: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "gobackward.5") }
 
     /// 􀶰
     /// 3 Localizations, 2 Layersets
@@ -2826,7 +2826,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "_5ArrowTriangleheadClockwise")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "_5ArrowTriangleheadClockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "_5ArrowTriangleheadClockwise")
-    static let goforward5 = SymbolWith2Localizations<Ar, Hi>(rawValue: "goforward.5")
+    static var goforward5: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "goforward.5") }
 
     /// 􁆾
     /// Single Localization, 2 Layersets
@@ -2834,7 +2834,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let graduationcapCircle = SFSymbol(rawValue: "graduationcap.circle")
+    static var graduationcapCircle: SFSymbol { .init(rawValue: "graduationcap.circle") }
 
     /// 􁆿
     /// Single Localization, 3 Layersets
@@ -2843,7 +2843,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let graduationcapCircleFill = SFSymbol(rawValue: "graduationcap.circle.fill")
+    static var graduationcapCircleFill: SFSymbol { .init(rawValue: "graduationcap.circle.fill") }
 
     /// 􀭝
     /// Single Localization, 3 Layersets
@@ -2852,7 +2852,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let hSquareOnSquareFill = SFSymbol(rawValue: "h.square.on.square.fill")
+    static var hSquareOnSquareFill: SFSymbol { .init(rawValue: "h.square.on.square.fill") }
 
     /// 􀷔
     /// Single Localization, 2 Layersets
@@ -2860,7 +2860,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hammerCircle = SFSymbol(rawValue: "hammer.circle")
+    static var hammerCircle: SFSymbol { .init(rawValue: "hammer.circle") }
 
     /// 􀷕
     /// Single Localization, 3 Layersets
@@ -2869,7 +2869,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hammerCircleFill = SFSymbol(rawValue: "hammer.circle.fill")
+    static var hammerCircleFill: SFSymbol { .init(rawValue: "hammer.circle.fill") }
 
     /// 􀷊
     /// Single Localization, 3 Layersets
@@ -2878,7 +2878,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedCircle = SFSymbol(rawValue: "hand.raised.circle")
+    static var handRaisedCircle: SFSymbol { .init(rawValue: "hand.raised.circle") }
 
     /// 􀷋
     /// Single Localization, 3 Layersets
@@ -2887,7 +2887,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedCircleFill = SFSymbol(rawValue: "hand.raised.circle.fill")
+    static var handRaisedCircleFill: SFSymbol { .init(rawValue: "hand.raised.circle.fill") }
 
     /// 􀽓
     /// Single Localization, 3 Layersets
@@ -2896,7 +2896,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedSquare = SFSymbol(rawValue: "hand.raised.square")
+    static var handRaisedSquare: SFSymbol { .init(rawValue: "hand.raised.square") }
 
     /// 􀽔
     /// Single Localization, 3 Layersets
@@ -2905,7 +2905,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedSquareFill = SFSymbol(rawValue: "hand.raised.square.fill")
+    static var handRaisedSquareFill: SFSymbol { .init(rawValue: "hand.raised.square.fill") }
 
     /// 􀴨
     /// Single Localization, 3 Layersets
@@ -2914,7 +2914,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let handRaisedSquareOnSquare = SFSymbol(rawValue: "hand.raised.square.on.square")
+    static var handRaisedSquareOnSquare: SFSymbol { .init(rawValue: "hand.raised.square.on.square") }
 
     /// 􀴩
     /// Single Localization, 3 Layersets
@@ -2923,7 +2923,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let handRaisedSquareOnSquareFill = SFSymbol(rawValue: "hand.raised.square.on.square.fill")
+    static var handRaisedSquareOnSquareFill: SFSymbol { .init(rawValue: "hand.raised.square.on.square.fill") }
 
     /// 􀷟
     /// Single Localization, 2 Layersets
@@ -2931,7 +2931,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsdownCircle = SFSymbol(rawValue: "hand.thumbsdown.circle")
+    static var handThumbsdownCircle: SFSymbol { .init(rawValue: "hand.thumbsdown.circle") }
 
     /// 􀷠
     /// Single Localization, 3 Layersets
@@ -2940,7 +2940,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handThumbsdownCircleFill = SFSymbol(rawValue: "hand.thumbsdown.circle.fill")
+    static var handThumbsdownCircleFill: SFSymbol { .init(rawValue: "hand.thumbsdown.circle.fill") }
 
     /// 􀷝
     /// Single Localization, 2 Layersets
@@ -2948,7 +2948,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsupCircle = SFSymbol(rawValue: "hand.thumbsup.circle")
+    static var handThumbsupCircle: SFSymbol { .init(rawValue: "hand.thumbsup.circle") }
 
     /// 􀷞
     /// Single Localization, 3 Layersets
@@ -2957,7 +2957,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handThumbsupCircleFill = SFSymbol(rawValue: "hand.thumbsup.circle.fill")
+    static var handThumbsupCircleFill: SFSymbol { .init(rawValue: "hand.thumbsup.circle.fill") }
 
     /// 􀪓
     /// Single Localization, 2 Layersets
@@ -2965,7 +2965,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hearingdeviceEar = SFSymbol(rawValue: "hearingdevice.ear")
+    static var hearingdeviceEar: SFSymbol { .init(rawValue: "hearingdevice.ear") }
 
     /// 􁃪
     /// Single Localization, 3 Layersets
@@ -2974,7 +2974,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heartRectangle = SFSymbol(rawValue: "heart.rectangle")
+    static var heartRectangle: SFSymbol { .init(rawValue: "heart.rectangle") }
 
     /// 􁃫
     /// Single Localization, 3 Layersets
@@ -2983,7 +2983,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heartRectangleFill = SFSymbol(rawValue: "heart.rectangle.fill")
+    static var heartRectangleFill: SFSymbol { .init(rawValue: "heart.rectangle.fill") }
 
     /// 􀼱
     /// Single Localization, 3 Layersets
@@ -2992,7 +2992,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heartSquare = SFSymbol(rawValue: "heart.square")
+    static var heartSquare: SFSymbol { .init(rawValue: "heart.square") }
 
     /// 􀼲
     /// Single Localization, 3 Layersets
@@ -3001,35 +3001,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heartSquareFill = SFSymbol(rawValue: "heart.square.fill")
+    static var heartSquareFill: SFSymbol { .init(rawValue: "heart.square.fill") }
 
     /// 􁀿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagonBottomhalfFilled = SFSymbol(rawValue: "hexagon.bottomhalf.filled")
+    static var hexagonBottomhalfFilled: SFSymbol { .init(rawValue: "hexagon.bottomhalf.filled") }
 
     /// 􁀉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagonLefthalfFilled = SFSymbol(rawValue: "hexagon.lefthalf.filled")
+    static var hexagonLefthalfFilled: SFSymbol { .init(rawValue: "hexagon.lefthalf.filled") }
 
     /// 􁀊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagonRighthalfFilled = SFSymbol(rawValue: "hexagon.righthalf.filled")
+    static var hexagonRighthalfFilled: SFSymbol { .init(rawValue: "hexagon.righthalf.filled") }
 
     /// 􁀾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hexagonTophalfFilled = SFSymbol(rawValue: "hexagon.tophalf.filled")
+    static var hexagonTophalfFilled: SFSymbol { .init(rawValue: "hexagon.tophalf.filled") }
 
     /// 􀻻
     /// 2 Localizations, Single Layerset, ⚠️ Restricted
@@ -3042,7 +3042,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let hifispeakerAndAppletv = SymbolWith1Localization<Rtl_v4>(rawValue: "hifispeaker.and.appletv")
+    static var hifispeakerAndAppletv: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "hifispeaker.and.appletv") }
 
     /// 􀻼
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -3056,7 +3056,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let hifispeakerAndAppletvFill = SymbolWith1Localization<Rtl_v4>(rawValue: "hifispeaker.and.appletv.fill")
+    static var hifispeakerAndAppletvFill: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "hifispeaker.and.appletv.fill") }
 
     /// 􀺌
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -3070,7 +3070,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and Apple TV.
-    static let homepodAndAppletv = SymbolWith1Localization<Rtl_v4>(rawValue: "homepod.and.appletv")
+    static var homepodAndAppletv: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "homepod.and.appletv") }
 
     /// 􀺍
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -3084,7 +3084,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and Apple TV.
-    static let homepodAndAppletvFill = SymbolWith1Localization<Rtl_v4>(rawValue: "homepod.and.appletv.fill")
+    static var homepodAndAppletvFill: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "homepod.and.appletv.fill") }
 
     /// 􀻹
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -3103,7 +3103,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 26.0, renamed: "homepodMiniAndAppletv")
     @available(watchOS, introduced: 8.0, deprecated: 26.0, renamed: "homepodMiniAndAppletv")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "homepodMiniAndAppletv")
-    static let homepodminiAndAppletv = SymbolWith1Localization<Rtl_v4>(rawValue: "homepodmini.and.appletv")
+    static var homepodminiAndAppletv: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "homepodmini.and.appletv") }
 
     /// 􀻺
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -3122,7 +3122,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 26.0, renamed: "homepodMiniAndAppletvFill")
     @available(watchOS, introduced: 8.0, deprecated: 26.0, renamed: "homepodMiniAndAppletvFill")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "homepodMiniAndAppletvFill")
-    static let homepodminiAndAppletvFill = SymbolWith1Localization<Rtl_v4>(rawValue: "homepodmini.and.appletv.fill")
+    static var homepodminiAndAppletvFill: SymbolWith1Localization<Rtl_v4> { .init(rawValue: "homepodmini.and.appletv.fill") }
 
     /// 􀖈
     /// Single Localization, 3 Layersets
@@ -3131,7 +3131,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassBottomhalfFilled = SFSymbol(rawValue: "hourglass.bottomhalf.filled")
+    static var hourglassBottomhalfFilled: SFSymbol { .init(rawValue: "hourglass.bottomhalf.filled") }
 
     /// 􁇛
     /// Single Localization, 3 Layersets
@@ -3140,7 +3140,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassCircle = SFSymbol(rawValue: "hourglass.circle")
+    static var hourglassCircle: SFSymbol { .init(rawValue: "hourglass.circle") }
 
     /// 􁇜
     /// Single Localization, 3 Layersets
@@ -3149,7 +3149,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassCircleFill = SFSymbol(rawValue: "hourglass.circle.fill")
+    static var hourglassCircleFill: SFSymbol { .init(rawValue: "hourglass.circle.fill") }
 
     /// 􀖉
     /// Single Localization, 3 Layersets
@@ -3158,7 +3158,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassTophalfFilled = SFSymbol(rawValue: "hourglass.tophalf.filled")
+    static var hourglassTophalfFilled: SFSymbol { .init(rawValue: "hourglass.tophalf.filled") }
 
     /// 􁃚
     /// Single Localization, 3 Layersets
@@ -3167,7 +3167,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let humidity = SFSymbol(rawValue: "humidity")
+    static var humidity: SFSymbol { .init(rawValue: "humidity") }
 
     /// 􁃛
     /// Single Localization, 2 Layersets
@@ -3175,7 +3175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let humidityFill = SFSymbol(rawValue: "humidity.fill")
+    static var humidityFill: SFSymbol { .init(rawValue: "humidity.fill") }
 
     /// 􀽑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3186,7 +3186,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudSquare = SFSymbol(rawValue: "icloud.square")
+    static var icloudSquare: SFSymbol { .init(rawValue: "icloud.square") }
 
     /// 􀽒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3197,7 +3197,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudSquareFill = SFSymbol(rawValue: "icloud.square.fill")
+    static var icloudSquareFill: SFSymbol { .init(rawValue: "icloud.square.fill") }
 
     /// 􀷀
     /// Single Localization, 2 Layersets
@@ -3205,7 +3205,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ipadAndArrowForward = SFSymbol(rawValue: "ipad.and.arrow.forward")
+    static var ipadAndArrowForward: SFSymbol { .init(rawValue: "ipad.and.arrow.forward") }
 
     /// 􁄟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3221,7 +3221,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "ipadLandscapeAndIphone")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "ipadLandscapeAndIphone")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipadLandscapeAndIphone")
-    static let ipadAndIphone = SFSymbol(rawValue: "ipad.and.iphone")
+    static var ipadAndIphone: SFSymbol { .init(rawValue: "ipad.and.iphone") }
 
     /// 􁀲
     /// Single Localization, 2 Layersets
@@ -3229,7 +3229,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ipadRearCamera = SFSymbol(rawValue: "ipad.rear.camera")
+    static var ipadRearCamera: SFSymbol { .init(rawValue: "ipad.rear.camera") }
 
     /// 􀶼
     /// Single Localization, 2 Layersets
@@ -3242,7 +3242,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "iphoneAndArrowForwardInward")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "iphoneAndArrowForwardInward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "iphoneAndArrowForwardInward")
-    static let iphoneAndArrowForward = SFSymbol(rawValue: "iphone.and.arrow.forward")
+    static var iphoneAndArrowForward: SFSymbol { .init(rawValue: "iphone.and.arrow.forward") }
 
     /// 􁄩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3252,7 +3252,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneCircle = SFSymbol(rawValue: "iphone.circle")
+    static var iphoneCircle: SFSymbol { .init(rawValue: "iphone.circle") }
 
     /// 􁄪
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3263,7 +3263,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneCircleFill = SFSymbol(rawValue: "iphone.circle.fill")
+    static var iphoneCircleFill: SFSymbol { .init(rawValue: "iphone.circle.fill") }
 
     /// 􁄥
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3278,7 +3278,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1Circle")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1Circle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1Circle")
-    static let iphoneHomebuttonCircle = SFSymbol(rawValue: "iphone.homebutton.circle")
+    static var iphoneHomebuttonCircle: SFSymbol { .init(rawValue: "iphone.homebutton.circle") }
 
     /// 􁄦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3294,7 +3294,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1CircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1CircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1CircleFill")
-    static let iphoneHomebuttonCircleFill = SFSymbol(rawValue: "iphone.homebutton.circle.fill")
+    static var iphoneHomebuttonCircleFill: SFSymbol { .init(rawValue: "iphone.homebutton.circle.fill") }
 
     /// 􁅚
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3310,7 +3310,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1RadiowavesLeftAndRightCircle")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1RadiowavesLeftAndRightCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1RadiowavesLeftAndRightCircle")
-    static let iphoneHomebuttonRadiowavesLeftAndRightCircle = SFSymbol(rawValue: "iphone.homebutton.radiowaves.left.and.right.circle")
+    static var iphoneHomebuttonRadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "iphone.homebutton.radiowaves.left.and.right.circle") }
 
     /// 􁅛
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3326,7 +3326,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1RadiowavesLeftAndRightCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1RadiowavesLeftAndRightCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1RadiowavesLeftAndRightCircleFill")
-    static let iphoneHomebuttonRadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "iphone.homebutton.radiowaves.left.and.right.circle.fill")
+    static var iphoneHomebuttonRadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "iphone.homebutton.radiowaves.left.and.right.circle.fill") }
 
     /// 􁄧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3341,7 +3341,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1SlashCircle")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1SlashCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1SlashCircle")
-    static let iphoneHomebuttonSlashCircle = SFSymbol(rawValue: "iphone.homebutton.slash.circle")
+    static var iphoneHomebuttonSlashCircle: SFSymbol { .init(rawValue: "iphone.homebutton.slash.circle") }
 
     /// 􁄨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3357,7 +3357,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.1, renamed: "iphoneGen1SlashCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 9.1, renamed: "iphoneGen1SlashCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "iphoneGen1SlashCircleFill")
-    static let iphoneHomebuttonSlashCircleFill = SFSymbol(rawValue: "iphone.homebutton.slash.circle.fill")
+    static var iphoneHomebuttonSlashCircleFill: SFSymbol { .init(rawValue: "iphone.homebutton.slash.circle.fill") }
 
     /// 􁅜
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3368,7 +3368,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneRadiowavesLeftAndRightCircle = SFSymbol(rawValue: "iphone.radiowaves.left.and.right.circle")
+    static var iphoneRadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "iphone.radiowaves.left.and.right.circle") }
 
     /// 􁅝
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3379,7 +3379,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneRadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "iphone.radiowaves.left.and.right.circle.fill")
+    static var iphoneRadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "iphone.radiowaves.left.and.right.circle.fill") }
 
     /// 􀾖
     /// Single Localization, 2 Layersets
@@ -3387,7 +3387,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphoneRearCamera = SFSymbol(rawValue: "iphone.rear.camera")
+    static var iphoneRearCamera: SFSymbol { .init(rawValue: "iphone.rear.camera") }
 
     /// 􁄫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3397,7 +3397,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneSlashCircle = SFSymbol(rawValue: "iphone.slash.circle")
+    static var iphoneSlashCircle: SFSymbol { .init(rawValue: "iphone.slash.circle") }
 
     /// 􁄬
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3408,7 +3408,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneSlashCircleFill = SFSymbol(rawValue: "iphone.slash.circle.fill")
+    static var iphoneSlashCircleFill: SFSymbol { .init(rawValue: "iphone.slash.circle.fill") }
 
     /// 􀺐
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3419,7 +3419,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone Smart Battery Case.
-    static let iphoneSmartbatterycaseGen1 = SFSymbol(rawValue: "iphone.smartbatterycase.gen1")
+    static var iphoneSmartbatterycaseGen1: SFSymbol { .init(rawValue: "iphone.smartbatterycase.gen1") }
 
     /// 􀺏
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3430,7 +3430,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone Smart Battery Case.
-    static let iphoneSmartbatterycaseGen2 = SFSymbol(rawValue: "iphone.smartbatterycase.gen2")
+    static var iphoneSmartbatterycaseGen2: SFSymbol { .init(rawValue: "iphone.smartbatterycase.gen2") }
 
     /// 􁂲
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3445,7 +3445,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "ipodTouchSlash")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "ipodTouchSlash")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipodTouchSlash")
-    static let ipodtouchSlash = SFSymbol(rawValue: "ipodtouch.slash")
+    static var ipodtouchSlash: SFSymbol { .init(rawValue: "ipodtouch.slash") }
 
     /// 􀼍
     /// Single Localization, 3 Layersets
@@ -3454,7 +3454,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ivfluidBag = SFSymbol(rawValue: "ivfluid.bag")
+    static var ivfluidBag: SFSymbol { .init(rawValue: "ivfluid.bag") }
 
     /// 􀼎
     /// Single Localization, 3 Layersets
@@ -3463,7 +3463,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let ivfluidBagFill = SFSymbol(rawValue: "ivfluid.bag.fill")
+    static var ivfluidBagFill: SFSymbol { .init(rawValue: "ivfluid.bag.fill") }
 
     /// 􀭛
     /// Single Localization, 3 Layersets
@@ -3472,14 +3472,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let jSquareOnSquareFill = SFSymbol(rawValue: "j.square.on.square.fill")
+    static var jSquareOnSquareFill: SFSymbol { .init(rawValue: "j.square.on.square.fill") }
 
     /// 􀺑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardFill = SFSymbol(rawValue: "keyboard.fill")
+    static var keyboardFill: SFSymbol { .init(rawValue: "keyboard.fill") }
 
     /// 􀦔
     /// Single Localization, 2 Layersets
@@ -3487,7 +3487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickPressDown = SFSymbol(rawValue: "l.joystick.press.down")
+    static var lJoystickPressDown: SFSymbol { .init(rawValue: "l.joystick.press.down") }
 
     /// 􀫃
     /// Single Localization, 3 Layersets
@@ -3496,7 +3496,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lJoystickPressDownFill = SFSymbol(rawValue: "l.joystick.press.down.fill")
+    static var lJoystickPressDownFill: SFSymbol { .init(rawValue: "l.joystick.press.down.fill") }
 
     /// 􀿜
     /// Single Localization, 2 Layersets
@@ -3504,7 +3504,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltDown = SFSymbol(rawValue: "l.joystick.tilt.down")
+    static var lJoystickTiltDown: SFSymbol { .init(rawValue: "l.joystick.tilt.down") }
 
     /// 􀿝
     /// Single Localization, 2 Layersets
@@ -3512,7 +3512,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltDownFill = SFSymbol(rawValue: "l.joystick.tilt.down.fill")
+    static var lJoystickTiltDownFill: SFSymbol { .init(rawValue: "l.joystick.tilt.down.fill") }
 
     /// 􀿖
     /// Single Localization, 2 Layersets
@@ -3520,7 +3520,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltLeft = SFSymbol(rawValue: "l.joystick.tilt.left")
+    static var lJoystickTiltLeft: SFSymbol { .init(rawValue: "l.joystick.tilt.left") }
 
     /// 􀿗
     /// Single Localization, 2 Layersets
@@ -3528,7 +3528,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltLeftFill = SFSymbol(rawValue: "l.joystick.tilt.left.fill")
+    static var lJoystickTiltLeftFill: SFSymbol { .init(rawValue: "l.joystick.tilt.left.fill") }
 
     /// 􀿘
     /// Single Localization, 2 Layersets
@@ -3536,7 +3536,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltRight = SFSymbol(rawValue: "l.joystick.tilt.right")
+    static var lJoystickTiltRight: SFSymbol { .init(rawValue: "l.joystick.tilt.right") }
 
     /// 􀿙
     /// Single Localization, 2 Layersets
@@ -3544,7 +3544,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltRightFill = SFSymbol(rawValue: "l.joystick.tilt.right.fill")
+    static var lJoystickTiltRightFill: SFSymbol { .init(rawValue: "l.joystick.tilt.right.fill") }
 
     /// 􀿚
     /// Single Localization, 2 Layersets
@@ -3552,7 +3552,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltUp = SFSymbol(rawValue: "l.joystick.tilt.up")
+    static var lJoystickTiltUp: SFSymbol { .init(rawValue: "l.joystick.tilt.up") }
 
     /// 􀿛
     /// Single Localization, 2 Layersets
@@ -3560,21 +3560,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lJoystickTiltUpFill = SFSymbol(rawValue: "l.joystick.tilt.up.fill")
+    static var lJoystickTiltUpFill: SFSymbol { .init(rawValue: "l.joystick.tilt.up.fill") }
 
     /// 􀰵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lanyardcard = SFSymbol(rawValue: "lanyardcard")
+    static var lanyardcard: SFSymbol { .init(rawValue: "lanyardcard") }
 
     /// 􀰶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lanyardcardFill = SFSymbol(rawValue: "lanyardcard.fill")
+    static var lanyardcardFill: SFSymbol { .init(rawValue: "lanyardcard.fill") }
 
     /// 􀶿
     /// Single Localization, 2 Layersets
@@ -3582,7 +3582,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let laptopcomputerAndArrowDown = SFSymbol(rawValue: "laptopcomputer.and.arrow.down")
+    static var laptopcomputerAndArrowDown: SFSymbol { .init(rawValue: "laptopcomputer.and.arrow.down") }
 
     /// 􁃂
     /// Single Localization, 3 Layersets
@@ -3591,7 +3591,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let laptopcomputerTrianglebadgeExclamationmark = SFSymbol(rawValue: "laptopcomputer.trianglebadge.exclamationmark")
+    static var laptopcomputerTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "laptopcomputer.trianglebadge.exclamationmark") }
 
     /// 􀣳
     /// Single Localization, 2 Layersets
@@ -3604,7 +3604,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "lassoBadgeSparkles")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "lassoBadgeSparkles")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "lassoBadgeSparkles")
-    static let lassoAndSparkles = SFSymbol(rawValue: "lasso.and.sparkles")
+    static var lassoAndSparkles: SFSymbol { .init(rawValue: "lasso.and.sparkles") }
 
     /// 􁂬
     /// Single Localization, 3 Layersets
@@ -3613,7 +3613,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let leafCircle = SFSymbol(rawValue: "leaf.circle")
+    static var leafCircle: SFSymbol { .init(rawValue: "leaf.circle") }
 
     /// 􁂭
     /// Single Localization, 3 Layersets
@@ -3622,7 +3622,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let leafCircleFill = SFSymbol(rawValue: "leaf.circle.fill")
+    static var leafCircleFill: SFSymbol { .init(rawValue: "leaf.circle.fill") }
 
     /// 􁇖
     /// Single Localization, 2 Layersets
@@ -3630,7 +3630,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulbCircle = SFSymbol(rawValue: "lightbulb.circle")
+    static var lightbulbCircle: SFSymbol { .init(rawValue: "lightbulb.circle") }
 
     /// 􁇗
     /// Single Localization, 3 Layersets
@@ -3639,7 +3639,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let lightbulbCircleFill = SFSymbol(rawValue: "lightbulb.circle.fill")
+    static var lightbulbCircleFill: SFSymbol { .init(rawValue: "lightbulb.circle.fill") }
 
     /// 􀘵
     /// Single Localization, 2 Layersets
@@ -3647,7 +3647,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let line2HorizontalDecreaseCircle = SFSymbol(rawValue: "line.2.horizontal.decrease.circle")
+    static var line2HorizontalDecreaseCircle: SFSymbol { .init(rawValue: "line.2.horizontal.decrease.circle") }
 
     /// 􀘶
     /// Single Localization, 3 Layersets
@@ -3656,14 +3656,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let line2HorizontalDecreaseCircleFill = SFSymbol(rawValue: "line.2.horizontal.decrease.circle.fill")
+    static var line2HorizontalDecreaseCircleFill: SFSymbol { .init(rawValue: "line.2.horizontal.decrease.circle.fill") }
 
     /// 􀌇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let line3Horizontal = SFSymbol(rawValue: "line.3.horizontal")
+    static var line3Horizontal: SFSymbol { .init(rawValue: "line.3.horizontal") }
 
     /// 􀧱
     /// Single Localization, 2 Layersets
@@ -3671,7 +3671,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let line3HorizontalCircle = SFSymbol(rawValue: "line.3.horizontal.circle")
+    static var line3HorizontalCircle: SFSymbol { .init(rawValue: "line.3.horizontal.circle") }
 
     /// 􀧲
     /// Single Localization, 3 Layersets
@@ -3680,14 +3680,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let line3HorizontalCircleFill = SFSymbol(rawValue: "line.3.horizontal.circle.fill")
+    static var line3HorizontalCircleFill: SFSymbol { .init(rawValue: "line.3.horizontal.circle.fill") }
 
     /// 􀜓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let line3HorizontalDecrease = SFSymbol(rawValue: "line.3.horizontal.decrease")
+    static var line3HorizontalDecrease: SFSymbol { .init(rawValue: "line.3.horizontal.decrease") }
 
     /// 􀌈
     /// Single Localization, 2 Layersets
@@ -3695,7 +3695,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let line3HorizontalDecreaseCircle = SFSymbol(rawValue: "line.3.horizontal.decrease.circle")
+    static var line3HorizontalDecreaseCircle: SFSymbol { .init(rawValue: "line.3.horizontal.decrease.circle") }
 
     /// 􀌉
     /// Single Localization, 3 Layersets
@@ -3704,7 +3704,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let line3HorizontalDecreaseCircleFill = SFSymbol(rawValue: "line.3.horizontal.decrease.circle.fill")
+    static var line3HorizontalDecreaseCircleFill: SFSymbol { .init(rawValue: "line.3.horizontal.decrease.circle.fill") }
 
     /// 􀰬
     /// Single Localization, 3 Layersets
@@ -3713,7 +3713,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let linesMeasurementHorizontal = SFSymbol(rawValue: "lines.measurement.horizontal")
+    static var linesMeasurementHorizontal: SFSymbol { .init(rawValue: "lines.measurement.horizontal") }
 
     /// 􀻧
     /// Single Localization, 2 Layersets
@@ -3721,7 +3721,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let listBulletCircle = SFSymbol(rawValue: "list.bullet.circle")
+    static var listBulletCircle: SFSymbol { .init(rawValue: "list.bullet.circle") }
 
     /// 􀻨
     /// Single Localization, 3 Layersets
@@ -3730,7 +3730,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listBulletCircleFill = SFSymbol(rawValue: "list.bullet.circle.fill")
+    static var listBulletCircleFill: SFSymbol { .init(rawValue: "list.bullet.circle.fill") }
 
     /// 􀺿
     /// Single Localization, 3 Layersets
@@ -3739,7 +3739,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let listBulletRectangleFill = SFSymbol(rawValue: "list.bullet.rectangle.fill")
+    static var listBulletRectangleFill: SFSymbol { .init(rawValue: "list.bullet.rectangle.fill") }
 
     /// 􀹲
     /// Single Localization, 2 Layersets
@@ -3747,7 +3747,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let listBulletRectanglePortrait = SFSymbol(rawValue: "list.bullet.rectangle.portrait")
+    static var listBulletRectanglePortrait: SFSymbol { .init(rawValue: "list.bullet.rectangle.portrait") }
 
     /// 􀹳
     /// Single Localization, 3 Layersets
@@ -3756,7 +3756,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let listBulletRectanglePortraitFill = SFSymbol(rawValue: "list.bullet.rectangle.portrait.fill")
+    static var listBulletRectanglePortraitFill: SFSymbol { .init(rawValue: "list.bullet.rectangle.portrait.fill") }
 
     /// 􀹆
     /// Single Localization, 2 Layersets
@@ -3764,7 +3764,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let listDashHeaderRectangle = SFSymbol(rawValue: "list.dash.header.rectangle")
+    static var listDashHeaderRectangle: SFSymbol { .init(rawValue: "list.dash.header.rectangle") }
 
     /// 􁈟
     /// Single Localization, 2 Layersets
@@ -3772,7 +3772,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let locationMagnifyingglass = SFSymbol(rawValue: "location.magnifyingglass")
+    static var locationMagnifyingglass: SFSymbol { .init(rawValue: "location.magnifyingglass") }
 
     /// 􀷌
     /// Single Localization, 3 Layersets
@@ -3781,7 +3781,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationNorthCircle = SFSymbol(rawValue: "location.north.circle")
+    static var locationNorthCircle: SFSymbol { .init(rawValue: "location.north.circle") }
 
     /// 􀷍
     /// Single Localization, 3 Layersets
@@ -3790,7 +3790,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationNorthCircleFill = SFSymbol(rawValue: "location.north.circle.fill")
+    static var locationNorthCircleFill: SFSymbol { .init(rawValue: "location.north.circle.fill") }
 
     /// 􀼻
     /// Single Localization, 3 Layersets
@@ -3799,7 +3799,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationSquare = SFSymbol(rawValue: "location.square")
+    static var locationSquare: SFSymbol { .init(rawValue: "location.square") }
 
     /// 􀼼
     /// Single Localization, 3 Layersets
@@ -3808,7 +3808,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationSquareFill = SFSymbol(rawValue: "location.square.fill")
+    static var locationSquareFill: SFSymbol { .init(rawValue: "location.square.fill") }
 
     /// 􀼒
     /// Single Localization, 2 Layersets
@@ -3816,7 +3816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockDesktopcomputer = SFSymbol(rawValue: "lock.desktopcomputer")
+    static var lockDesktopcomputer: SFSymbol { .init(rawValue: "lock.desktopcomputer") }
 
     /// 􀼑
     /// Single Localization, 2 Layersets
@@ -3824,7 +3824,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockDisplay = SFSymbol(rawValue: "lock.display")
+    static var lockDisplay: SFSymbol { .init(rawValue: "lock.display") }
 
     /// 􀼕
     /// Single Localization, 2 Layersets
@@ -3832,7 +3832,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockIpad = SFSymbol(rawValue: "lock.ipad")
+    static var lockIpad: SFSymbol { .init(rawValue: "lock.ipad") }
 
     /// 􀼔
     /// Single Localization, 2 Layersets
@@ -3840,7 +3840,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockIphone = SFSymbol(rawValue: "lock.iphone")
+    static var lockIphone: SFSymbol { .init(rawValue: "lock.iphone") }
 
     /// 􀼓
     /// Single Localization, 2 Layersets
@@ -3848,7 +3848,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockLaptopcomputer = SFSymbol(rawValue: "lock.laptopcomputer")
+    static var lockLaptopcomputer: SFSymbol { .init(rawValue: "lock.laptopcomputer") }
 
     /// 􀼡
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3858,7 +3858,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let lockOpenApplewatch = SFSymbol(rawValue: "lock.open.applewatch")
+    static var lockOpenApplewatch: SFSymbol { .init(rawValue: "lock.open.applewatch") }
 
     /// 􀼝
     /// Single Localization, 2 Layersets
@@ -3866,7 +3866,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenDesktopcomputer = SFSymbol(rawValue: "lock.open.desktopcomputer")
+    static var lockOpenDesktopcomputer: SFSymbol { .init(rawValue: "lock.open.desktopcomputer") }
 
     /// 􀼜
     /// Single Localization, 2 Layersets
@@ -3874,7 +3874,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenDisplay = SFSymbol(rawValue: "lock.open.display")
+    static var lockOpenDisplay: SFSymbol { .init(rawValue: "lock.open.display") }
 
     /// 􀼠
     /// Single Localization, 2 Layersets
@@ -3882,7 +3882,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenIpad = SFSymbol(rawValue: "lock.open.ipad")
+    static var lockOpenIpad: SFSymbol { .init(rawValue: "lock.open.ipad") }
 
     /// 􀼟
     /// Single Localization, 2 Layersets
@@ -3890,7 +3890,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenIphone = SFSymbol(rawValue: "lock.open.iphone")
+    static var lockOpenIphone: SFSymbol { .init(rawValue: "lock.open.iphone") }
 
     /// 􀼞
     /// Single Localization, 2 Layersets
@@ -3898,7 +3898,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenLaptopcomputer = SFSymbol(rawValue: "lock.open.laptopcomputer")
+    static var lockOpenLaptopcomputer: SFSymbol { .init(rawValue: "lock.open.laptopcomputer") }
 
     /// 􀾈
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3912,7 +3912,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "playstationLogo")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "playstationLogo")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "playstationLogo")
-    static let logoPlaystation = SFSymbol(rawValue: "logo.playstation")
+    static var logoPlaystation: SFSymbol { .init(rawValue: "logo.playstation") }
 
     /// 􀾉
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3926,7 +3926,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "xboxLogo")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "xboxLogo")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "xboxLogo")
-    static let logoXbox = SFSymbol(rawValue: "logo.xbox")
+    static var logoXbox: SFSymbol { .init(rawValue: "logo.xbox") }
 
     /// 􀼢
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3935,7 +3935,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen1Fill = SFSymbol(rawValue: "macpro.gen1.fill")
+    static var macproGen1Fill: SFSymbol { .init(rawValue: "macpro.gen1.fill") }
 
     /// 􀼣
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3944,21 +3944,21 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen3Fill = SFSymbol(rawValue: "macpro.gen3.fill")
+    static var macproGen3Fill: SFSymbol { .init(rawValue: "macpro.gen3.fill") }
 
     /// 􁂾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let magazine = SFSymbol(rawValue: "magazine")
+    static var magazine: SFSymbol { .init(rawValue: "magazine") }
 
     /// 􁂿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let magazineFill = SFSymbol(rawValue: "magazine.fill")
+    static var magazineFill: SFSymbol { .init(rawValue: "magazine.fill") }
 
     /// 􀺰
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3967,7 +3967,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Magic Mouse.
-    static let magicmouse = SFSymbol(rawValue: "magicmouse")
+    static var magicmouse: SFSymbol { .init(rawValue: "magicmouse") }
 
     /// 􀺱
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3976,7 +3976,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Magic Mouse.
-    static let magicmouseFill = SFSymbol(rawValue: "magicmouse.fill")
+    static var magicmouseFill: SFSymbol { .init(rawValue: "magicmouse.fill") }
 
     /// 􀺓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3986,7 +3986,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MagSafe Battery Pack.
-    static let magsafeBatterypack = SFSymbol(rawValue: "magsafe.batterypack")
+    static var magsafeBatterypack: SFSymbol { .init(rawValue: "magsafe.batterypack") }
 
     /// 􀺔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3996,7 +3996,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MagSafe Battery Pack.
-    static let magsafeBatterypackFill = SFSymbol(rawValue: "magsafe.batterypack.fill")
+    static var magsafeBatterypackFill: SFSymbol { .init(rawValue: "magsafe.batterypack.fill") }
 
     /// 􀻫
     /// Single Localization, 2 Layersets
@@ -4004,7 +4004,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mapCircle = SFSymbol(rawValue: "map.circle")
+    static var mapCircle: SFSymbol { .init(rawValue: "map.circle") }
 
     /// 􀻬
     /// Single Localization, 3 Layersets
@@ -4013,7 +4013,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mapCircleFill = SFSymbol(rawValue: "map.circle.fill")
+    static var mapCircleFill: SFSymbol { .init(rawValue: "map.circle.fill") }
 
     /// 􁇯
     /// Single Localization, 3 Layersets
@@ -4022,7 +4022,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let mappinSlashCircle = SFSymbol(rawValue: "mappin.slash.circle")
+    static var mappinSlashCircle: SFSymbol { .init(rawValue: "mappin.slash.circle") }
 
     /// 􁇰
     /// Single Localization, 3 Layersets
@@ -4031,7 +4031,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let mappinSlashCircleFill = SFSymbol(rawValue: "mappin.slash.circle.fill")
+    static var mappinSlashCircleFill: SFSymbol { .init(rawValue: "mappin.slash.circle.fill") }
 
     /// 􀽕
     /// Single Localization, 3 Layersets
@@ -4040,7 +4040,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mappinSquare = SFSymbol(rawValue: "mappin.square")
+    static var mappinSquare: SFSymbol { .init(rawValue: "mappin.square") }
 
     /// 􀽖
     /// Single Localization, 3 Layersets
@@ -4049,7 +4049,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mappinSquareFill = SFSymbol(rawValue: "mappin.square.fill")
+    static var mappinSquareFill: SFSymbol { .init(rawValue: "mappin.square.fill") }
 
     /// 􀺥
     /// Single Localization, 2 Layersets
@@ -4057,21 +4057,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mediastick = SFSymbol(rawValue: "mediastick")
+    static var mediastick: SFSymbol { .init(rawValue: "mediastick") }
 
     /// 􀧖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let memorychipFill = SFSymbol(rawValue: "memorychip.fill")
+    static var memorychipFill: SFSymbol { .init(rawValue: "memorychip.fill") }
 
     /// 􀻒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let menucard = SFSymbol(rawValue: "menucard")
+    static var menucard: SFSymbol { .init(rawValue: "menucard") }
 
     /// 􀻓
     /// Single Localization, 2 Layersets
@@ -4079,7 +4079,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let menucardFill = SFSymbol(rawValue: "menucard.fill")
+    static var menucardFill: SFSymbol { .init(rawValue: "menucard.fill") }
 
     /// 􀼁
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4095,7 +4095,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "messageBadgeWaveform")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "messageBadgeWaveform")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "messageBadgeWaveform")
-    static let messageAndWaveform = SFSymbol(rawValue: "message.and.waveform")
+    static var messageAndWaveform: SFSymbol { .init(rawValue: "message.and.waveform") }
 
     /// 􀼂
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4111,7 +4111,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "messageBadgeWaveformFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "messageBadgeWaveformFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "messageBadgeWaveformFill")
-    static let messageAndWaveformFill = SFSymbol(rawValue: "message.and.waveform.fill")
+    static var messageAndWaveformFill: SFSymbol { .init(rawValue: "message.and.waveform.fill") }
 
     /// 􀺁
     /// Single Localization, 3 Layersets
@@ -4125,7 +4125,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneBadgePlus")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneBadgePlus")
-    static let micBadgePlus = SFSymbol(rawValue: "mic.badge.plus")
+    static var micBadgePlus: SFSymbol { .init(rawValue: "mic.badge.plus") }
 
     /// 􀺂
     /// Single Localization, 3 Layersets
@@ -4139,7 +4139,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneBadgePlusFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneBadgePlusFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneBadgePlusFill")
-    static let micFillBadgePlus = SFSymbol(rawValue: "mic.fill.badge.plus")
+    static var micFillBadgePlus: SFSymbol { .init(rawValue: "mic.fill.badge.plus") }
 
     /// 􀻩
     /// Single Localization, 3 Layersets
@@ -4153,7 +4153,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneSlashCircle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneSlashCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSlashCircle")
-    static let micSlashCircle = SFSymbol(rawValue: "mic.slash.circle")
+    static var micSlashCircle: SFSymbol { .init(rawValue: "mic.slash.circle") }
 
     /// 􀻪
     /// Single Localization, 3 Layersets
@@ -4167,7 +4167,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneSlashCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneSlashCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSlashCircleFill")
-    static let micSlashCircleFill = SFSymbol(rawValue: "mic.slash.circle.fill")
+    static var micSlashCircleFill: SFSymbol { .init(rawValue: "mic.slash.circle.fill") }
 
     /// 􀼿
     /// Single Localization, 3 Layersets
@@ -4181,7 +4181,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneSquare")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSquare")
-    static let micSquare = SFSymbol(rawValue: "mic.square")
+    static var micSquare: SFSymbol { .init(rawValue: "mic.square") }
 
     /// 􀽀
     /// Single Localization, 3 Layersets
@@ -4195,14 +4195,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "microphoneSquareFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "microphoneSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneSquareFill")
-    static let micSquareFill = SFSymbol(rawValue: "mic.square.fill")
+    static var micSquareFill: SFSymbol { .init(rawValue: "mic.square.fill") }
 
     /// 􀅻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let minusForwardslashPlus = SFSymbol(rawValue: "minus.forwardslash.plus")
+    static var minusForwardslashPlus: SFSymbol { .init(rawValue: "minus.forwardslash.plus") }
 
     /// 􁁑
     /// Single Localization, 2 Layersets
@@ -4215,7 +4215,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "musicMicrophoneCircle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "musicMicrophoneCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "musicMicrophoneCircle")
-    static let musicMicCircle = SFSymbol(rawValue: "music.mic.circle")
+    static var musicMicCircle: SFSymbol { .init(rawValue: "music.mic.circle") }
 
     /// 􁁒
     /// Single Localization, 3 Layersets
@@ -4229,7 +4229,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "musicMicrophoneCircleFill")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "musicMicrophoneCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "musicMicrophoneCircleFill")
-    static let musicMicCircleFill = SFSymbol(rawValue: "music.mic.circle.fill")
+    static var musicMicCircleFill: SFSymbol { .init(rawValue: "music.mic.circle.fill") }
 
     /// 􀎵
     /// Single Localization, 2 Layersets
@@ -4237,7 +4237,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicNoteTv = SFSymbol(rawValue: "music.note.tv")
+    static var musicNoteTv: SFSymbol { .init(rawValue: "music.note.tv") }
 
     /// 􀒷
     /// Single Localization, 3 Layersets
@@ -4246,7 +4246,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let musicNoteTvFill = SFSymbol(rawValue: "music.note.tv.fill")
+    static var musicNoteTvFill: SFSymbol { .init(rawValue: "music.note.tv.fill") }
 
     /// 􁅏
     /// Single Localization, 2 Layersets
@@ -4254,7 +4254,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let networkBadgeShieldHalfFilled = SFSymbol(rawValue: "network.badge.shield.half.filled")
+    static var networkBadgeShieldHalfFilled: SFSymbol { .init(rawValue: "network.badge.shield.half.filled") }
 
     /// 􁆴
     /// Single Localization, 2 Layersets
@@ -4262,7 +4262,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let newspaperCircle = SFSymbol(rawValue: "newspaper.circle")
+    static var newspaperCircle: SFSymbol { .init(rawValue: "newspaper.circle") }
 
     /// 􁆵
     /// Single Localization, 3 Layersets
@@ -4271,42 +4271,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let newspaperCircleFill = SFSymbol(rawValue: "newspaper.circle.fill")
+    static var newspaperCircleFill: SFSymbol { .init(rawValue: "newspaper.circle.fill") }
 
     /// 􁀽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagonBottomhalfFilled = SFSymbol(rawValue: "octagon.bottomhalf.filled")
+    static var octagonBottomhalfFilled: SFSymbol { .init(rawValue: "octagon.bottomhalf.filled") }
 
     /// 􁀇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagonLefthalfFilled = SFSymbol(rawValue: "octagon.lefthalf.filled")
+    static var octagonLefthalfFilled: SFSymbol { .init(rawValue: "octagon.lefthalf.filled") }
 
     /// 􁀈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagonRighthalfFilled = SFSymbol(rawValue: "octagon.righthalf.filled")
+    static var octagonRighthalfFilled: SFSymbol { .init(rawValue: "octagon.righthalf.filled") }
 
     /// 􁀼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let octagonTophalfFilled = SFSymbol(rawValue: "octagon.tophalf.filled")
+    static var octagonTophalfFilled: SFSymbol { .init(rawValue: "octagon.tophalf.filled") }
 
     /// 􀿾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalBottomhalfFilled = SFSymbol(rawValue: "oval.bottomhalf.filled")
+    static var ovalBottomhalfFilled: SFSymbol { .init(rawValue: "oval.bottomhalf.filled") }
 
     /// 􀾜
     /// Single Localization, 2 Layersets
@@ -4319,21 +4319,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledOval")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledOval")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledOval")
-    static let ovalInsetFilled = SFSymbol(rawValue: "oval.inset.filled")
+    static var ovalInsetFilled: SFSymbol { .init(rawValue: "oval.inset.filled") }
 
     /// 􀿻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalLefthalfFilled = SFSymbol(rawValue: "oval.lefthalf.filled")
+    static var ovalLefthalfFilled: SFSymbol { .init(rawValue: "oval.lefthalf.filled") }
 
     /// 􁀂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortraitBottomhalfFilled = SFSymbol(rawValue: "oval.portrait.bottomhalf.filled")
+    static var ovalPortraitBottomhalfFilled: SFSymbol { .init(rawValue: "oval.portrait.bottomhalf.filled") }
 
     /// 􀾝
     /// Single Localization, 2 Layersets
@@ -4346,56 +4346,56 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledOvalPortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledOvalPortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledOvalPortrait")
-    static let ovalPortraitInsetFilled = SFSymbol(rawValue: "oval.portrait.inset.filled")
+    static var ovalPortraitInsetFilled: SFSymbol { .init(rawValue: "oval.portrait.inset.filled") }
 
     /// 􀿿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortraitLefthalfFilled = SFSymbol(rawValue: "oval.portrait.lefthalf.filled")
+    static var ovalPortraitLefthalfFilled: SFSymbol { .init(rawValue: "oval.portrait.lefthalf.filled") }
 
     /// 􁀀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortraitRighthalfFilled = SFSymbol(rawValue: "oval.portrait.righthalf.filled")
+    static var ovalPortraitRighthalfFilled: SFSymbol { .init(rawValue: "oval.portrait.righthalf.filled") }
 
     /// 􁀁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalPortraitTophalfFilled = SFSymbol(rawValue: "oval.portrait.tophalf.filled")
+    static var ovalPortraitTophalfFilled: SFSymbol { .init(rawValue: "oval.portrait.tophalf.filled") }
 
     /// 􀿼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalRighthalfFilled = SFSymbol(rawValue: "oval.righthalf.filled")
+    static var ovalRighthalfFilled: SFSymbol { .init(rawValue: "oval.righthalf.filled") }
 
     /// 􀿽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovalTophalfFilled = SFSymbol(rawValue: "oval.tophalf.filled")
+    static var ovalTophalfFilled: SFSymbol { .init(rawValue: "oval.tophalf.filled") }
 
     /// 􀸏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let parentheses = SFSymbol(rawValue: "parentheses")
+    static var parentheses: SFSymbol { .init(rawValue: "parentheses") }
 
     /// 􀵢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let parkingsign = SFSymbol(rawValue: "parkingsign")
+    static var parkingsign: SFSymbol { .init(rawValue: "parkingsign") }
 
     /// 􀷁
     /// Single Localization, 2 Layersets
@@ -4403,7 +4403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignCircle = SFSymbol(rawValue: "parkingsign.circle")
+    static var parkingsignCircle: SFSymbol { .init(rawValue: "parkingsign.circle") }
 
     /// 􀷂
     /// Single Localization, 3 Layersets
@@ -4412,14 +4412,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let parkingsignCircleFill = SFSymbol(rawValue: "parkingsign.circle.fill")
+    static var parkingsignCircleFill: SFSymbol { .init(rawValue: "parkingsign.circle.fill") }
 
     /// 􀾞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pawprint = SFSymbol(rawValue: "pawprint")
+    static var pawprint: SFSymbol { .init(rawValue: "pawprint") }
 
     /// 􁂰
     /// Single Localization, 2 Layersets
@@ -4427,7 +4427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pawprintCircle = SFSymbol(rawValue: "pawprint.circle")
+    static var pawprintCircle: SFSymbol { .init(rawValue: "pawprint.circle") }
 
     /// 􁂱
     /// Single Localization, 3 Layersets
@@ -4436,70 +4436,70 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pawprintCircleFill = SFSymbol(rawValue: "pawprint.circle.fill")
+    static var pawprintCircleFill: SFSymbol { .init(rawValue: "pawprint.circle.fill") }
 
     /// 􀾟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pawprintFill = SFSymbol(rawValue: "pawprint.fill")
+    static var pawprintFill: SFSymbol { .init(rawValue: "pawprint.fill") }
 
     /// 􀺎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let peacesign = SFSymbol(rawValue: "peacesign")
+    static var peacesign: SFSymbol { .init(rawValue: "peacesign") }
 
     /// 􀶺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagon = SFSymbol(rawValue: "pentagon")
+    static var pentagon: SFSymbol { .init(rawValue: "pentagon") }
 
     /// 􁀻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagonBottomhalfFilled = SFSymbol(rawValue: "pentagon.bottomhalf.filled")
+    static var pentagonBottomhalfFilled: SFSymbol { .init(rawValue: "pentagon.bottomhalf.filled") }
 
     /// 􀶻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagonFill = SFSymbol(rawValue: "pentagon.fill")
+    static var pentagonFill: SFSymbol { .init(rawValue: "pentagon.fill") }
 
     /// 􁀋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagonLefthalfFilled = SFSymbol(rawValue: "pentagon.lefthalf.filled")
+    static var pentagonLefthalfFilled: SFSymbol { .init(rawValue: "pentagon.lefthalf.filled") }
 
     /// 􁀌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagonRighthalfFilled = SFSymbol(rawValue: "pentagon.righthalf.filled")
+    static var pentagonRighthalfFilled: SFSymbol { .init(rawValue: "pentagon.righthalf.filled") }
 
     /// 􁀺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pentagonTophalfFilled = SFSymbol(rawValue: "pentagon.tophalf.filled")
+    static var pentagonTophalfFilled: SFSymbol { .init(rawValue: "pentagon.tophalf.filled") }
 
     /// 􀓥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let person2CropSquareStack = SFSymbol(rawValue: "person.2.crop.square.stack")
+    static var person2CropSquareStack: SFSymbol { .init(rawValue: "person.2.crop.square.stack") }
 
     /// 􀓦
     /// Single Localization, 3 Layersets
@@ -4508,7 +4508,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
-    static let person2CropSquareStackFill = SFSymbol(rawValue: "person.2.crop.square.stack.fill")
+    static var person2CropSquareStackFill: SFSymbol { .init(rawValue: "person.2.crop.square.stack.fill") }
 
     /// 􀾌
     /// Single Localization, 3 Layersets
@@ -4517,7 +4517,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let person2Wave2 = SFSymbol(rawValue: "person.2.wave.2")
+    static var person2Wave2: SFSymbol { .init(rawValue: "person.2.wave.2") }
 
     /// 􀾍
     /// Single Localization, 3 Layersets
@@ -4526,7 +4526,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let person2Wave2Fill = SFSymbol(rawValue: "person.2.wave.2.fill")
+    static var person2Wave2Fill: SFSymbol { .init(rawValue: "person.2.wave.2.fill") }
 
     /// 􀻷
     /// Single Localization, 3 Layersets
@@ -4535,7 +4535,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let person3Sequence = SFSymbol(rawValue: "person.3.sequence")
+    static var person3Sequence: SFSymbol { .init(rawValue: "person.3.sequence") }
 
     /// 􀻸
     /// Single Localization, 3 Layersets
@@ -4544,7 +4544,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let person3SequenceFill = SFSymbol(rawValue: "person.3.sequence.fill")
+    static var person3SequenceFill: SFSymbol { .init(rawValue: "person.3.sequence.fill") }
 
     /// 􁅖
     /// Single Localization, 3 Layersets
@@ -4553,7 +4553,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personBadgeClock = SFSymbol(rawValue: "person.badge.clock")
+    static var personBadgeClock: SFSymbol { .init(rawValue: "person.badge.clock") }
 
     /// 􁅗
     /// Single Localization, 3 Layersets
@@ -4562,7 +4562,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personBadgeClockFill = SFSymbol(rawValue: "person.badge.clock.fill")
+    static var personBadgeClockFill: SFSymbol { .init(rawValue: "person.badge.clock.fill") }
 
     /// 􀿏
     /// Single Localization, 2 Layersets
@@ -4570,7 +4570,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropArtframe = SFSymbol(rawValue: "person.crop.artframe")
+    static var personCropArtframe: SFSymbol { .init(rawValue: "person.crop.artframe") }
 
     /// 􁂛
     /// Single Localization, 3 Layersets
@@ -4579,7 +4579,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let personCropCircleBadge = SFSymbol(rawValue: "person.crop.circle.badge")
+    static var personCropCircleBadge: SFSymbol { .init(rawValue: "person.crop.circle.badge") }
 
     /// 􁅔
     /// Single Localization, 3 Layersets
@@ -4588,7 +4588,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropCircleBadgeClock = SFSymbol(rawValue: "person.crop.circle.badge.clock")
+    static var personCropCircleBadgeClock: SFSymbol { .init(rawValue: "person.crop.circle.badge.clock") }
 
     /// 􁅕
     /// Single Localization, 3 Layersets
@@ -4597,7 +4597,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropCircleBadgeClockFill = SFSymbol(rawValue: "person.crop.circle.badge.clock.fill")
+    static var personCropCircleBadgeClockFill: SFSymbol { .init(rawValue: "person.crop.circle.badge.clock.fill") }
 
     /// 􀉸
     /// Single Localization, 3 Layersets
@@ -4606,7 +4606,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let personCropCircleBadgeExclamationmarkFill = SFSymbol(rawValue: "person.crop.circle.badge.exclamationmark.fill")
+    static var personCropCircleBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "person.crop.circle.badge.exclamationmark.fill") }
 
     /// 􁂜
     /// Single Localization, 3 Layersets
@@ -4615,7 +4615,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let personCropCircleBadgeFill = SFSymbol(rawValue: "person.crop.circle.badge.fill")
+    static var personCropCircleBadgeFill: SFSymbol { .init(rawValue: "person.crop.circle.badge.fill") }
 
     /// 􁃈
     /// Single Localization, 3 Layersets
@@ -4624,7 +4624,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropCircleBadgeMoon = SFSymbol(rawValue: "person.crop.circle.badge.moon")
+    static var personCropCircleBadgeMoon: SFSymbol { .init(rawValue: "person.crop.circle.badge.moon") }
 
     /// 􁃉
     /// Single Localization, 3 Layersets
@@ -4633,7 +4633,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropCircleBadgeMoonFill = SFSymbol(rawValue: "person.crop.circle.badge.moon.fill")
+    static var personCropCircleBadgeMoonFill: SFSymbol { .init(rawValue: "person.crop.circle.badge.moon.fill") }
 
     /// 􀭾
     /// 2 Localizations, 3 Layersets
@@ -4646,14 +4646,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropCircleBadgeQuestionmarkFill = SymbolWith1Localization<Ar>(rawValue: "person.crop.circle.badge.questionmark.fill")
+    static var personCropCircleBadgeQuestionmarkFill: SymbolWith1Localization<Ar> { .init(rawValue: "person.crop.circle.badge.questionmark.fill") }
 
     /// 􀏻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personCropRectangleStack = SFSymbol(rawValue: "person.crop.rectangle.stack")
+    static var personCropRectangleStack: SFSymbol { .init(rawValue: "person.crop.rectangle.stack") }
 
     /// 􀏼
     /// Single Localization, 3 Layersets
@@ -4662,7 +4662,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
     /// - Multicolor (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
-    static let personCropRectangleStackFill = SFSymbol(rawValue: "person.crop.rectangle.stack.fill")
+    static var personCropRectangleStackFill: SFSymbol { .init(rawValue: "person.crop.rectangle.stack.fill") }
 
     /// 􀦎
     /// Single Localization, 2 Layersets
@@ -4670,7 +4670,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareFilledAndAtRectangle = SFSymbol(rawValue: "person.crop.square.filled.and.at.rectangle")
+    static var personCropSquareFilledAndAtRectangle: SFSymbol { .init(rawValue: "person.crop.square.filled.and.at.rectangle") }
 
     /// 􀿐
     /// Single Localization, 3 Layersets
@@ -4679,7 +4679,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personCropSquareFilledAndAtRectangleFill = SFSymbol(rawValue: "person.crop.square.filled.and.at.rectangle.fill")
+    static var personCropSquareFilledAndAtRectangleFill: SFSymbol { .init(rawValue: "person.crop.square.filled.and.at.rectangle.fill") }
 
     /// 􀿒
     /// Single Localization, 2 Layersets
@@ -4687,7 +4687,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personTextRectangle = SFSymbol(rawValue: "person.text.rectangle")
+    static var personTextRectangle: SFSymbol { .init(rawValue: "person.text.rectangle") }
 
     /// 􀿓
     /// Single Localization, 3 Layersets
@@ -4696,7 +4696,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personTextRectangleFill = SFSymbol(rawValue: "person.text.rectangle.fill")
+    static var personTextRectangleFill: SFSymbol { .init(rawValue: "person.text.rectangle.fill") }
 
     /// 􁅇
     /// Single Localization, 3 Layersets
@@ -4705,7 +4705,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personWave2 = SFSymbol(rawValue: "person.wave.2")
+    static var personWave2: SFSymbol { .init(rawValue: "person.wave.2") }
 
     /// 􁅈
     /// Single Localization, 3 Layersets
@@ -4714,7 +4714,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personWave2Fill = SFSymbol(rawValue: "person.wave.2.fill")
+    static var personWave2Fill: SFSymbol { .init(rawValue: "person.wave.2.fill") }
 
     /// 􁈨
     /// Single Localization, 2 Layersets
@@ -4722,7 +4722,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personalhotspotCircle = SFSymbol(rawValue: "personalhotspot.circle")
+    static var personalhotspotCircle: SFSymbol { .init(rawValue: "personalhotspot.circle") }
 
     /// 􁈩
     /// Single Localization, 3 Layersets
@@ -4731,7 +4731,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let personalhotspotCircleFill = SFSymbol(rawValue: "personalhotspot.circle.fill")
+    static var personalhotspotCircleFill: SFSymbol { .init(rawValue: "personalhotspot.circle.fill") }
 
     /// 􀼃
     /// Single Localization, 3 Layersets
@@ -4745,7 +4745,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "phoneBadgeWaveform")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "phoneBadgeWaveform")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneBadgeWaveform")
-    static let phoneAndWaveform = SFSymbol(rawValue: "phone.and.waveform")
+    static var phoneAndWaveform: SFSymbol { .init(rawValue: "phone.and.waveform") }
 
     /// 􀼄
     /// Single Localization, 3 Layersets
@@ -4759,7 +4759,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "phoneBadgeWaveformFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "phoneBadgeWaveformFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "phoneBadgeWaveformFill")
-    static let phoneAndWaveformFill = SFSymbol(rawValue: "phone.and.waveform.fill")
+    static var phoneAndWaveformFill: SFSymbol { .init(rawValue: "phone.and.waveform.fill") }
 
     /// 􁀶
     /// Single Localization, 2 Layersets
@@ -4767,7 +4767,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoArtframe = SFSymbol(rawValue: "photo.artframe")
+    static var photoArtframe: SFSymbol { .init(rawValue: "photo.artframe") }
 
     /// 􁂮
     /// Single Localization, 2 Layersets
@@ -4775,7 +4775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoCircle = SFSymbol(rawValue: "photo.circle")
+    static var photoCircle: SFSymbol { .init(rawValue: "photo.circle") }
 
     /// 􁂯
     /// Single Localization, 3 Layersets
@@ -4784,7 +4784,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let photoCircleFill = SFSymbol(rawValue: "photo.circle.fill")
+    static var photoCircleFill: SFSymbol { .init(rawValue: "photo.circle.fill") }
 
     /// 􁇂
     /// Single Localization, 3 Layersets
@@ -4793,7 +4793,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pillsCircle = SFSymbol(rawValue: "pills.circle")
+    static var pillsCircle: SFSymbol { .init(rawValue: "pills.circle") }
 
     /// 􁇃
     /// Single Localization, 3 Layersets
@@ -4802,7 +4802,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let pillsCircleFill = SFSymbol(rawValue: "pills.circle.fill")
+    static var pillsCircleFill: SFSymbol { .init(rawValue: "pills.circle.fill") }
 
     /// 􀽋
     /// Single Localization, 3 Layersets
@@ -4811,7 +4811,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pinSquare = SFSymbol(rawValue: "pin.square")
+    static var pinSquare: SFSymbol { .init(rawValue: "pin.square") }
 
     /// 􀽌
     /// Single Localization, 3 Layersets
@@ -4820,7 +4820,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pinSquareFill = SFSymbol(rawValue: "pin.square.fill")
+    static var pinSquareFill: SFSymbol { .init(rawValue: "pin.square.fill") }
 
     /// 􁁍
     /// Single Localization, 2 Layersets
@@ -4828,7 +4828,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platter2FilledIpad = SFSymbol(rawValue: "platter.2.filled.ipad")
+    static var platter2FilledIpad: SFSymbol { .init(rawValue: "platter.2.filled.ipad") }
 
     /// 􁁎
     /// Single Localization, 2 Layersets
@@ -4836,7 +4836,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platter2FilledIpadLandscape = SFSymbol(rawValue: "platter.2.filled.ipad.landscape")
+    static var platter2FilledIpadLandscape: SFSymbol { .init(rawValue: "platter.2.filled.ipad.landscape") }
 
     /// 􀾩
     /// Single Localization, 2 Layersets
@@ -4844,7 +4844,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platter2FilledIphone = SFSymbol(rawValue: "platter.2.filled.iphone")
+    static var platter2FilledIphone: SFSymbol { .init(rawValue: "platter.2.filled.iphone") }
 
     /// 􀾪
     /// Single Localization, 2 Layersets
@@ -4852,7 +4852,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platter2FilledIphoneLandscape = SFSymbol(rawValue: "platter.2.filled.iphone.landscape")
+    static var platter2FilledIphoneLandscape: SFSymbol { .init(rawValue: "platter.2.filled.iphone.landscape") }
 
     /// 􁃇
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4862,7 +4862,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let platterBottomApplewatchCase = SFSymbol(rawValue: "platter.bottom.applewatch.case")
+    static var platterBottomApplewatchCase: SFSymbol { .init(rawValue: "platter.bottom.applewatch.case") }
 
     /// 􁃅
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4872,7 +4872,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let platterFilledBottomApplewatchCase = SFSymbol(rawValue: "platter.filled.bottom.applewatch.case")
+    static var platterFilledBottomApplewatchCase: SFSymbol { .init(rawValue: "platter.filled.bottom.applewatch.case") }
 
     /// 􁃄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4882,7 +4882,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let platterFilledTopApplewatchCase = SFSymbol(rawValue: "platter.filled.top.applewatch.case")
+    static var platterFilledTopApplewatchCase: SFSymbol { .init(rawValue: "platter.filled.top.applewatch.case") }
 
     /// 􁃆
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4892,7 +4892,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let platterTopApplewatchCase = SFSymbol(rawValue: "platter.top.applewatch.case")
+    static var platterTopApplewatchCase: SFSymbol { .init(rawValue: "platter.top.applewatch.case") }
 
     /// 􀾬
     /// Single Localization, 3 Layersets
@@ -4901,7 +4901,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playRectangleOnRectangle = SFSymbol(rawValue: "play.rectangle.on.rectangle")
+    static var playRectangleOnRectangle: SFSymbol { .init(rawValue: "play.rectangle.on.rectangle") }
 
     /// 􁃀
     /// Single Localization, 2 Layersets
@@ -4909,7 +4909,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playRectangleOnRectangleCircle = SFSymbol(rawValue: "play.rectangle.on.rectangle.circle")
+    static var playRectangleOnRectangleCircle: SFSymbol { .init(rawValue: "play.rectangle.on.rectangle.circle") }
 
     /// 􁃁
     /// Single Localization, 3 Layersets
@@ -4918,7 +4918,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playRectangleOnRectangleCircleFill = SFSymbol(rawValue: "play.rectangle.on.rectangle.circle.fill")
+    static var playRectangleOnRectangleCircleFill: SFSymbol { .init(rawValue: "play.rectangle.on.rectangle.circle.fill") }
 
     /// 􀾭
     /// Single Localization, 3 Layersets
@@ -4927,7 +4927,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playRectangleOnRectangleFill = SFSymbol(rawValue: "play.rectangle.on.rectangle.fill")
+    static var playRectangleOnRectangleFill: SFSymbol { .init(rawValue: "play.rectangle.on.rectangle.fill") }
 
     /// 􀽍
     /// Single Localization, 2 Layersets
@@ -4935,7 +4935,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playSquare = SFSymbol(rawValue: "play.square")
+    static var playSquare: SFSymbol { .init(rawValue: "play.square") }
 
     /// 􀽎
     /// Single Localization, 3 Layersets
@@ -4944,14 +4944,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let playSquareFill = SFSymbol(rawValue: "play.square.fill")
+    static var playSquareFill: SFSymbol { .init(rawValue: "play.square.fill") }
 
     /// 􀅺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let plusForwardslashMinus = SFSymbol(rawValue: "plus.forwardslash.minus")
+    static var plusForwardslashMinus: SFSymbol { .init(rawValue: "plus.forwardslash.minus") }
 
     /// 􀤱
     /// Single Localization, 2 Layersets
@@ -4959,7 +4959,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusRectangleOnFolderFill = SFSymbol(rawValue: "plus.rectangle.on.folder.fill")
+    static var plusRectangleOnFolderFill: SFSymbol { .init(rawValue: "plus.rectangle.on.folder.fill") }
 
     /// 􀴥
     /// Single Localization, 2 Layersets
@@ -4967,7 +4967,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusSquareDashed = SFSymbol(rawValue: "plus.square.dashed")
+    static var plusSquareDashed: SFSymbol { .init(rawValue: "plus.square.dashed") }
 
     /// 􁆬
     /// Single Localization, 3 Layersets
@@ -4976,7 +4976,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let point3ConnectedTrianglepathDotted = SFSymbol(rawValue: "point.3.connected.trianglepath.dotted")
+    static var point3ConnectedTrianglepathDotted: SFSymbol { .init(rawValue: "point.3.connected.trianglepath.dotted") }
 
     /// 􁅥
     /// Single Localization, 3 Layersets
@@ -4985,7 +4985,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let point3FilledConnectedTrianglepathDotted = SFSymbol(rawValue: "point.3.filled.connected.trianglepath.dotted")
+    static var point3FilledConnectedTrianglepathDotted: SFSymbol { .init(rawValue: "point.3.filled.connected.trianglepath.dotted") }
 
     /// 􀾕
     /// Single Localization, 3 Layersets
@@ -4999,7 +4999,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "pointTopleftFilledDownToPointBottomrightCurvepath")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "pointTopleftFilledDownToPointBottomrightCurvepath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "pointTopleftFilledDownToPointBottomrightCurvepath")
-    static let pointFilledTopleftDownCurvedtoPointBottomrightUp = SFSymbol(rawValue: "point.filled.topleft.down.curvedto.point.bottomright.up")
+    static var pointFilledTopleftDownCurvedtoPointBottomrightUp: SFSymbol { .init(rawValue: "point.filled.topleft.down.curvedto.point.bottomright.up") }
 
     /// 􀬱
     /// Single Localization, 3 Layersets
@@ -5013,7 +5013,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "pointTopleftDownToPointBottomrightCurvepathFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "pointTopleftDownToPointBottomrightCurvepathFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "pointTopleftDownToPointBottomrightCurvepathFill")
-    static let pointTopleftDownCurvedtoPointBottomrightUpFill = SFSymbol(rawValue: "point.topleft.down.curvedto.point.bottomright.up.fill")
+    static var pointTopleftDownCurvedtoPointBottomrightUpFill: SFSymbol { .init(rawValue: "point.topleft.down.curvedto.point.bottomright.up.fill") }
 
     /// 􀾔
     /// Single Localization, 3 Layersets
@@ -5027,7 +5027,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "pointTopleftDownToPointBottomrightFilledCurvepath")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "pointTopleftDownToPointBottomrightFilledCurvepath")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "pointTopleftDownToPointBottomrightFilledCurvepath")
-    static let pointTopleftDownCurvedtoPointFilledBottomrightUp = SFSymbol(rawValue: "point.topleft.down.curvedto.point.filled.bottomright.up")
+    static var pointTopleftDownCurvedtoPointFilledBottomrightUp: SFSymbol { .init(rawValue: "point.topleft.down.curvedto.point.filled.bottomright.up") }
 
     /// 􀷃
     /// Single Localization, 2 Layersets
@@ -5035,7 +5035,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let powerCircle = SFSymbol(rawValue: "power.circle")
+    static var powerCircle: SFSymbol { .init(rawValue: "power.circle") }
 
     /// 􀷄
     /// Single Localization, 3 Layersets
@@ -5044,56 +5044,56 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let powerCircleFill = SFSymbol(rawValue: "power.circle.fill")
+    static var powerCircleFill: SFSymbol { .init(rawValue: "power.circle.fill") }
 
     /// 􀆩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powerDotted = SFSymbol(rawValue: "power.dotted")
+    static var powerDotted: SFSymbol { .init(rawValue: "power.dotted") }
 
     /// 􀡷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powerplug = SFSymbol(rawValue: "powerplug")
+    static var powerplug: SFSymbol { .init(rawValue: "powerplug") }
 
     /// 􀡸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powerplugFill = SFSymbol(rawValue: "powerplug.fill")
+    static var powerplugFill: SFSymbol { .init(rawValue: "powerplug.fill") }
 
     /// 􀪿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerDotmatrixFilledAndPaper = SFSymbol(rawValue: "printer.dotmatrix.filled.and.paper")
+    static var printerDotmatrixFilledAndPaper: SFSymbol { .init(rawValue: "printer.dotmatrix.filled.and.paper") }
 
     /// 􀪾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerFilledAndPaper = SFSymbol(rawValue: "printer.filled.and.paper")
+    static var printerFilledAndPaper: SFSymbol { .init(rawValue: "printer.filled.and.paper") }
 
     /// 􀥭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let puzzlepieceExtension = SFSymbol(rawValue: "puzzlepiece.extension")
+    static var puzzlepieceExtension: SFSymbol { .init(rawValue: "puzzlepiece.extension") }
 
     /// 􀥮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let puzzlepieceExtensionFill = SFSymbol(rawValue: "puzzlepiece.extension.fill")
+    static var puzzlepieceExtensionFill: SFSymbol { .init(rawValue: "puzzlepiece.extension.fill") }
 
     /// 􀿨
     /// 2 Localizations, 2 Layersets
@@ -5105,7 +5105,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let questionmarkApp = SymbolWith1Localization<Ar>(rawValue: "questionmark.app")
+    static var questionmarkApp: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.app") }
 
     /// 􀿪
     /// 2 Localizations, 2 Layersets
@@ -5117,7 +5117,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let questionmarkAppDashed = SymbolWith1Localization<Ar>(rawValue: "questionmark.app.dashed")
+    static var questionmarkAppDashed: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.app.dashed") }
 
     /// 􀿩
     /// 2 Localizations, 3 Layersets
@@ -5130,21 +5130,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let questionmarkAppFill = SymbolWith1Localization<Ar>(rawValue: "questionmark.app.fill")
+    static var questionmarkAppFill: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.app.fill") }
 
     /// 􁈐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let quoteClosing = SFSymbol(rawValue: "quote.closing")
+    static var quoteClosing: SFSymbol { .init(rawValue: "quote.closing") }
 
     /// 􁈏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let quoteOpening = SFSymbol(rawValue: "quote.opening")
+    static var quoteOpening: SFSymbol { .init(rawValue: "quote.opening") }
 
     /// 􀦕
     /// Single Localization, 2 Layersets
@@ -5152,7 +5152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickPressDown = SFSymbol(rawValue: "r.joystick.press.down")
+    static var rJoystickPressDown: SFSymbol { .init(rawValue: "r.joystick.press.down") }
 
     /// 􀫄
     /// Single Localization, 3 Layersets
@@ -5161,7 +5161,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rJoystickPressDownFill = SFSymbol(rawValue: "r.joystick.press.down.fill")
+    static var rJoystickPressDownFill: SFSymbol { .init(rawValue: "r.joystick.press.down.fill") }
 
     /// 􀿤
     /// Single Localization, 2 Layersets
@@ -5169,7 +5169,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltDown = SFSymbol(rawValue: "r.joystick.tilt.down")
+    static var rJoystickTiltDown: SFSymbol { .init(rawValue: "r.joystick.tilt.down") }
 
     /// 􀿥
     /// Single Localization, 2 Layersets
@@ -5177,7 +5177,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltDownFill = SFSymbol(rawValue: "r.joystick.tilt.down.fill")
+    static var rJoystickTiltDownFill: SFSymbol { .init(rawValue: "r.joystick.tilt.down.fill") }
 
     /// 􀿞
     /// Single Localization, 2 Layersets
@@ -5185,7 +5185,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltLeft = SFSymbol(rawValue: "r.joystick.tilt.left")
+    static var rJoystickTiltLeft: SFSymbol { .init(rawValue: "r.joystick.tilt.left") }
 
     /// 􀿟
     /// Single Localization, 2 Layersets
@@ -5193,7 +5193,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltLeftFill = SFSymbol(rawValue: "r.joystick.tilt.left.fill")
+    static var rJoystickTiltLeftFill: SFSymbol { .init(rawValue: "r.joystick.tilt.left.fill") }
 
     /// 􀿠
     /// Single Localization, 2 Layersets
@@ -5201,7 +5201,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltRight = SFSymbol(rawValue: "r.joystick.tilt.right")
+    static var rJoystickTiltRight: SFSymbol { .init(rawValue: "r.joystick.tilt.right") }
 
     /// 􀿡
     /// Single Localization, 2 Layersets
@@ -5209,7 +5209,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltRightFill = SFSymbol(rawValue: "r.joystick.tilt.right.fill")
+    static var rJoystickTiltRightFill: SFSymbol { .init(rawValue: "r.joystick.tilt.right.fill") }
 
     /// 􀿢
     /// Single Localization, 2 Layersets
@@ -5217,7 +5217,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltUp = SFSymbol(rawValue: "r.joystick.tilt.up")
+    static var rJoystickTiltUp: SFSymbol { .init(rawValue: "r.joystick.tilt.up") }
 
     /// 􀿣
     /// Single Localization, 2 Layersets
@@ -5225,7 +5225,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rJoystickTiltUpFill = SFSymbol(rawValue: "r.joystick.tilt.up.fill")
+    static var rJoystickTiltUpFill: SFSymbol { .init(rawValue: "r.joystick.tilt.up.fill") }
 
     /// 􀭙
     /// Single Localization, 3 Layersets
@@ -5234,7 +5234,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rSquareOnSquareFill = SFSymbol(rawValue: "r.square.on.square.fill")
+    static var rSquareOnSquareFill: SFSymbol { .init(rawValue: "r.square.on.square.fill") }
 
     /// 􁁀
     /// Single Localization, 2 Layersets
@@ -5242,14 +5242,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangle2Swap = SFSymbol(rawValue: "rectangle.2.swap")
+    static var rectangle2Swap: SFSymbol { .init(rawValue: "rectangle.2.swap") }
 
     /// 􀇴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangle3Group = SFSymbol(rawValue: "rectangle.3.group")
+    static var rectangle3Group: SFSymbol { .init(rawValue: "rectangle.3.group") }
 
     /// 􀬄
     /// Single Localization, 2 Layersets
@@ -5262,7 +5262,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "rectangle3GroupBubble")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "rectangle3GroupBubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3GroupBubble")
-    static let rectangle3GroupBubbleLeft = SFSymbol(rawValue: "rectangle.3.group.bubble.left")
+    static var rectangle3GroupBubbleLeft: SFSymbol { .init(rawValue: "rectangle.3.group.bubble.left") }
 
     /// 􀬅
     /// Single Localization, 3 Layersets
@@ -5276,14 +5276,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "rectangle3GroupBubbleFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "rectangle3GroupBubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "rectangle3GroupBubbleFill")
-    static let rectangle3GroupBubbleLeftFill = SFSymbol(rawValue: "rectangle.3.group.bubble.left.fill")
+    static var rectangle3GroupBubbleLeftFill: SFSymbol { .init(rawValue: "rectangle.3.group.bubble.left.fill") }
 
     /// 􀚅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangle3GroupFill = SFSymbol(rawValue: "rectangle.3.group.fill")
+    static var rectangle3GroupFill: SFSymbol { .init(rawValue: "rectangle.3.group.fill") }
 
     /// 􀪤
     /// Single Localization, 3 Layersets
@@ -5292,7 +5292,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleAndHandPointUpLeft = SFSymbol(rawValue: "rectangle.and.hand.point.up.left")
+    static var rectangleAndHandPointUpLeft: SFSymbol { .init(rawValue: "rectangle.and.hand.point.up.left") }
 
     /// 􀪥
     /// Single Localization, 2 Layersets
@@ -5300,7 +5300,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleAndHandPointUpLeftFill = SFSymbol(rawValue: "rectangle.and.hand.point.up.left.fill")
+    static var rectangleAndHandPointUpLeftFill: SFSymbol { .init(rawValue: "rectangle.and.hand.point.up.left.fill") }
 
     /// 􀪧
     /// Single Localization, 2 Layersets
@@ -5308,14 +5308,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleAndHandPointUpLeftFilled = SFSymbol(rawValue: "rectangle.and.hand.point.up.left.filled")
+    static var rectangleAndHandPointUpLeftFilled: SFSymbol { .init(rawValue: "rectangle.and.hand.point.up.left.filled") }
 
     /// 􀿰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleBottomhalfFilled = SFSymbol(rawValue: "rectangle.bottomhalf.filled")
+    static var rectangleBottomhalfFilled: SFSymbol { .init(rawValue: "rectangle.bottomhalf.filled") }
 
     /// 􀾯
     /// Single Localization, 2 Layersets
@@ -5328,7 +5328,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomhalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomhalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomhalfRectangle")
-    static let rectangleBottomhalfInsetFilled = SFSymbol(rawValue: "rectangle.bottomhalf.inset.filled")
+    static var rectangleBottomhalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.bottomhalf.inset.filled") }
 
     /// 􀨨
     /// Single Localization, 2 Layersets
@@ -5341,7 +5341,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomthirdRectangle")
-    static let rectangleBottomthirdInsetFilled = SFSymbol(rawValue: "rectangle.bottomthird.inset.filled")
+    static var rectangleBottomthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.bottomthird.inset.filled") }
 
     /// 􀥝
     /// Single Localization, 2 Layersets
@@ -5354,7 +5354,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCenterRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCenterRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCenterRectangle")
-    static let rectangleCenterInsetFilled = SFSymbol(rawValue: "rectangle.center.inset.filled")
+    static var rectangleCenterInsetFilled: SFSymbol { .init(rawValue: "rectangle.center.inset.filled") }
 
     /// 􁈔
     /// Single Localization, 3 Layersets
@@ -5368,7 +5368,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCenterRectangleBadgePlus")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCenterRectangleBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCenterRectangleBadgePlus")
-    static let rectangleCenterInsetFilledBadgePlus = SFSymbol(rawValue: "rectangle.center.inset.filled.badge.plus")
+    static var rectangleCenterInsetFilledBadgePlus: SFSymbol { .init(rawValue: "rectangle.center.inset.filled.badge.plus") }
 
     /// 􀪦
     /// Single Localization, 3 Layersets
@@ -5377,7 +5377,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleFilledAndHandPointUpLeft = SFSymbol(rawValue: "rectangle.filled.and.hand.point.up.left")
+    static var rectangleFilledAndHandPointUpLeft: SFSymbol { .init(rawValue: "rectangle.filled.and.hand.point.up.left") }
 
     /// 􁁫
     /// Single Localization, 2 Layersets
@@ -5390,7 +5390,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomleadingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomleadingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomleadingRectangle")
-    static let rectangleInsetBottomleadingFilled = SFSymbol(rawValue: "rectangle.inset.bottomleading.filled")
+    static var rectangleInsetBottomleadingFilled: SFSymbol { .init(rawValue: "rectangle.inset.bottomleading.filled") }
 
     /// 􀭵
     /// Single Localization, 2 Layersets
@@ -5403,7 +5403,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomleftRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomleftRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomleftRectangle")
-    static let rectangleInsetBottomleftFilled = SFSymbol(rawValue: "rectangle.inset.bottomleft.filled")
+    static var rectangleInsetBottomleftFilled: SFSymbol { .init(rawValue: "rectangle.inset.bottomleft.filled") }
 
     /// 􀭶
     /// Single Localization, 2 Layersets
@@ -5416,7 +5416,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomrightRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomrightRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomrightRectangle")
-    static let rectangleInsetBottomrightFilled = SFSymbol(rawValue: "rectangle.inset.bottomright.filled")
+    static var rectangleInsetBottomrightFilled: SFSymbol { .init(rawValue: "rectangle.inset.bottomright.filled") }
 
     /// 􁁬
     /// Single Localization, 2 Layersets
@@ -5429,7 +5429,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomtrailingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomtrailingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomtrailingRectangle")
-    static let rectangleInsetBottomtrailingFilled = SFSymbol(rawValue: "rectangle.inset.bottomtrailing.filled")
+    static var rectangleInsetBottomtrailingFilled: SFSymbol { .init(rawValue: "rectangle.inset.bottomtrailing.filled") }
 
     /// 􀤳
     /// Single Localization, 2 Layersets
@@ -5442,7 +5442,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectangle")
-    static let rectangleInsetFilled = SFSymbol(rawValue: "rectangle.inset.filled")
+    static var rectangleInsetFilled: SFSymbol { .init(rawValue: "rectangle.inset.filled") }
 
     /// 􁅀
     /// Single Localization, 2 Layersets
@@ -5455,7 +5455,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRectangleAndPersonFilled")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRectangleAndPersonFilled")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectangleAndPersonFilled")
-    static let rectangleInsetFilledAndPersonFilled = SFSymbol(rawValue: "rectangle.inset.filled.and.person.filled")
+    static var rectangleInsetFilledAndPersonFilled: SFSymbol { .init(rawValue: "rectangle.inset.filled.and.person.filled") }
 
     /// 􀶣
     /// Single Localization, 2 Layersets
@@ -5468,7 +5468,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRectangleOnRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRectangleOnRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectangleOnRectangle")
-    static let rectangleInsetFilledOnRectangle = SFSymbol(rawValue: "rectangle.inset.filled.on.rectangle")
+    static var rectangleInsetFilledOnRectangle: SFSymbol { .init(rawValue: "rectangle.inset.filled.on.rectangle") }
 
     /// 􁁩
     /// Single Localization, 2 Layersets
@@ -5481,7 +5481,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopleadingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopleadingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopleadingRectangle")
-    static let rectangleInsetTopleadingFilled = SFSymbol(rawValue: "rectangle.inset.topleading.filled")
+    static var rectangleInsetTopleadingFilled: SFSymbol { .init(rawValue: "rectangle.inset.topleading.filled") }
 
     /// 􀭳
     /// Single Localization, 2 Layersets
@@ -5494,7 +5494,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopleftRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopleftRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopleftRectangle")
-    static let rectangleInsetTopleftFilled = SFSymbol(rawValue: "rectangle.inset.topleft.filled")
+    static var rectangleInsetTopleftFilled: SFSymbol { .init(rawValue: "rectangle.inset.topleft.filled") }
 
     /// 􀭴
     /// Single Localization, 2 Layersets
@@ -5507,7 +5507,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledToprightRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledToprightRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledToprightRectangle")
-    static let rectangleInsetToprightFilled = SFSymbol(rawValue: "rectangle.inset.topright.filled")
+    static var rectangleInsetToprightFilled: SFSymbol { .init(rawValue: "rectangle.inset.topright.filled") }
 
     /// 􁁪
     /// Single Localization, 2 Layersets
@@ -5520,7 +5520,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledToptrailingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledToptrailingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledToptrailingRectangle")
-    static let rectangleInsetToptrailingFilled = SFSymbol(rawValue: "rectangle.inset.toptrailing.filled")
+    static var rectangleInsetToptrailingFilled: SFSymbol { .init(rawValue: "rectangle.inset.toptrailing.filled") }
 
     /// 􁁣
     /// Single Localization, 2 Layersets
@@ -5533,7 +5533,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeadinghalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeadinghalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadinghalfRectangle")
-    static let rectangleLeadinghalfInsetFilled = SFSymbol(rawValue: "rectangle.leadinghalf.inset.filled")
+    static var rectangleLeadinghalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.leadinghalf.inset.filled") }
 
     /// 􁁥
     /// Single Localization, 2 Layersets
@@ -5546,7 +5546,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeadinghalfArrowLeadingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeadinghalfArrowLeadingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadinghalfArrowLeadingRectangle")
-    static let rectangleLeadinghalfInsetFilledArrowLeading = SFSymbol(rawValue: "rectangle.leadinghalf.inset.filled.arrow.leading")
+    static var rectangleLeadinghalfInsetFilledArrowLeading: SFSymbol { .init(rawValue: "rectangle.leadinghalf.inset.filled.arrow.leading") }
 
     /// 􁁧
     /// Single Localization, 2 Layersets
@@ -5559,14 +5559,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeadingthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeadingthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadingthirdRectangle")
-    static let rectangleLeadingthirdInsetFilled = SFSymbol(rawValue: "rectangle.leadingthird.inset.filled")
+    static var rectangleLeadingthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.leadingthird.inset.filled") }
 
     /// 􀤶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleLefthalfFilled = SFSymbol(rawValue: "rectangle.lefthalf.filled")
+    static var rectangleLefthalfFilled: SFSymbol { .init(rawValue: "rectangle.lefthalf.filled") }
 
     /// 􀤴
     /// Single Localization, 2 Layersets
@@ -5579,7 +5579,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLefthalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLefthalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLefthalfRectangle")
-    static let rectangleLefthalfInsetFilled = SFSymbol(rawValue: "rectangle.lefthalf.inset.filled")
+    static var rectangleLefthalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.lefthalf.inset.filled") }
 
     /// 􀥞
     /// Single Localization, 2 Layersets
@@ -5592,7 +5592,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLefthalfArrowLeftRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLefthalfArrowLeftRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLefthalfArrowLeftRectangle")
-    static let rectangleLefthalfInsetFilledArrowLeft = SFSymbol(rawValue: "rectangle.lefthalf.inset.filled.arrow.left")
+    static var rectangleLefthalfInsetFilledArrowLeft: SFSymbol { .init(rawValue: "rectangle.lefthalf.inset.filled.arrow.left") }
 
     /// 􀨱
     /// Single Localization, 2 Layersets
@@ -5605,7 +5605,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeftthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeftthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeftthirdRectangle")
-    static let rectangleLeftthirdInsetFilled = SFSymbol(rawValue: "rectangle.leftthird.inset.filled")
+    static var rectangleLeftthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.leftthird.inset.filled") }
 
     /// 􀤽
     /// Single Localization, 2 Layersets
@@ -5613,7 +5613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleCircle = SFSymbol(rawValue: "rectangle.on.rectangle.circle")
+    static var rectangleOnRectangleCircle: SFSymbol { .init(rawValue: "rectangle.on.rectangle.circle") }
 
     /// 􀤾
     /// Single Localization, 3 Layersets
@@ -5622,7 +5622,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectangleOnRectangleCircleFill = SFSymbol(rawValue: "rectangle.on.rectangle.circle.fill")
+    static var rectangleOnRectangleCircleFill: SFSymbol { .init(rawValue: "rectangle.on.rectangle.circle.fill") }
 
     /// 􀻯
     /// Single Localization, 2 Layersets
@@ -5630,7 +5630,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleSlashCircle = SFSymbol(rawValue: "rectangle.on.rectangle.slash.circle")
+    static var rectangleOnRectangleSlashCircle: SFSymbol { .init(rawValue: "rectangle.on.rectangle.slash.circle") }
 
     /// 􀻰
     /// Single Localization, 3 Layersets
@@ -5639,7 +5639,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectangleOnRectangleSlashCircleFill = SFSymbol(rawValue: "rectangle.on.rectangle.slash.circle.fill")
+    static var rectangleOnRectangleSlashCircleFill: SFSymbol { .init(rawValue: "rectangle.on.rectangle.slash.circle.fill") }
 
     /// 􀤿
     /// Single Localization, 2 Layersets
@@ -5647,7 +5647,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleSlashFill = SFSymbol(rawValue: "rectangle.on.rectangle.slash.fill")
+    static var rectangleOnRectangleSlashFill: SFSymbol { .init(rawValue: "rectangle.on.rectangle.slash.fill") }
 
     /// 􀽏
     /// Single Localization, 2 Layersets
@@ -5655,7 +5655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleSquare = SFSymbol(rawValue: "rectangle.on.rectangle.square")
+    static var rectangleOnRectangleSquare: SFSymbol { .init(rawValue: "rectangle.on.rectangle.square") }
 
     /// 􀽐
     /// Single Localization, 3 Layersets
@@ -5664,7 +5664,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleOnRectangleSquareFill = SFSymbol(rawValue: "rectangle.on.rectangle.square.fill")
+    static var rectangleOnRectangleSquareFill: SFSymbol { .init(rawValue: "rectangle.on.rectangle.square.fill") }
 
     /// 􀻵
     /// Single Localization, 2 Layersets
@@ -5672,7 +5672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitAndArrowRight = SFSymbol(rawValue: "rectangle.portrait.and.arrow.right")
+    static var rectanglePortraitAndArrowRight: SFSymbol { .init(rawValue: "rectangle.portrait.and.arrow.right") }
 
     /// 􀻶
     /// Single Localization, 2 Layersets
@@ -5680,14 +5680,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let rectanglePortraitAndArrowRightFill = SFSymbol(rawValue: "rectangle.portrait.and.arrow.right.fill")
+    static var rectanglePortraitAndArrowRightFill: SFSymbol { .init(rawValue: "rectangle.portrait.and.arrow.right.fill") }
 
     /// 􀿲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitBottomhalfFilled = SFSymbol(rawValue: "rectangle.portrait.bottomhalf.filled")
+    static var rectanglePortraitBottomhalfFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomhalf.filled") }
 
     /// 􀽺
     /// Single Localization, 2 Layersets
@@ -5700,7 +5700,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomhalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomhalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomhalfRectanglePortrait")
-    static let rectanglePortraitBottomhalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomhalf.inset.filled")
+    static var rectanglePortraitBottomhalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomhalf.inset.filled") }
 
     /// 􁁳
     /// Single Localization, 2 Layersets
@@ -5713,7 +5713,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomleadingRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomleadingRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomleadingRectanglePortrait")
-    static let rectanglePortraitBottomleadingInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomleading.inset.filled")
+    static var rectanglePortraitBottomleadingInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomleading.inset.filled") }
 
     /// 􀾃
     /// Single Localization, 2 Layersets
@@ -5726,7 +5726,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomleftRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomleftRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomleftRectanglePortrait")
-    static let rectanglePortraitBottomleftInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomleft.inset.filled")
+    static var rectanglePortraitBottomleftInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomleft.inset.filled") }
 
     /// 􀾂
     /// Single Localization, 2 Layersets
@@ -5739,7 +5739,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomrightRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomrightRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomrightRectanglePortrait")
-    static let rectanglePortraitBottomrightInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomright.inset.filled")
+    static var rectanglePortraitBottomrightInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomright.inset.filled") }
 
     /// 􀽾
     /// Single Localization, 2 Layersets
@@ -5752,7 +5752,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomthirdRectanglePortrait")
-    static let rectanglePortraitBottomthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomthird.inset.filled")
+    static var rectanglePortraitBottomthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomthird.inset.filled") }
 
     /// 􁁴
     /// Single Localization, 2 Layersets
@@ -5765,7 +5765,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledBottomtrailingRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledBottomtrailingRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomtrailingRectanglePortrait")
-    static let rectanglePortraitBottomtrailingInsetFilled = SFSymbol(rawValue: "rectangle.portrait.bottomtrailing.inset.filled")
+    static var rectanglePortraitBottomtrailingInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.bottomtrailing.inset.filled") }
 
     /// 􀽿
     /// Single Localization, 2 Layersets
@@ -5778,7 +5778,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledCenterRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledCenterRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledCenterRectanglePortrait")
-    static let rectanglePortraitCenterInsetFilled = SFSymbol(rawValue: "rectangle.portrait.center.inset.filled")
+    static var rectanglePortraitCenterInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.center.inset.filled") }
 
     /// 􀽸
     /// Single Localization, 2 Layersets
@@ -5791,7 +5791,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectanglePortrait")
-    static let rectanglePortraitInsetFilled = SFSymbol(rawValue: "rectangle.portrait.inset.filled")
+    static var rectanglePortraitInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.inset.filled") }
 
     /// 􁁭
     /// Single Localization, 2 Layersets
@@ -5804,7 +5804,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeadinghalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeadinghalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadinghalfRectanglePortrait")
-    static let rectanglePortraitLeadinghalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.leadinghalf.inset.filled")
+    static var rectanglePortraitLeadinghalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.leadinghalf.inset.filled") }
 
     /// 􁁯
     /// Single Localization, 2 Layersets
@@ -5817,14 +5817,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeadingthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeadingthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadingthirdRectanglePortrait")
-    static let rectanglePortraitLeadingthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.leadingthird.inset.filled")
+    static var rectanglePortraitLeadingthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.leadingthird.inset.filled") }
 
     /// 􀿬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitLefthalfFilled = SFSymbol(rawValue: "rectangle.portrait.lefthalf.filled")
+    static var rectanglePortraitLefthalfFilled: SFSymbol { .init(rawValue: "rectangle.portrait.lefthalf.filled") }
 
     /// 􀾄
     /// Single Localization, 2 Layersets
@@ -5837,7 +5837,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLefthalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLefthalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLefthalfRectanglePortrait")
-    static let rectanglePortraitLefthalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.lefthalf.inset.filled")
+    static var rectanglePortraitLefthalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.lefthalf.inset.filled") }
 
     /// 􀽼
     /// Single Localization, 2 Layersets
@@ -5850,7 +5850,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledLeftthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledLeftthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeftthirdRectanglePortrait")
-    static let rectanglePortraitLeftthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.leftthird.inset.filled")
+    static var rectanglePortraitLeftthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.leftthird.inset.filled") }
 
     /// 􀽰
     /// Single Localization, 3 Layersets
@@ -5859,7 +5859,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectanglePortraitOnRectanglePortrait = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait")
+    static var rectanglePortraitOnRectanglePortrait: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait") }
 
     /// 􀽱
     /// Single Localization, 2 Layersets
@@ -5867,7 +5867,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitOnRectanglePortraitFill = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait.fill")
+    static var rectanglePortraitOnRectanglePortraitFill: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait.fill") }
 
     /// 􀽲
     /// Single Localization, 2 Layersets
@@ -5875,7 +5875,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitOnRectanglePortraitSlash = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait.slash")
+    static var rectanglePortraitOnRectanglePortraitSlash: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait.slash") }
 
     /// 􀽳
     /// Single Localization, 2 Layersets
@@ -5883,14 +5883,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitOnRectanglePortraitSlashFill = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait.slash.fill")
+    static var rectanglePortraitOnRectanglePortraitSlashFill: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait.slash.fill") }
 
     /// 􀿭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitRighthalfFilled = SFSymbol(rawValue: "rectangle.portrait.righthalf.filled")
+    static var rectanglePortraitRighthalfFilled: SFSymbol { .init(rawValue: "rectangle.portrait.righthalf.filled") }
 
     /// 􀾅
     /// Single Localization, 2 Layersets
@@ -5903,7 +5903,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRighthalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRighthalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRighthalfRectanglePortrait")
-    static let rectanglePortraitRighthalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.righthalf.inset.filled")
+    static var rectanglePortraitRighthalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.righthalf.inset.filled") }
 
     /// 􀽻
     /// Single Localization, 2 Layersets
@@ -5916,7 +5916,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRightthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRightthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRightthirdRectanglePortrait")
-    static let rectanglePortraitRightthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.rightthird.inset.filled")
+    static var rectanglePortraitRightthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.rightthird.inset.filled") }
 
     /// 􀾆
     /// Single Localization, 2 Layersets
@@ -5924,7 +5924,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitSlash = SFSymbol(rawValue: "rectangle.portrait.slash")
+    static var rectanglePortraitSlash: SFSymbol { .init(rawValue: "rectangle.portrait.slash") }
 
     /// 􀾇
     /// Single Localization, 2 Layersets
@@ -5932,21 +5932,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitSlashFill = SFSymbol(rawValue: "rectangle.portrait.slash.fill")
+    static var rectanglePortraitSlashFill: SFSymbol { .init(rawValue: "rectangle.portrait.slash.fill") }
 
     /// 􀽴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitSplit2x1 = SFSymbol(rawValue: "rectangle.portrait.split.2x1")
+    static var rectanglePortraitSplit2x1: SFSymbol { .init(rawValue: "rectangle.portrait.split.2x1") }
 
     /// 􀽵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitSplit2x1Fill = SFSymbol(rawValue: "rectangle.portrait.split.2x1.fill")
+    static var rectanglePortraitSplit2x1Fill: SFSymbol { .init(rawValue: "rectangle.portrait.split.2x1.fill") }
 
     /// 􀽶
     /// Single Localization, 2 Layersets
@@ -5954,7 +5954,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitSplit2x1Slash = SFSymbol(rawValue: "rectangle.portrait.split.2x1.slash")
+    static var rectanglePortraitSplit2x1Slash: SFSymbol { .init(rawValue: "rectangle.portrait.split.2x1.slash") }
 
     /// 􀽷
     /// Single Localization, 2 Layersets
@@ -5962,14 +5962,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitSplit2x1SlashFill = SFSymbol(rawValue: "rectangle.portrait.split.2x1.slash.fill")
+    static var rectanglePortraitSplit2x1SlashFill: SFSymbol { .init(rawValue: "rectangle.portrait.split.2x1.slash.fill") }
 
     /// 􀿱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePortraitTophalfFilled = SFSymbol(rawValue: "rectangle.portrait.tophalf.filled")
+    static var rectanglePortraitTophalfFilled: SFSymbol { .init(rawValue: "rectangle.portrait.tophalf.filled") }
 
     /// 􀽹
     /// Single Localization, 2 Layersets
@@ -5982,7 +5982,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTophalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTophalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTophalfRectanglePortrait")
-    static let rectanglePortraitTophalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.tophalf.inset.filled")
+    static var rectanglePortraitTophalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.tophalf.inset.filled") }
 
     /// 􁁱
     /// Single Localization, 2 Layersets
@@ -5995,7 +5995,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopleadingRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopleadingRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopleadingRectanglePortrait")
-    static let rectanglePortraitTopleadingInsetFilled = SFSymbol(rawValue: "rectangle.portrait.topleading.inset.filled")
+    static var rectanglePortraitTopleadingInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.topleading.inset.filled") }
 
     /// 􀾀
     /// Single Localization, 2 Layersets
@@ -6008,7 +6008,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopleftRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopleftRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopleftRectanglePortrait")
-    static let rectanglePortraitTopleftInsetFilled = SFSymbol(rawValue: "rectangle.portrait.topleft.inset.filled")
+    static var rectanglePortraitTopleftInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.topleft.inset.filled") }
 
     /// 􀾁
     /// Single Localization, 2 Layersets
@@ -6021,7 +6021,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledToprightRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledToprightRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledToprightRectanglePortrait")
-    static let rectanglePortraitToprightInsetFilled = SFSymbol(rawValue: "rectangle.portrait.topright.inset.filled")
+    static var rectanglePortraitToprightInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.topright.inset.filled") }
 
     /// 􀽽
     /// Single Localization, 2 Layersets
@@ -6034,7 +6034,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopthirdRectanglePortrait")
-    static let rectanglePortraitTopthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.topthird.inset.filled")
+    static var rectanglePortraitTopthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.topthird.inset.filled") }
 
     /// 􁁲
     /// Single Localization, 2 Layersets
@@ -6047,7 +6047,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledToptrailingRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledToptrailingRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledToptrailingRectanglePortrait")
-    static let rectanglePortraitToptrailingInsetFilled = SFSymbol(rawValue: "rectangle.portrait.toptrailing.inset.filled")
+    static var rectanglePortraitToptrailingInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.toptrailing.inset.filled") }
 
     /// 􁁮
     /// Single Localization, 2 Layersets
@@ -6060,7 +6060,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTrailinghalfRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTrailinghalfRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailinghalfRectanglePortrait")
-    static let rectanglePortraitTrailinghalfInsetFilled = SFSymbol(rawValue: "rectangle.portrait.trailinghalf.inset.filled")
+    static var rectanglePortraitTrailinghalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.trailinghalf.inset.filled") }
 
     /// 􁁰
     /// Single Localization, 2 Layersets
@@ -6073,14 +6073,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTrailingthirdRectanglePortrait")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTrailingthirdRectanglePortrait")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailingthirdRectanglePortrait")
-    static let rectanglePortraitTrailingthirdInsetFilled = SFSymbol(rawValue: "rectangle.portrait.trailingthird.inset.filled")
+    static var rectanglePortraitTrailingthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.portrait.trailingthird.inset.filled") }
 
     /// 􀤷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRighthalfFilled = SFSymbol(rawValue: "rectangle.righthalf.filled")
+    static var rectangleRighthalfFilled: SFSymbol { .init(rawValue: "rectangle.righthalf.filled") }
 
     /// 􀤵
     /// Single Localization, 2 Layersets
@@ -6093,7 +6093,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRighthalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRighthalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRighthalfRectangle")
-    static let rectangleRighthalfInsetFilled = SFSymbol(rawValue: "rectangle.righthalf.inset.filled")
+    static var rectangleRighthalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.righthalf.inset.filled") }
 
     /// 􀥟
     /// Single Localization, 2 Layersets
@@ -6106,7 +6106,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRighthalfArrowRightRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRighthalfArrowRightRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRighthalfArrowRightRectangle")
-    static let rectangleRighthalfInsetFilledArrowRight = SFSymbol(rawValue: "rectangle.righthalf.inset.filled.arrow.right")
+    static var rectangleRighthalfInsetFilledArrowRight: SFSymbol { .init(rawValue: "rectangle.righthalf.inset.filled.arrow.right") }
 
     /// 􀨩
     /// Single Localization, 2 Layersets
@@ -6119,7 +6119,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledRightthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledRightthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRightthirdRectangle")
-    static let rectangleRightthirdInsetFilled = SFSymbol(rawValue: "rectangle.rightthird.inset.filled")
+    static var rectangleRightthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.rightthird.inset.filled") }
 
     /// 􀾊
     /// Single Localization, 2 Layersets
@@ -6127,7 +6127,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleSplit2x1Slash = SFSymbol(rawValue: "rectangle.split.2x1.slash")
+    static var rectangleSplit2x1Slash: SFSymbol { .init(rawValue: "rectangle.split.2x1.slash") }
 
     /// 􀾋
     /// Single Localization, 2 Layersets
@@ -6135,7 +6135,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleSplit2x1SlashFill = SFSymbol(rawValue: "rectangle.split.2x1.slash.fill")
+    static var rectangleSplit2x1SlashFill: SFSymbol { .init(rawValue: "rectangle.split.2x1.slash.fill") }
 
     /// 􀏺
     /// Single Localization, 3 Layersets
@@ -6144,7 +6144,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleStackBadgePersonCropFill = SFSymbol(rawValue: "rectangle.stack.badge.person.crop.fill")
+    static var rectangleStackBadgePersonCropFill: SFSymbol { .init(rawValue: "rectangle.stack.badge.person.crop.fill") }
 
     /// 􀽙
     /// Single Localization, 3 Layersets
@@ -6153,7 +6153,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleStackBadgePlay = SFSymbol(rawValue: "rectangle.stack.badge.play")
+    static var rectangleStackBadgePlay: SFSymbol { .init(rawValue: "rectangle.stack.badge.play") }
 
     /// 􀽚
     /// Single Localization, 3 Layersets
@@ -6162,14 +6162,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let rectangleStackBadgePlayFill = SFSymbol(rawValue: "rectangle.stack.badge.play.fill")
+    static var rectangleStackBadgePlayFill: SFSymbol { .init(rawValue: "rectangle.stack.badge.play.fill") }
 
     /// 􀿯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleTophalfFilled = SFSymbol(rawValue: "rectangle.tophalf.filled")
+    static var rectangleTophalfFilled: SFSymbol { .init(rawValue: "rectangle.tophalf.filled") }
 
     /// 􀾮
     /// Single Localization, 2 Layersets
@@ -6182,7 +6182,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTophalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTophalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTophalfRectangle")
-    static let rectangleTophalfInsetFilled = SFSymbol(rawValue: "rectangle.tophalf.inset.filled")
+    static var rectangleTophalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.tophalf.inset.filled") }
 
     /// 􀴊
     /// Single Localization, 2 Layersets
@@ -6195,7 +6195,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTopthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTopthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopthirdRectangle")
-    static let rectangleTopthirdInsetFilled = SFSymbol(rawValue: "rectangle.topthird.inset.filled")
+    static var rectangleTopthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.topthird.inset.filled") }
 
     /// 􁁤
     /// Single Localization, 2 Layersets
@@ -6208,7 +6208,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTrailinghalfRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTrailinghalfRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailinghalfRectangle")
-    static let rectangleTrailinghalfInsetFilled = SFSymbol(rawValue: "rectangle.trailinghalf.inset.filled")
+    static var rectangleTrailinghalfInsetFilled: SFSymbol { .init(rawValue: "rectangle.trailinghalf.inset.filled") }
 
     /// 􁁦
     /// Single Localization, 2 Layersets
@@ -6221,7 +6221,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTrailinghalfArrowTrailingRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTrailinghalfArrowTrailingRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailinghalfArrowTrailingRectangle")
-    static let rectangleTrailinghalfInsetFilledArrowTrailing = SFSymbol(rawValue: "rectangle.trailinghalf.inset.filled.arrow.trailing")
+    static var rectangleTrailinghalfInsetFilledArrowTrailing: SFSymbol { .init(rawValue: "rectangle.trailinghalf.inset.filled.arrow.trailing") }
 
     /// 􁁨
     /// Single Localization, 2 Layersets
@@ -6234,7 +6234,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTrailingthirdRectangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTrailingthirdRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailingthirdRectangle")
-    static let rectangleTrailingthirdInsetFilled = SFSymbol(rawValue: "rectangle.trailingthird.inset.filled")
+    static var rectangleTrailingthirdInsetFilled: SFSymbol { .init(rawValue: "rectangle.trailingthird.inset.filled") }
 
     /// 􀶞
     /// Single Localization, 3 Layersets
@@ -6243,21 +6243,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let restartCircleFill = SFSymbol(rawValue: "restart.circle.fill")
+    static var restartCircleFill: SFSymbol { .init(rawValue: "restart.circle.fill") }
 
     /// 􁂆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let returnLeft = SFSymbol(rawValue: "return.left")
+    static var returnLeft: SFSymbol { .init(rawValue: "return.left") }
 
     /// 􁂇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let returnRight = SFSymbol(rawValue: "return.right")
+    static var returnRight: SFSymbol { .init(rawValue: "return.right") }
 
     /// 􁇔
     /// Single Localization, 2 Layersets
@@ -6265,7 +6265,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let scissorsCircle = SFSymbol(rawValue: "scissors.circle")
+    static var scissorsCircle: SFSymbol { .init(rawValue: "scissors.circle") }
 
     /// 􁇕
     /// Single Localization, 3 Layersets
@@ -6274,28 +6274,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let scissorsCircleFill = SFSymbol(rawValue: "scissors.circle.fill")
+    static var scissorsCircleFill: SFSymbol { .init(rawValue: "scissors.circle.fill") }
 
     /// 􁈌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let scooter = SFSymbol(rawValue: "scooter")
+    static var scooter: SFSymbol { .init(rawValue: "scooter") }
 
     /// 􀤈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let screwdriver = SFSymbol(rawValue: "screwdriver")
+    static var screwdriver: SFSymbol { .init(rawValue: "screwdriver") }
 
     /// 􀤉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let screwdriverFill = SFSymbol(rawValue: "screwdriver.fill")
+    static var screwdriverFill: SFSymbol { .init(rawValue: "screwdriver.fill") }
 
     /// 􁁝
     /// Single Localization, 3 Layersets
@@ -6304,7 +6304,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sensorTagRadiowavesForward = SFSymbol(rawValue: "sensor.tag.radiowaves.forward")
+    static var sensorTagRadiowavesForward: SFSymbol { .init(rawValue: "sensor.tag.radiowaves.forward") }
 
     /// 􁁞
     /// Single Localization, 3 Layersets
@@ -6313,7 +6313,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sensorTagRadiowavesForwardFill = SFSymbol(rawValue: "sensor.tag.radiowaves.forward.fill")
+    static var sensorTagRadiowavesForwardFill: SFSymbol { .init(rawValue: "sensor.tag.radiowaves.forward.fill") }
 
     /// 􁃑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6324,7 +6324,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s SharePlay.
-    static let shareplay = SFSymbol(rawValue: "shareplay")
+    static var shareplay: SFSymbol { .init(rawValue: "shareplay") }
 
     /// 􀴔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6334,14 +6334,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s SharePlay.
-    static let shareplaySlash = SFSymbol(rawValue: "shareplay.slash")
+    static var shareplaySlash: SFSymbol { .init(rawValue: "shareplay.slash") }
 
     /// 􀙨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shieldLefthalfFilled = SFSymbol(rawValue: "shield.lefthalf.filled")
+    static var shieldLefthalfFilled: SFSymbol { .init(rawValue: "shield.lefthalf.filled") }
 
     /// 􀲊
     /// Single Localization, 2 Layersets
@@ -6349,14 +6349,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shieldLefthalfFilledSlash = SFSymbol(rawValue: "shield.lefthalf.filled.slash")
+    static var shieldLefthalfFilledSlash: SFSymbol { .init(rawValue: "shield.lefthalf.filled.slash") }
 
     /// 􀿮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shieldRighthalfFilled = SFSymbol(rawValue: "shield.righthalf.filled")
+    static var shieldRighthalfFilled: SFSymbol { .init(rawValue: "shield.righthalf.filled") }
 
     /// 􁇈
     /// Single Localization, 2 Layersets
@@ -6364,7 +6364,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shippingboxCircle = SFSymbol(rawValue: "shippingbox.circle")
+    static var shippingboxCircle: SFSymbol { .init(rawValue: "shippingbox.circle") }
 
     /// 􁇉
     /// Single Localization, 3 Layersets
@@ -6373,7 +6373,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let shippingboxCircleFill = SFSymbol(rawValue: "shippingbox.circle.fill")
+    static var shippingboxCircleFill: SFSymbol { .init(rawValue: "shippingbox.circle.fill") }
 
     /// 􀶟
     /// Single Localization, 2 Layersets
@@ -6381,7 +6381,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sleepCircle = SFSymbol(rawValue: "sleep.circle")
+    static var sleepCircle: SFSymbol { .init(rawValue: "sleep.circle") }
 
     /// 􀶠
     /// Single Localization, 3 Layersets
@@ -6390,7 +6390,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sleepCircleFill = SFSymbol(rawValue: "sleep.circle.fill")
+    static var sleepCircleFill: SFSymbol { .init(rawValue: "sleep.circle.fill") }
 
     /// 􁅊
     /// Single Localization, 2 Layersets
@@ -6403,7 +6403,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90")
-    static let sliderHorizontal2RectangleAndArrowTriangle2Circlepath = SFSymbol(rawValue: "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath")
+    static var sliderHorizontal2RectangleAndArrowTriangle2Circlepath: SFSymbol { .init(rawValue: "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath") }
 
     /// 􀰗
     /// Single Localization, 2 Layersets
@@ -6411,7 +6411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowSquareFilledAndSquare = SFSymbol(rawValue: "slider.horizontal.below.square.filled.and.square")
+    static var sliderHorizontalBelowSquareFilledAndSquare: SFSymbol { .init(rawValue: "slider.horizontal.below.square.filled.and.square") }
 
     /// 􀍷
     /// Single Localization, 2 Layersets
@@ -6419,7 +6419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let smallcircleFilledCircle = SFSymbol(rawValue: "smallcircle.filled.circle")
+    static var smallcircleFilledCircle: SFSymbol { .init(rawValue: "smallcircle.filled.circle") }
 
     /// 􀕩
     /// Single Localization, 3 Layersets
@@ -6428,7 +6428,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let smallcircleFilledCircleFill = SFSymbol(rawValue: "smallcircle.filled.circle.fill")
+    static var smallcircleFilledCircleFill: SFSymbol { .init(rawValue: "smallcircle.filled.circle.fill") }
 
     /// 􀇥
     /// Single Localization, 2 Layersets
@@ -6436,7 +6436,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let snowflake = SFSymbol(rawValue: "snowflake")
+    static var snowflake: SFSymbol { .init(rawValue: "snowflake") }
 
     /// 􁇌
     /// Single Localization, 2 Layersets
@@ -6444,7 +6444,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let snowflakeCircle = SFSymbol(rawValue: "snowflake.circle")
+    static var snowflakeCircle: SFSymbol { .init(rawValue: "snowflake.circle") }
 
     /// 􁇍
     /// Single Localization, 3 Layersets
@@ -6453,7 +6453,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let snowflakeCircleFill = SFSymbol(rawValue: "snowflake.circle.fill")
+    static var snowflakeCircleFill: SFSymbol { .init(rawValue: "snowflake.circle.fill") }
 
     /// 􁇥
     /// Single Localization, 2 Layersets
@@ -6461,7 +6461,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let sparkleMagnifyingglass = SFSymbol(rawValue: "sparkle.magnifyingglass")
+    static var sparkleMagnifyingglass: SFSymbol { .init(rawValue: "sparkle.magnifyingglass") }
 
     /// 􀰙
     /// Single Localization, 3 Layersets
@@ -6470,7 +6470,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sparklesSquareFilledOnSquare = SFSymbol(rawValue: "sparkles.square.filled.on.square")
+    static var sparklesSquareFilledOnSquare: SFSymbol { .init(rawValue: "sparkles.square.filled.on.square") }
 
     /// 􁅋
     /// Single Localization, 2 Layersets
@@ -6478,7 +6478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sparklesTv = SFSymbol(rawValue: "sparkles.tv")
+    static var sparklesTv: SFSymbol { .init(rawValue: "sparkles.tv") }
 
     /// 􁅌
     /// Single Localization, 3 Layersets
@@ -6487,7 +6487,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let sparklesTvFill = SFSymbol(rawValue: "sparkles.tv.fill")
+    static var sparklesTvFill: SFSymbol { .init(rawValue: "sparkles.tv.fill") }
 
     /// 􀾏
     /// Single Localization, 3 Layersets
@@ -6496,7 +6496,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerBadgeExclamationmark = SFSymbol(rawValue: "speaker.badge.exclamationmark")
+    static var speakerBadgeExclamationmark: SFSymbol { .init(rawValue: "speaker.badge.exclamationmark") }
 
     /// 􀾐
     /// Single Localization, 3 Layersets
@@ -6505,7 +6505,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerBadgeExclamationmarkFill = SFSymbol(rawValue: "speaker.badge.exclamationmark.fill")
+    static var speakerBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "speaker.badge.exclamationmark.fill") }
 
     /// 􀻁
     /// Single Localization, 2 Layersets
@@ -6513,7 +6513,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerCircle = SFSymbol(rawValue: "speaker.circle")
+    static var speakerCircle: SFSymbol { .init(rawValue: "speaker.circle") }
 
     /// 􀻂
     /// Single Localization, 3 Layersets
@@ -6522,7 +6522,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerCircleFill = SFSymbol(rawValue: "speaker.circle.fill")
+    static var speakerCircleFill: SFSymbol { .init(rawValue: "speaker.circle.fill") }
 
     /// 􀯯
     /// Single Localization, 3 Layersets
@@ -6536,7 +6536,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "square2Layers3dBottomFilled")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "square2Layers3dBottomFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square2Layers3dBottomFilled")
-    static let square2Stack3dBottomFilled = SFSymbol(rawValue: "square.2.stack.3d.bottom.filled")
+    static var square2Stack3dBottomFilled: SFSymbol { .init(rawValue: "square.2.stack.3d.bottom.filled") }
 
     /// 􀯮
     /// Single Localization, 3 Layersets
@@ -6550,7 +6550,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "square2Layers3dTopFilled")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "square2Layers3dTopFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square2Layers3dTopFilled")
-    static let square2Stack3dTopFilled = SFSymbol(rawValue: "square.2.stack.3d.top.filled")
+    static var square2Stack3dTopFilled: SFSymbol { .init(rawValue: "square.2.stack.3d.top.filled") }
 
     /// 􀯳
     /// Single Localization, 3 Layersets
@@ -6564,7 +6564,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "square3Layers3dBottomFilled")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "square3Layers3dBottomFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Layers3dBottomFilled")
-    static let square3Stack3dBottomFilled = SFSymbol(rawValue: "square.3.stack.3d.bottom.filled")
+    static var square3Stack3dBottomFilled: SFSymbol { .init(rawValue: "square.3.stack.3d.bottom.filled") }
 
     /// 􀯲
     /// Single Localization, 3 Layersets
@@ -6578,7 +6578,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "square3Layers3dMiddleFilled")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "square3Layers3dMiddleFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Layers3dMiddleFilled")
-    static let square3Stack3dMiddleFilled = SFSymbol(rawValue: "square.3.stack.3d.middle.filled")
+    static var square3Stack3dMiddleFilled: SFSymbol { .init(rawValue: "square.3.stack.3d.middle.filled") }
 
     /// 􀯱
     /// Single Localization, 3 Layersets
@@ -6592,7 +6592,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 16.0, renamed: "square3Layers3dTopFilled")
     @available(watchOS, introduced: 8.0, deprecated: 9.0, renamed: "square3Layers3dTopFilled")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Layers3dTopFilled")
-    static let square3Stack3dTopFilled = SFSymbol(rawValue: "square.3.stack.3d.top.filled")
+    static var square3Stack3dTopFilled: SFSymbol { .init(rawValue: "square.3.stack.3d.top.filled") }
 
     /// 􁅅
     /// Single Localization, 2 Layersets
@@ -6600,7 +6600,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareAndArrowUpCircle = SFSymbol(rawValue: "square.and.arrow.up.circle")
+    static var squareAndArrowUpCircle: SFSymbol { .init(rawValue: "square.and.arrow.up.circle") }
 
     /// 􁅆
     /// Single Localization, 3 Layersets
@@ -6609,7 +6609,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareAndArrowUpCircleFill = SFSymbol(rawValue: "square.and.arrow.up.circle.fill")
+    static var squareAndArrowUpCircleFill: SFSymbol { .init(rawValue: "square.and.arrow.up.circle.fill") }
 
     /// 􁂚
     /// Single Localization, 3 Layersets
@@ -6618,7 +6618,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpTrianglebadgeExclamationmark = SFSymbol(rawValue: "square.and.arrow.up.trianglebadge.exclamationmark")
+    static var squareAndArrowUpTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "square.and.arrow.up.trianglebadge.exclamationmark") }
 
     /// 􀿑
     /// Single Localization, 3 Layersets
@@ -6627,7 +6627,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareAndAtRectangleFill = SFSymbol(rawValue: "square.and.at.rectangle.fill")
+    static var squareAndAtRectangleFill: SFSymbol { .init(rawValue: "square.and.at.rectangle.fill") }
 
     /// 􀐔
     /// Single Localization, 2 Layersets
@@ -6635,14 +6635,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareAndLineVerticalAndSquareFilled = SFSymbol(rawValue: "square.and.line.vertical.and.square.filled")
+    static var squareAndLineVerticalAndSquareFilled: SFSymbol { .init(rawValue: "square.and.line.vertical.and.square.filled") }
 
     /// 􀪚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareBottomhalfFilled = SFSymbol(rawValue: "square.bottomhalf.filled")
+    static var squareBottomhalfFilled: SFSymbol { .init(rawValue: "square.bottomhalf.filled") }
 
     /// 􀧑
     /// Single Localization, 2 Layersets
@@ -6655,14 +6655,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledSquareDashed")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledSquareDashed")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledSquareDashed")
-    static let squareDashedInsetFilled = SFSymbol(rawValue: "square.dashed.inset.filled")
+    static var squareDashedInsetFilled: SFSymbol { .init(rawValue: "square.dashed.inset.filled") }
 
     /// 􀐒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareFillAndLineVerticalAndSquareFill = SFSymbol(rawValue: "square.fill.and.line.vertical.and.square.fill")
+    static var squareFillAndLineVerticalAndSquareFill: SFSymbol { .init(rawValue: "square.fill.and.line.vertical.and.square.fill") }
 
     /// 􀐓
     /// Single Localization, 2 Layersets
@@ -6670,7 +6670,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareFilledAndLineVerticalAndSquare = SFSymbol(rawValue: "square.filled.and.line.vertical.and.square")
+    static var squareFilledAndLineVerticalAndSquare: SFSymbol { .init(rawValue: "square.filled.and.line.vertical.and.square") }
 
     /// 􀫝
     /// Single Localization, 3 Layersets
@@ -6679,14 +6679,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareFilledOnSquare = SFSymbol(rawValue: "square.filled.on.square")
+    static var squareFilledOnSquare: SFSymbol { .init(rawValue: "square.filled.on.square") }
 
     /// 􀤲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareGrid3x1BelowLineGrid1x2Fill = SFSymbol(rawValue: "square.grid.3x1.below.line.grid.1x2.fill")
+    static var squareGrid3x1BelowLineGrid1x2Fill: SFSymbol { .init(rawValue: "square.grid.3x1.below.line.grid.1x2.fill") }
 
     /// 􀦺
     /// Single Localization, 2 Layersets
@@ -6694,7 +6694,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3BottomleftFilled = SFSymbol(rawValue: "square.grid.3x3.bottomleft.filled")
+    static var squareGrid3x3BottomleftFilled: SFSymbol { .init(rawValue: "square.grid.3x3.bottomleft.filled") }
 
     /// 􀦻
     /// Single Localization, 2 Layersets
@@ -6702,7 +6702,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3BottommiddleFilled = SFSymbol(rawValue: "square.grid.3x3.bottommiddle.filled")
+    static var squareGrid3x3BottommiddleFilled: SFSymbol { .init(rawValue: "square.grid.3x3.bottommiddle.filled") }
 
     /// 􀦼
     /// Single Localization, 2 Layersets
@@ -6710,7 +6710,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3BottomrightFilled = SFSymbol(rawValue: "square.grid.3x3.bottomright.filled")
+    static var squareGrid3x3BottomrightFilled: SFSymbol { .init(rawValue: "square.grid.3x3.bottomright.filled") }
 
     /// 􀦸
     /// Single Localization, 2 Layersets
@@ -6718,7 +6718,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3MiddleFilled = SFSymbol(rawValue: "square.grid.3x3.middle.filled")
+    static var squareGrid3x3MiddleFilled: SFSymbol { .init(rawValue: "square.grid.3x3.middle.filled") }
 
     /// 􀦷
     /// Single Localization, 2 Layersets
@@ -6726,7 +6726,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3MiddleleftFilled = SFSymbol(rawValue: "square.grid.3x3.middleleft.filled")
+    static var squareGrid3x3MiddleleftFilled: SFSymbol { .init(rawValue: "square.grid.3x3.middleleft.filled") }
 
     /// 􀦹
     /// Single Localization, 2 Layersets
@@ -6734,7 +6734,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3MiddlerightFilled = SFSymbol(rawValue: "square.grid.3x3.middleright.filled")
+    static var squareGrid3x3MiddlerightFilled: SFSymbol { .init(rawValue: "square.grid.3x3.middleright.filled") }
 
     /// 􀫐
     /// Single Localization, 2 Layersets
@@ -6742,7 +6742,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3Square = SFSymbol(rawValue: "square.grid.3x3.square")
+    static var squareGrid3x3Square: SFSymbol { .init(rawValue: "square.grid.3x3.square") }
 
     /// 􀦴
     /// Single Localization, 2 Layersets
@@ -6750,7 +6750,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3TopleftFilled = SFSymbol(rawValue: "square.grid.3x3.topleft.filled")
+    static var squareGrid3x3TopleftFilled: SFSymbol { .init(rawValue: "square.grid.3x3.topleft.filled") }
 
     /// 􀦵
     /// Single Localization, 2 Layersets
@@ -6758,7 +6758,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3TopmiddleFilled = SFSymbol(rawValue: "square.grid.3x3.topmiddle.filled")
+    static var squareGrid3x3TopmiddleFilled: SFSymbol { .init(rawValue: "square.grid.3x3.topmiddle.filled") }
 
     /// 􀦶
     /// Single Localization, 2 Layersets
@@ -6766,7 +6766,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareGrid3x3ToprightFilled = SFSymbol(rawValue: "square.grid.3x3.topright.filled")
+    static var squareGrid3x3ToprightFilled: SFSymbol { .init(rawValue: "square.grid.3x3.topright.filled") }
 
     /// 􀾘
     /// Single Localization, 2 Layersets
@@ -6779,21 +6779,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledSquare")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledSquare")
-    static let squareInsetFilled = SFSymbol(rawValue: "square.inset.filled")
+    static var squareInsetFilled: SFSymbol { .init(rawValue: "square.inset.filled") }
 
     /// 􀚓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareLefthalfFilled = SFSymbol(rawValue: "square.lefthalf.filled")
+    static var squareLefthalfFilled: SFSymbol { .init(rawValue: "square.lefthalf.filled") }
 
     /// 􀚔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareRighthalfFilled = SFSymbol(rawValue: "square.righthalf.filled")
+    static var squareRighthalfFilled: SFSymbol { .init(rawValue: "square.righthalf.filled") }
 
     /// 􀻡
     /// Single Localization, 2 Layersets
@@ -6801,7 +6801,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareTextSquare = SFSymbol(rawValue: "square.text.square")
+    static var squareTextSquare: SFSymbol { .init(rawValue: "square.text.square") }
 
     /// 􀻢
     /// Single Localization, 3 Layersets
@@ -6810,14 +6810,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let squareTextSquareFill = SFSymbol(rawValue: "square.text.square.fill")
+    static var squareTextSquareFill: SFSymbol { .init(rawValue: "square.text.square.fill") }
 
     /// 􀪛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareTophalfFilled = SFSymbol(rawValue: "square.tophalf.filled")
+    static var squareTophalfFilled: SFSymbol { .init(rawValue: "square.tophalf.filled") }
 
     /// 􁂪
     /// Single Localization, 2 Layersets
@@ -6825,7 +6825,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let starBubble = SFSymbol(rawValue: "star.bubble")
+    static var starBubble: SFSymbol { .init(rawValue: "star.bubble") }
 
     /// 􁂫
     /// Single Localization, 3 Layersets
@@ -6834,7 +6834,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let starBubbleFill = SFSymbol(rawValue: "star.bubble.fill")
+    static var starBubbleFill: SFSymbol { .init(rawValue: "star.bubble.fill") }
 
     /// 􀋄
     /// Single Localization, 2 Layersets
@@ -6842,7 +6842,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let starLeadinghalfFilled = SFSymbol(rawValue: "star.leadinghalf.filled")
+    static var starLeadinghalfFilled: SFSymbol { .init(rawValue: "star.leadinghalf.filled") }
 
     /// 􁇄
     /// Single Localization, 2 Layersets
@@ -6850,7 +6850,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let stethoscopeCircle = SFSymbol(rawValue: "stethoscope.circle")
+    static var stethoscopeCircle: SFSymbol { .init(rawValue: "stethoscope.circle") }
 
     /// 􁇅
     /// Single Localization, 3 Layersets
@@ -6859,14 +6859,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let stethoscopeCircleFill = SFSymbol(rawValue: "stethoscope.circle.fill")
+    static var stethoscopeCircleFill: SFSymbol { .init(rawValue: "stethoscope.circle.fill") }
 
     /// 􀶉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suitcase = SFSymbol(rawValue: "suitcase")
+    static var suitcase: SFSymbol { .init(rawValue: "suitcase") }
 
     /// 􀶋
     /// Single Localization, 2 Layersets
@@ -6874,7 +6874,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseCart = SFSymbol(rawValue: "suitcase.cart")
+    static var suitcaseCart: SFSymbol { .init(rawValue: "suitcase.cart") }
 
     /// 􀶌
     /// Single Localization, 2 Layersets
@@ -6882,14 +6882,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseCartFill = SFSymbol(rawValue: "suitcase.cart.fill")
+    static var suitcaseCartFill: SFSymbol { .init(rawValue: "suitcase.cart.fill") }
 
     /// 􀶊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suitcaseFill = SFSymbol(rawValue: "suitcase.fill")
+    static var suitcaseFill: SFSymbol { .init(rawValue: "suitcase.fill") }
 
     /// 􀻞
     /// Single Localization, 3 Layersets
@@ -6903,7 +6903,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "sunHorizon")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "sunHorizon")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sunHorizon")
-    static let sunAndHorizon = SFSymbol(rawValue: "sun.and.horizon")
+    static var sunAndHorizon: SFSymbol { .init(rawValue: "sun.and.horizon") }
 
     /// 􀻟
     /// Single Localization, 3 Layersets
@@ -6917,7 +6917,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "sunHorizonFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "sunHorizonFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sunHorizonFill")
-    static let sunAndHorizonFill = SFSymbol(rawValue: "sun.and.horizon.fill")
+    static var sunAndHorizonFill: SFSymbol { .init(rawValue: "sun.and.horizon.fill") }
 
     /// 􀷎
     /// Single Localization, 2 Layersets
@@ -6925,7 +6925,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunMaxCircle = SFSymbol(rawValue: "sun.max.circle")
+    static var sunMaxCircle: SFSymbol { .init(rawValue: "sun.max.circle") }
 
     /// 􀷏
     /// Single Localization, 3 Layersets
@@ -6934,7 +6934,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunMaxCircleFill = SFSymbol(rawValue: "sun.max.circle.fill")
+    static var sunMaxCircleFill: SFSymbol { .init(rawValue: "sun.max.circle.fill") }
 
     /// 􀏦
     /// Single Localization, 3 Layersets
@@ -6943,7 +6943,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let tablecellsFillBadgeEllipsis = SFSymbol(rawValue: "tablecells.fill.badge.ellipsis")
+    static var tablecellsFillBadgeEllipsis: SFSymbol { .init(rawValue: "tablecells.fill.badge.ellipsis") }
 
     /// 􀽁
     /// Single Localization, 2 Layersets
@@ -6951,7 +6951,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tagSquare = SFSymbol(rawValue: "tag.square")
+    static var tagSquare: SFSymbol { .init(rawValue: "tag.square") }
 
     /// 􀽂
     /// Single Localization, 3 Layersets
@@ -6960,7 +6960,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let tagSquareFill = SFSymbol(rawValue: "tag.square.fill")
+    static var tagSquareFill: SFSymbol { .init(rawValue: "tag.square.fill") }
 
     /// 􀻐
     /// Single Localization, 2 Layersets
@@ -6968,7 +6968,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let takeoutbagAndCupAndStraw = SFSymbol(rawValue: "takeoutbag.and.cup.and.straw")
+    static var takeoutbagAndCupAndStraw: SFSymbol { .init(rawValue: "takeoutbag.and.cup.and.straw") }
 
     /// 􀻑
     /// Single Localization, 2 Layersets
@@ -6976,7 +6976,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let takeoutbagAndCupAndStrawFill = SFSymbol(rawValue: "takeoutbag.and.cup.and.straw.fill")
+    static var takeoutbagAndCupAndStrawFill: SFSymbol { .init(rawValue: "takeoutbag.and.cup.and.straw.fill") }
 
     /// 􀴦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6987,7 +6987,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletypeAnswerCircle = SFSymbol(rawValue: "teletype.answer.circle")
+    static var teletypeAnswerCircle: SFSymbol { .init(rawValue: "teletype.answer.circle") }
 
     /// 􀴧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6998,7 +6998,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
-    static let teletypeAnswerCircleFill = SFSymbol(rawValue: "teletype.answer.circle.fill")
+    static var teletypeAnswerCircleFill: SFSymbol { .init(rawValue: "teletype.answer.circle.fill") }
 
     /// 􁂶
     /// Single Localization, 3 Layersets
@@ -7007,7 +7007,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let testtube2 = SFSymbol(rawValue: "testtube.2")
+    static var testtube2: SFSymbol { .init(rawValue: "testtube.2") }
 
     /// 􀹃
     /// Single Localization, 2 Layersets
@@ -7015,7 +7015,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textViewfinder = SFSymbol(rawValue: "text.viewfinder")
+    static var textViewfinder: SFSymbol { .init(rawValue: "text.viewfinder") }
 
     /// 􀺧
     /// Single Localization, 3 Layersets
@@ -7024,7 +7024,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let theatermasks = SFSymbol(rawValue: "theatermasks")
+    static var theatermasks: SFSymbol { .init(rawValue: "theatermasks") }
 
     /// 􁂻
     /// Single Localization, 2 Layersets
@@ -7032,7 +7032,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let theatermasksCircle = SFSymbol(rawValue: "theatermasks.circle")
+    static var theatermasksCircle: SFSymbol { .init(rawValue: "theatermasks.circle") }
 
     /// 􁂼
     /// Single Localization, 3 Layersets
@@ -7041,7 +7041,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let theatermasksCircleFill = SFSymbol(rawValue: "theatermasks.circle.fill")
+    static var theatermasksCircleFill: SFSymbol { .init(rawValue: "theatermasks.circle.fill") }
 
     /// 􀺨
     /// Single Localization, 2 Layersets
@@ -7049,35 +7049,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let theatermasksFill = SFSymbol(rawValue: "theatermasks.fill")
+    static var theatermasksFill: SFSymbol { .init(rawValue: "theatermasks.fill") }
 
     /// 􀼮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trainSideFrontCar = SFSymbol(rawValue: "train.side.front.car")
+    static var trainSideFrontCar: SFSymbol { .init(rawValue: "train.side.front.car") }
 
     /// 􀼯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trainSideMiddleCar = SFSymbol(rawValue: "train.side.middle.car")
+    static var trainSideMiddleCar: SFSymbol { .init(rawValue: "train.side.middle.car") }
 
     /// 􀼰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trainSideRearCar = SFSymbol(rawValue: "train.side.rear.car")
+    static var trainSideRearCar: SFSymbol { .init(rawValue: "train.side.rear.car") }
 
     /// 􀜝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tramFillTunnel = SFSymbol(rawValue: "tram.fill.tunnel")
+    static var tramFillTunnel: SFSymbol { .init(rawValue: "tram.fill.tunnel") }
 
     /// 􀡛
     /// Single Localization, 2 Layersets
@@ -7085,14 +7085,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let trapezoidAndLineHorizontal = SFSymbol(rawValue: "trapezoid.and.line.horizontal")
+    static var trapezoidAndLineHorizontal: SFSymbol { .init(rawValue: "trapezoid.and.line.horizontal") }
 
     /// 􀞑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trapezoidAndLineHorizontalFill = SFSymbol(rawValue: "trapezoid.and.line.horizontal.fill")
+    static var trapezoidAndLineHorizontalFill: SFSymbol { .init(rawValue: "trapezoid.and.line.horizontal.fill") }
 
     /// 􀡠
     /// Single Localization, 2 Layersets
@@ -7100,14 +7100,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let trapezoidAndLineVertical = SFSymbol(rawValue: "trapezoid.and.line.vertical")
+    static var trapezoidAndLineVertical: SFSymbol { .init(rawValue: "trapezoid.and.line.vertical") }
 
     /// 􀞐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trapezoidAndLineVerticalFill = SFSymbol(rawValue: "trapezoid.and.line.vertical.fill")
+    static var trapezoidAndLineVerticalFill: SFSymbol { .init(rawValue: "trapezoid.and.line.vertical.fill") }
 
     /// 􀿍
     /// Single Localization, 3 Layersets
@@ -7116,7 +7116,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSlashCircle = SFSymbol(rawValue: "trash.slash.circle")
+    static var trashSlashCircle: SFSymbol { .init(rawValue: "trash.slash.circle") }
 
     /// 􀿎
     /// Single Localization, 3 Layersets
@@ -7125,7 +7125,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSlashCircleFill = SFSymbol(rawValue: "trash.slash.circle.fill")
+    static var trashSlashCircleFill: SFSymbol { .init(rawValue: "trash.slash.circle.fill") }
 
     /// 􀿔
     /// Single Localization, 3 Layersets
@@ -7134,7 +7134,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSlashSquare = SFSymbol(rawValue: "trash.slash.square")
+    static var trashSlashSquare: SFSymbol { .init(rawValue: "trash.slash.square") }
 
     /// 􀿕
     /// Single Localization, 3 Layersets
@@ -7143,7 +7143,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSlashSquareFill = SFSymbol(rawValue: "trash.slash.square.fill")
+    static var trashSlashSquareFill: SFSymbol { .init(rawValue: "trash.slash.square.fill") }
 
     /// 􀼽
     /// Single Localization, 3 Layersets
@@ -7152,7 +7152,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSquare = SFSymbol(rawValue: "trash.square")
+    static var trashSquare: SFSymbol { .init(rawValue: "trash.square") }
 
     /// 􀼾
     /// Single Localization, 3 Layersets
@@ -7161,14 +7161,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trashSquareFill = SFSymbol(rawValue: "trash.square.fill")
+    static var trashSquareFill: SFSymbol { .init(rawValue: "trash.square.fill") }
 
     /// 􁀹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleBottomhalfFilled = SFSymbol(rawValue: "triangle.bottomhalf.filled")
+    static var triangleBottomhalfFilled: SFSymbol { .init(rawValue: "triangle.bottomhalf.filled") }
 
     /// 􀾙
     /// Single Localization, 2 Layersets
@@ -7181,42 +7181,42 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTriangle")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTriangle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTriangle")
-    static let triangleInsetFilled = SFSymbol(rawValue: "triangle.inset.filled")
+    static var triangleInsetFilled: SFSymbol { .init(rawValue: "triangle.inset.filled") }
 
     /// 􀚕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleLefthalfFilled = SFSymbol(rawValue: "triangle.lefthalf.filled")
+    static var triangleLefthalfFilled: SFSymbol { .init(rawValue: "triangle.lefthalf.filled") }
 
     /// 􀚖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleRighthalfFilled = SFSymbol(rawValue: "triangle.righthalf.filled")
+    static var triangleRighthalfFilled: SFSymbol { .init(rawValue: "triangle.righthalf.filled") }
 
     /// 􁀸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleTophalfFilled = SFSymbol(rawValue: "triangle.tophalf.filled")
+    static var triangleTophalfFilled: SFSymbol { .init(rawValue: "triangle.tophalf.filled") }
 
     /// 􀾠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tshirt = SFSymbol(rawValue: "tshirt")
+    static var tshirt: SFSymbol { .init(rawValue: "tshirt") }
 
     /// 􀾡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tshirtFill = SFSymbol(rawValue: "tshirt.fill")
+    static var tshirtFill: SFSymbol { .init(rawValue: "tshirt.fill") }
 
     /// 􀷘
     /// Single Localization, 2 Layersets
@@ -7229,7 +7229,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 18.0, renamed: "insetFilledTv")
     @available(watchOS, introduced: 8.0, deprecated: 11.0, renamed: "insetFilledTv")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTv")
-    static let tvInsetFilled = SFSymbol(rawValue: "tv.inset.filled")
+    static var tvInsetFilled: SFSymbol { .init(rawValue: "tv.inset.filled") }
 
     /// 􀼅
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7245,7 +7245,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "videoBadgeWaveform")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "videoBadgeWaveform")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "videoBadgeWaveform")
-    static let videoAndWaveform = SFSymbol(rawValue: "video.and.waveform")
+    static var videoAndWaveform: SFSymbol { .init(rawValue: "video.and.waveform") }
 
     /// 􀼆
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7261,7 +7261,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "videoBadgeWaveformFill")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "videoBadgeWaveformFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "videoBadgeWaveformFill")
-    static let videoAndWaveformFill = SFSymbol(rawValue: "video.and.waveform.fill")
+    static var videoAndWaveformFill: SFSymbol { .init(rawValue: "video.and.waveform.fill") }
 
     /// 􁃊
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7272,7 +7272,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBadgeEllipsis = SFSymbol(rawValue: "video.badge.ellipsis")
+    static var videoBadgeEllipsis: SFSymbol { .init(rawValue: "video.badge.ellipsis") }
 
     /// 􁃋
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7283,7 +7283,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoFillBadgeEllipsis = SFSymbol(rawValue: "video.fill.badge.ellipsis")
+    static var videoFillBadgeEllipsis: SFSymbol { .init(rawValue: "video.fill.badge.ellipsis") }
 
     /// 􀽉
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7294,7 +7294,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSquare = SFSymbol(rawValue: "video.square")
+    static var videoSquare: SFSymbol { .init(rawValue: "video.square") }
 
     /// 􀽊
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7305,7 +7305,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSquareFill = SFSymbol(rawValue: "video.square.fill")
+    static var videoSquareFill: SFSymbol { .init(rawValue: "video.square.fill") }
 
     /// 􀶡
     /// Single Localization, 2 Layersets
@@ -7313,7 +7313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wakeCircle = SFSymbol(rawValue: "wake.circle")
+    static var wakeCircle: SFSymbol { .init(rawValue: "wake.circle") }
 
     /// 􀶢
     /// Single Localization, 3 Layersets
@@ -7322,7 +7322,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wakeCircleFill = SFSymbol(rawValue: "wake.circle.fill")
+    static var wakeCircleFill: SFSymbol { .init(rawValue: "wake.circle.fill") }
 
     /// 􀺗
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7332,7 +7332,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let watchfaceApplewatchCase = SFSymbol(rawValue: "watchface.applewatch.case")
+    static var watchfaceApplewatchCase: SFSymbol { .init(rawValue: "watchface.applewatch.case") }
 
     /// 􀻾
     /// Single Localization, 3 Layersets
@@ -7346,7 +7346,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "waveformBadgeMagnifyingglass")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "waveformBadgeMagnifyingglass")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "waveformBadgeMagnifyingglass")
-    static let waveformAndMagnifyingglass = SFSymbol(rawValue: "waveform.and.magnifyingglass")
+    static var waveformAndMagnifyingglass: SFSymbol { .init(rawValue: "waveform.and.magnifyingglass") }
 
     /// 􁃨
     /// Single Localization, Single Layerset
@@ -7358,7 +7358,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.0, deprecated: 17.0, renamed: "waveformBadgeMic")
     @available(watchOS, introduced: 8.0, deprecated: 10.0, renamed: "waveformBadgeMic")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "waveformBadgeMic")
-    static let waveformAndMic = SFSymbol(rawValue: "waveform.and.mic")
+    static var waveformAndMic: SFSymbol { .init(rawValue: "waveform.and.mic") }
 
     /// 􀻽
     /// Single Localization, 3 Layersets
@@ -7367,7 +7367,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeExclamationmark = SFSymbol(rawValue: "waveform.badge.exclamationmark")
+    static var waveformBadgeExclamationmark: SFSymbol { .init(rawValue: "waveform.badge.exclamationmark") }
 
     /// 􀸷
     /// Single Localization, 3 Layersets
@@ -7376,7 +7376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeMinus = SFSymbol(rawValue: "waveform.badge.minus")
+    static var waveformBadgeMinus: SFSymbol { .init(rawValue: "waveform.badge.minus") }
 
     /// 􀸶
     /// Single Localization, 3 Layersets
@@ -7385,7 +7385,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgePlus = SFSymbol(rawValue: "waveform.badge.plus")
+    static var waveformBadgePlus: SFSymbol { .init(rawValue: "waveform.badge.plus") }
 
     /// 􀷖
     /// Single Localization, 3 Layersets
@@ -7394,7 +7394,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wifiCircle = SFSymbol(rawValue: "wifi.circle")
+    static var wifiCircle: SFSymbol { .init(rawValue: "wifi.circle") }
 
     /// 􀷗
     /// Single Localization, 3 Layersets
@@ -7403,7 +7403,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wifiCircleFill = SFSymbol(rawValue: "wifi.circle.fill")
+    static var wifiCircleFill: SFSymbol { .init(rawValue: "wifi.circle.fill") }
 
     /// 􀽗
     /// Single Localization, 3 Layersets
@@ -7412,7 +7412,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wifiSquare = SFSymbol(rawValue: "wifi.square")
+    static var wifiSquare: SFSymbol { .init(rawValue: "wifi.square") }
 
     /// 􀽘
     /// Single Localization, 3 Layersets
@@ -7421,7 +7421,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let wifiSquareFill = SFSymbol(rawValue: "wifi.square.fill")
+    static var wifiSquareFill: SFSymbol { .init(rawValue: "wifi.square.fill") }
 
     /// 􀺾
     /// Single Localization, 3 Layersets
@@ -7430,7 +7430,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let xmarkApp = SFSymbol(rawValue: "xmark.app")
+    static var xmarkApp: SFSymbol { .init(rawValue: "xmark.app") }
 
     /// 􀻀
     /// Single Localization, 3 Layersets
@@ -7439,5 +7439,5 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let xmarkAppFill = SFSymbol(rawValue: "xmark.app.fill")
+    static var xmarkAppFill: SFSymbol { .init(rawValue: "xmark.app.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+3.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+3.1.swift
@@ -9,7 +9,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let boltRingClosed = SFSymbol(rawValue: "bolt.ring.closed")
+    static var boltRingClosed: SFSymbol { .init(rawValue: "bolt.ring.closed") }
 
     /// 􁋂
     /// Single Localization, 2 Layersets
@@ -17,7 +17,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platterFilledBottomAndArrowDownIphone = SFSymbol(rawValue: "platter.filled.bottom.and.arrow.down.iphone")
+    static var platterFilledBottomAndArrowDownIphone: SFSymbol { .init(rawValue: "platter.filled.bottom.and.arrow.down.iphone") }
 
     /// 􁋀
     /// Single Localization, 2 Layersets
@@ -25,7 +25,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platterFilledBottomIphone = SFSymbol(rawValue: "platter.filled.bottom.iphone")
+    static var platterFilledBottomIphone: SFSymbol { .init(rawValue: "platter.filled.bottom.iphone") }
 
     /// 􁋁
     /// Single Localization, 2 Layersets
@@ -33,7 +33,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platterFilledTopAndArrowUpIphone = SFSymbol(rawValue: "platter.filled.top.and.arrow.up.iphone")
+    static var platterFilledTopAndArrowUpIphone: SFSymbol { .init(rawValue: "platter.filled.top.and.arrow.up.iphone") }
 
     /// 􁊿
     /// Single Localization, 2 Layersets
@@ -41,7 +41,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let platterFilledTopIphone = SFSymbol(rawValue: "platter.filled.top.iphone")
+    static var platterFilledTopIphone: SFSymbol { .init(rawValue: "platter.filled.top.iphone") }
 
     /// 􁋜
     /// Single Localization, 3 Layersets
@@ -50,7 +50,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let square3Layers3dDownBackward = SFSymbol(rawValue: "square.3.layers.3d.down.backward")
+    static var square3Layers3dDownBackward: SFSymbol { .init(rawValue: "square.3.layers.3d.down.backward") }
 
     /// 􁋛
     /// Single Localization, 3 Layersets
@@ -59,7 +59,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let square3Layers3dDownForward = SFSymbol(rawValue: "square.3.layers.3d.down.forward")
+    static var square3Layers3dDownForward: SFSymbol { .init(rawValue: "square.3.layers.3d.down.forward") }
 
     /// 􁉼
     /// Single Localization, 3 Layersets
@@ -68,7 +68,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let square3Layers3dDownLeft = SFSymbol(rawValue: "square.3.layers.3d.down.left")
+    static var square3Layers3dDownLeft: SFSymbol { .init(rawValue: "square.3.layers.3d.down.left") }
 
     /// 􁉽
     /// Single Localization, 3 Layersets
@@ -77,33 +77,33 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let square3Layers3dDownRight = SFSymbol(rawValue: "square.3.layers.3d.down.right")
+    static var square3Layers3dDownRight: SFSymbol { .init(rawValue: "square.3.layers.3d.down.right") }
 
     /// 􁉀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textJustifyLeading = SFSymbol(rawValue: "text.justify.leading")
+    static var textJustifyLeading: SFSymbol { .init(rawValue: "text.justify.leading") }
 
     /// 􀌄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textJustifyLeft = SFSymbol(rawValue: "text.justify.left")
+    static var textJustifyLeft: SFSymbol { .init(rawValue: "text.justify.left") }
 
     /// 􀌅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textJustifyRight = SFSymbol(rawValue: "text.justify.right")
+    static var textJustifyRight: SFSymbol { .init(rawValue: "text.justify.right") }
 
     /// 􁉁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textJustifyTrailing = SFSymbol(rawValue: "text.justify.trailing")
+    static var textJustifyTrailing: SFSymbol { .init(rawValue: "text.justify.trailing") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+3.2.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+3.2.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodGen3Left = SFSymbol(rawValue: "airpod.gen3.left")
+    static var airpodGen3Left: SFSymbol { .init(rawValue: "airpod.gen3.left") }
 
     /// 􁄢
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -19,7 +19,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodGen3Right = SFSymbol(rawValue: "airpod.gen3.right")
+    static var airpodGen3Right: SFSymbol { .init(rawValue: "airpod.gen3.right") }
 
     /// 􁄡
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -28,7 +28,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen3 = SFSymbol(rawValue: "airpods.gen3")
+    static var airpodsGen3: SFSymbol { .init(rawValue: "airpods.gen3") }
 
     /// 􁅐
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -37,7 +37,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen3ChargingcaseWireless = SFSymbol(rawValue: "airpods.gen3.chargingcase.wireless")
+    static var airpodsGen3ChargingcaseWireless: SFSymbol { .init(rawValue: "airpods.gen3.chargingcase.wireless") }
 
     /// 􁅑
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen3ChargingcaseWirelessFill = SFSymbol(rawValue: "airpods.gen3.chargingcase.wireless.fill")
+    static var airpodsGen3ChargingcaseWirelessFill: SFSymbol { .init(rawValue: "airpods.gen3.chargingcase.wireless.fill") }
 
     /// 􁅞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -61,7 +61,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 17.0, renamed: "beatsFitpro")
     @available(watchOS, introduced: 8.3, deprecated: 10.0, renamed: "beatsFitpro")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "beatsFitpro")
-    static let beatsFitPro = SFSymbol(rawValue: "beats.fit.pro")
+    static var beatsFitPro: SFSymbol { .init(rawValue: "beats.fit.pro") }
 
     /// 􁅡
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -75,7 +75,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 17.0, renamed: "beatsFitproChargingcase")
     @available(watchOS, introduced: 8.3, deprecated: 10.0, renamed: "beatsFitproChargingcase")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "beatsFitproChargingcase")
-    static let beatsFitProChargingcase = SFSymbol(rawValue: "beats.fit.pro.chargingcase")
+    static var beatsFitProChargingcase: SFSymbol { .init(rawValue: "beats.fit.pro.chargingcase") }
 
     /// 􁅢
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -89,7 +89,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 17.0, renamed: "beatsFitproChargingcaseFill")
     @available(watchOS, introduced: 8.3, deprecated: 10.0, renamed: "beatsFitproChargingcaseFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "beatsFitproChargingcaseFill")
-    static let beatsFitProChargingcaseFill = SFSymbol(rawValue: "beats.fit.pro.chargingcase.fill")
+    static var beatsFitProChargingcaseFill: SFSymbol { .init(rawValue: "beats.fit.pro.chargingcase.fill") }
 
     /// 􁅟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -104,7 +104,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 17.0, renamed: "beatsFitproLeft")
     @available(watchOS, introduced: 8.3, deprecated: 10.0, renamed: "beatsFitproLeft")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "beatsFitproLeft")
-    static let beatsFitProLeft = SFSymbol(rawValue: "beats.fit.pro.left")
+    static var beatsFitProLeft: SFSymbol { .init(rawValue: "beats.fit.pro.left") }
 
     /// 􁅠
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -119,21 +119,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 17.0, renamed: "beatsFitproRight")
     @available(watchOS, introduced: 8.3, deprecated: 10.0, renamed: "beatsFitproRight")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "beatsFitproRight")
-    static let beatsFitProRight = SFSymbol(rawValue: "beats.fit.pro.right")
+    static var beatsFitProRight: SFSymbol { .init(rawValue: "beats.fit.pro.right") }
 
     /// 􁋶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleLeadinghalfFilled = SFSymbol(rawValue: "rectangle.leadinghalf.filled")
+    static var rectangleLeadinghalfFilled: SFSymbol { .init(rawValue: "rectangle.leadinghalf.filled") }
 
     /// 􁋷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleTrailinghalfFilled = SFSymbol(rawValue: "rectangle.trailinghalf.filled")
+    static var rectangleTrailinghalfFilled: SFSymbol { .init(rawValue: "rectangle.trailinghalf.filled") }
 
     /// 􁋽
     /// Single Localization, 2 Layersets
@@ -141,7 +141,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let square3Layers3dDownLeftSlash = SFSymbol(rawValue: "square.3.layers.3d.down.left.slash")
+    static var square3Layers3dDownLeftSlash: SFSymbol { .init(rawValue: "square.3.layers.3d.down.left.slash") }
 
     /// 􁋼
     /// Single Localization, 2 Layersets
@@ -149,7 +149,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let square3Layers3dDownRightSlash = SFSymbol(rawValue: "square.3.layers.3d.down.right.slash")
+    static var square3Layers3dDownRightSlash: SFSymbol { .init(rawValue: "square.3.layers.3d.down.right.slash") }
 
     /// 􁌅
     /// Single Localization, 2 Layersets
@@ -162,5 +162,5 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.2, deprecated: 16.0, renamed: "square3Layers3dSlash")
     @available(watchOS, introduced: 8.3, deprecated: 9.0, renamed: "square3Layers3dSlash")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "square3Layers3dSlash")
-    static let square3Stack3dSlash = SFSymbol(rawValue: "square.3.stack.3d.slash")
+    static var square3Stack3dSlash: SFSymbol { .init(rawValue: "square.3.stack.3d.slash") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+3.3.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+3.3.swift
@@ -8,7 +8,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let cameraMacro = SFSymbol(rawValue: "camera.macro")
+    static var cameraMacro: SFSymbol { .init(rawValue: "camera.macro") }
 
     /// 􁂃
     /// Single Localization, 2 Layersets
@@ -16,7 +16,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraMacroCircle = SFSymbol(rawValue: "camera.macro.circle")
+    static var cameraMacroCircle: SFSymbol { .init(rawValue: "camera.macro.circle") }
 
     /// 􁂄
     /// Single Localization, 3 Layersets
@@ -25,7 +25,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0)
-    static let cameraMacroCircleFill = SFSymbol(rawValue: "camera.macro.circle.fill")
+    static var cameraMacroCircleFill: SFSymbol { .init(rawValue: "camera.macro.circle.fill") }
 
     /// 􁑢
     /// Single Localization, 2 Layersets
@@ -38,7 +38,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 15.4, deprecated: 26.0, renamed: "dotsAndLineVerticalAndPointerArrowRectangle")
     @available(watchOS, introduced: 8.5, deprecated: 26.0, renamed: "dotsAndLineVerticalAndPointerArrowRectangle")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "dotsAndLineVerticalAndPointerArrowRectangle")
-    static let dotsAndLineVerticalAndCursorarrowRectangle = SFSymbol(rawValue: "dots.and.line.vertical.and.cursorarrow.rectangle")
+    static var dotsAndLineVerticalAndCursorarrowRectangle: SFSymbol { .init(rawValue: "dots.and.line.vertical.and.cursorarrow.rectangle") }
 
     /// 􁎕
     /// Single Localization, 2 Layersets
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyViewfinder = SFSymbol(rawValue: "key.viewfinder")
+    static var keyViewfinder: SFSymbol { .init(rawValue: "key.viewfinder") }
 
     /// 􁏺
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -56,7 +56,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to creating or signing in with a passkey.
-    static let personBadgeKey = SFSymbol(rawValue: "person.badge.key")
+    static var personBadgeKey: SFSymbol { .init(rawValue: "person.badge.key") }
 
     /// 􁎨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -66,5 +66,5 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to creating or signing in with a passkey.
-    static let personBadgeKeyFill = SFSymbol(rawValue: "person.badge.key.fill")
+    static var personBadgeKeyFill: SFSymbol { .init(rawValue: "person.badge.key.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+4.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+4.0.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let absBrakesignal = SFSymbol(rawValue: "abs.brakesignal")
+    static var absBrakesignal: SFSymbol { .init(rawValue: "abs.brakesignal") }
 
     /// 􁓭
     /// Single Localization, 2 Layersets
@@ -18,7 +18,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airConditionerHorizontal = SFSymbol(rawValue: "air.conditioner.horizontal")
+    static var airConditionerHorizontal: SFSymbol { .init(rawValue: "air.conditioner.horizontal") }
 
     /// 􁓮
     /// Single Localization, 2 Layersets
@@ -26,7 +26,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airConditionerHorizontalFill = SFSymbol(rawValue: "air.conditioner.horizontal.fill")
+    static var airConditionerHorizontalFill: SFSymbol { .init(rawValue: "air.conditioner.horizontal.fill") }
 
     /// 􁓫
     /// Single Localization, 2 Layersets
@@ -34,7 +34,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airConditionerVertical = SFSymbol(rawValue: "air.conditioner.vertical")
+    static var airConditionerVertical: SFSymbol { .init(rawValue: "air.conditioner.vertical") }
 
     /// 􁓬
     /// Single Localization, 2 Layersets
@@ -42,7 +42,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airConditionerVerticalFill = SFSymbol(rawValue: "air.conditioner.vertical.fill")
+    static var airConditionerVerticalFill: SFSymbol { .init(rawValue: "air.conditioner.vertical.fill") }
 
     /// 􁓥
     /// Single Localization, 2 Layersets
@@ -50,7 +50,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airPurifier = SFSymbol(rawValue: "air.purifier")
+    static var airPurifier: SFSymbol { .init(rawValue: "air.purifier") }
 
     /// 􁓦
     /// Single Localization, 2 Layersets
@@ -58,7 +58,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airPurifierFill = SFSymbol(rawValue: "air.purifier.fill")
+    static var airPurifierFill: SFSymbol { .init(rawValue: "air.purifier.fill") }
 
     /// 􁗀
     /// Single Localization, 3 Layersets
@@ -67,7 +67,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let alarmWavesLeftAndRight = SFSymbol(rawValue: "alarm.waves.left.and.right")
+    static var alarmWavesLeftAndRight: SFSymbol { .init(rawValue: "alarm.waves.left.and.right") }
 
     /// 􁗁
     /// Single Localization, 3 Layersets
@@ -76,21 +76,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let alarmWavesLeftAndRightFill = SFSymbol(rawValue: "alarm.waves.left.and.right.fill")
+    static var alarmWavesLeftAndRightFill: SFSymbol { .init(rawValue: "alarm.waves.left.and.right.fill") }
 
     /// 􁒆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let allergensFill = SFSymbol(rawValue: "allergens.fill")
+    static var allergensFill: SFSymbol { .init(rawValue: "allergens.fill") }
 
     /// 􁑡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let angle = SFSymbol(rawValue: "angle")
+    static var angle: SFSymbol { .init(rawValue: "angle") }
 
     /// 􀣺
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -99,7 +99,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Sign in with Apple.
-    static let appleLogo = SFSymbol(rawValue: "apple.logo")
+    static var appleLogo: SFSymbol { .init(rawValue: "apple.logo") }
 
     /// 􀚍
     /// Single Localization, 2 Layersets
@@ -107,7 +107,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowDownAndLineHorizontalAndArrowUp = SFSymbol(rawValue: "arrow.down.and.line.horizontal.and.arrow.up")
+    static var arrowDownAndLineHorizontalAndArrowUp: SFSymbol { .init(rawValue: "arrow.down.and.line.horizontal.and.arrow.up") }
 
     /// 􁒞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -117,7 +117,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let arrowDownMessage = SFSymbol(rawValue: "arrow.down.message")
+    static var arrowDownMessage: SFSymbol { .init(rawValue: "arrow.down.message") }
 
     /// 􁒟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -128,7 +128,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let arrowDownMessageFill = SFSymbol(rawValue: "arrow.down.message.fill")
+    static var arrowDownMessageFill: SFSymbol { .init(rawValue: "arrow.down.message.fill") }
 
     /// 􀚋
     /// Single Localization, 2 Layersets
@@ -136,7 +136,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowLeftAndLineVerticalAndArrowRight = SFSymbol(rawValue: "arrow.left.and.line.vertical.and.arrow.right")
+    static var arrowLeftAndLineVerticalAndArrowRight: SFSymbol { .init(rawValue: "arrow.left.and.line.vertical.and.arrow.right") }
 
     /// 􁖭
     /// Single Localization, 2 Layersets
@@ -144,7 +144,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowLeftAndRightTextVertical = SFSymbol(rawValue: "arrow.left.and.right.text.vertical")
+    static var arrowLeftAndRightTextVertical: SFSymbol { .init(rawValue: "arrow.left.and.right.text.vertical") }
 
     /// 􀚌
     /// Single Localization, 2 Layersets
@@ -152,14 +152,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowRightAndLineVerticalAndArrowLeft = SFSymbol(rawValue: "arrow.right.and.line.vertical.and.arrow.left")
+    static var arrowRightAndLineVerticalAndArrowLeft: SFSymbol { .init(rawValue: "arrow.right.and.line.vertical.and.arrow.left") }
 
     /// 􁒏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpAndDownAndSparkles = SFSymbol(rawValue: "arrow.up.and.down.and.sparkles")
+    static var arrowUpAndDownAndSparkles: SFSymbol { .init(rawValue: "arrow.up.and.down.and.sparkles") }
 
     /// 􀵬
     /// Single Localization, 2 Layersets
@@ -167,7 +167,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpAndDownTextHorizontal = SFSymbol(rawValue: "arrow.up.and.down.text.horizontal")
+    static var arrowUpAndDownTextHorizontal: SFSymbol { .init(rawValue: "arrow.up.and.down.text.horizontal") }
 
     /// 􀚎
     /// Single Localization, 2 Layersets
@@ -175,7 +175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let arrowUpAndLineHorizontalAndArrowDown = SFSymbol(rawValue: "arrow.up.and.line.horizontal.and.arrow.down")
+    static var arrowUpAndLineHorizontalAndArrowDown: SFSymbol { .init(rawValue: "arrow.up.and.line.horizontal.and.arrow.down") }
 
     /// 􁎳
     /// Single Localization, 3 Layersets
@@ -184,63 +184,63 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpCircleBadgeClock = SFSymbol(rawValue: "arrow.up.circle.badge.clock")
+    static var arrowUpCircleBadgeClock: SFSymbol { .init(rawValue: "arrow.up.circle.badge.clock") }
 
     /// 􁉈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBackward = SFSymbol(rawValue: "arrowshape.backward")
+    static var arrowshapeBackward: SFSymbol { .init(rawValue: "arrowshape.backward") }
 
     /// 􁉉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeBackwardFill = SFSymbol(rawValue: "arrowshape.backward.fill")
+    static var arrowshapeBackwardFill: SFSymbol { .init(rawValue: "arrowshape.backward.fill") }
 
     /// 􁉆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeForward = SFSymbol(rawValue: "arrowshape.forward")
+    static var arrowshapeForward: SFSymbol { .init(rawValue: "arrowshape.forward") }
 
     /// 􁉇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeForwardFill = SFSymbol(rawValue: "arrowshape.forward.fill")
+    static var arrowshapeForwardFill: SFSymbol { .init(rawValue: "arrowshape.forward.fill") }
 
     /// 􁉄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeLeft = SFSymbol(rawValue: "arrowshape.left")
+    static var arrowshapeLeft: SFSymbol { .init(rawValue: "arrowshape.left") }
 
     /// 􁉅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeLeftFill = SFSymbol(rawValue: "arrowshape.left.fill")
+    static var arrowshapeLeftFill: SFSymbol { .init(rawValue: "arrowshape.left.fill") }
 
     /// 􁉂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeRight = SFSymbol(rawValue: "arrowshape.right")
+    static var arrowshapeRight: SFSymbol { .init(rawValue: "arrowshape.right") }
 
     /// 􁉃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeRightFill = SFSymbol(rawValue: "arrowshape.right.fill")
+    static var arrowshapeRightFill: SFSymbol { .init(rawValue: "arrowshape.right.fill") }
 
     /// 􁎱
     /// 2 Localizations, 3 Layersets
@@ -253,7 +253,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeTurnUpBackwardBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "arrowshape.turn.up.backward.badge.clock")
+    static var arrowshapeTurnUpBackwardBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "arrowshape.turn.up.backward.badge.clock") }
 
     /// 􁖾
     /// 2 Localizations, 3 Layersets
@@ -266,42 +266,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeTurnUpBackwardBadgeClockFill = SymbolWith1Localization<Rtl>(rawValue: "arrowshape.turn.up.backward.badge.clock.fill")
+    static var arrowshapeTurnUpBackwardBadgeClockFill: SymbolWith1Localization<Rtl> { .init(rawValue: "arrowshape.turn.up.backward.badge.clock.fill") }
 
     /// 􁑐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let australsign = SFSymbol(rawValue: "australsign")
+    static var australsign: SFSymbol { .init(rawValue: "australsign") }
 
     /// 􁓺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let avRemote = SFSymbol(rawValue: "av.remote")
+    static var avRemote: SFSymbol { .init(rawValue: "av.remote") }
 
     /// 􁓻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let avRemoteFill = SFSymbol(rawValue: "av.remote.fill")
+    static var avRemoteFill: SFSymbol { .init(rawValue: "av.remote.fill") }
 
     /// 􁋹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backpack = SFSymbol(rawValue: "backpack")
+    static var backpack: SFSymbol { .init(rawValue: "backpack") }
 
     /// 􁋺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let backpackFill = SFSymbol(rawValue: "backpack.fill")
+    static var backpackFill: SFSymbol { .init(rawValue: "backpack.fill") }
 
     /// 􁋮
     /// Single Localization, 2 Layersets
@@ -309,7 +309,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let backwardEndCircle = SFSymbol(rawValue: "backward.end.circle")
+    static var backwardEndCircle: SFSymbol { .init(rawValue: "backward.end.circle") }
 
     /// 􁋯
     /// Single Localization, 3 Layersets
@@ -318,7 +318,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let backwardEndCircleFill = SFSymbol(rawValue: "backward.end.circle.fill")
+    static var backwardEndCircleFill: SFSymbol { .init(rawValue: "backward.end.circle.fill") }
 
     /// 􁚢
     /// 2 Localizations, 3 Layersets
@@ -331,7 +331,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bagBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "bag.badge.questionmark")
+    static var bagBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "bag.badge.questionmark") }
 
     /// 􁚣
     /// 2 Localizations, 3 Layersets
@@ -344,21 +344,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bagFillBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "bag.fill.badge.questionmark")
+    static var bagFillBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "bag.fill.badge.questionmark") }
 
     /// 􁑜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bahtsign = SFSymbol(rawValue: "bahtsign")
+    static var bahtsign: SFSymbol { .init(rawValue: "bahtsign") }
 
     /// 􁔎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let balloon = SFSymbol(rawValue: "balloon")
+    static var balloon: SFSymbol { .init(rawValue: "balloon") }
 
     /// 􁓷
     /// Single Localization, 3 Layersets
@@ -367,7 +367,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let balloon2 = SFSymbol(rawValue: "balloon.2")
+    static var balloon2: SFSymbol { .init(rawValue: "balloon.2") }
 
     /// 􁓸
     /// Single Localization, 2 Layersets
@@ -375,21 +375,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let balloon2Fill = SFSymbol(rawValue: "balloon.2.fill")
+    static var balloon2Fill: SFSymbol { .init(rawValue: "balloon.2.fill") }
 
     /// 􁔏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let balloonFill = SFSymbol(rawValue: "balloon.fill")
+    static var balloonFill: SFSymbol { .init(rawValue: "balloon.fill") }
 
     /// 􀡵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let baseball = SFSymbol(rawValue: "baseball")
+    static var baseball: SFSymbol { .init(rawValue: "baseball") }
 
     /// 􁚻
     /// Single Localization, 2 Layersets
@@ -397,7 +397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let baseballCircle = SFSymbol(rawValue: "baseball.circle")
+    static var baseballCircle: SFSymbol { .init(rawValue: "baseball.circle") }
 
     /// 􁚼
     /// Single Localization, 3 Layersets
@@ -406,42 +406,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let baseballCircleFill = SFSymbol(rawValue: "baseball.circle.fill")
+    static var baseballCircleFill: SFSymbol { .init(rawValue: "baseball.circle.fill") }
 
     /// 􁑠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let baseballDiamondBases = SFSymbol(rawValue: "baseball.diamond.bases")
+    static var baseballDiamondBases: SFSymbol { .init(rawValue: "baseball.diamond.bases") }
 
     /// 􀡶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let baseballFill = SFSymbol(rawValue: "baseball.fill")
+    static var baseballFill: SFSymbol { .init(rawValue: "baseball.fill") }
 
     /// 􁖊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let basket = SFSymbol(rawValue: "basket")
+    static var basket: SFSymbol { .init(rawValue: "basket") }
 
     /// 􁖋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let basketFill = SFSymbol(rawValue: "basket.fill")
+    static var basketFill: SFSymbol { .init(rawValue: "basket.fill") }
 
     /// 􁗉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let basketball = SFSymbol(rawValue: "basketball")
+    static var basketball: SFSymbol { .init(rawValue: "basketball") }
 
     /// 􁚽
     /// Single Localization, 2 Layersets
@@ -449,7 +449,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let basketballCircle = SFSymbol(rawValue: "basketball.circle")
+    static var basketballCircle: SFSymbol { .init(rawValue: "basketball.circle") }
 
     /// 􁚾
     /// Single Localization, 3 Layersets
@@ -458,28 +458,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let basketballCircleFill = SFSymbol(rawValue: "basketball.circle.fill")
+    static var basketballCircleFill: SFSymbol { .init(rawValue: "basketball.circle.fill") }
 
     /// 􁗊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let basketballFill = SFSymbol(rawValue: "basketball.fill")
+    static var basketballFill: SFSymbol { .init(rawValue: "basketball.fill") }
 
     /// 􁐼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bathtub = SFSymbol(rawValue: "bathtub")
+    static var bathtub: SFSymbol { .init(rawValue: "bathtub") }
 
     /// 􁐽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bathtubFill = SFSymbol(rawValue: "bathtub.fill")
+    static var bathtubFill: SFSymbol { .init(rawValue: "bathtub.fill") }
 
     /// 􁁔
     /// Single Localization, 3 Layersets
@@ -493,7 +493,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "battery100percentCircle")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "battery100percentCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery100percentCircle")
-    static let battery100Circle = SFSymbol(rawValue: "battery.100.circle")
+    static var battery100Circle: SFSymbol { .init(rawValue: "battery.100.circle") }
 
     /// 􁁕
     /// Single Localization, 3 Layersets
@@ -507,21 +507,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "battery100percentCircleFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "battery100percentCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "battery100percentCircleFill")
-    static let battery100CircleFill = SFSymbol(rawValue: "battery.100.circle.fill")
+    static var battery100CircleFill: SFSymbol { .init(rawValue: "battery.100.circle.fill") }
 
     /// 􁋸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let beachUmbrella = SFSymbol(rawValue: "beach.umbrella")
+    static var beachUmbrella: SFSymbol { .init(rawValue: "beach.umbrella") }
 
     /// 􁋻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let beachUmbrellaFill = SFSymbol(rawValue: "beach.umbrella.fill")
+    static var beachUmbrellaFill: SFSymbol { .init(rawValue: "beach.umbrella.fill") }
 
     /// 􁄤
     /// Single Localization, 3 Layersets
@@ -530,7 +530,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellAndWavesLeftAndRight = SFSymbol(rawValue: "bell.and.waves.left.and.right")
+    static var bellAndWavesLeftAndRight: SFSymbol { .init(rawValue: "bell.and.waves.left.and.right") }
 
     /// 􁄠
     /// Single Localization, 3 Layersets
@@ -539,42 +539,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellAndWavesLeftAndRightFill = SFSymbol(rawValue: "bell.and.waves.left.and.right.fill")
+    static var bellAndWavesLeftAndRightFill: SFSymbol { .init(rawValue: "bell.and.waves.left.and.right.fill") }
 
     /// 􁗟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bird = SFSymbol(rawValue: "bird")
+    static var bird: SFSymbol { .init(rawValue: "bird") }
 
     /// 􁗠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let birdFill = SFSymbol(rawValue: "bird.fill")
+    static var birdFill: SFSymbol { .init(rawValue: "bird.fill") }
 
     /// 􁖩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let birthdayCake = SFSymbol(rawValue: "birthday.cake")
+    static var birthdayCake: SFSymbol { .init(rawValue: "birthday.cake") }
 
     /// 􁖪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let birthdayCakeFill = SFSymbol(rawValue: "birthday.cake.fill")
+    static var birthdayCakeFill: SFSymbol { .init(rawValue: "birthday.cake.fill") }
 
     /// 􁑞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bitcoinsign = SFSymbol(rawValue: "bitcoinsign")
+    static var bitcoinsign: SFSymbol { .init(rawValue: "bitcoinsign") }
 
     /// 􁑶
     /// Single Localization, 2 Layersets
@@ -582,7 +582,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let blindsHorizontalClosed = SFSymbol(rawValue: "blinds.horizontal.closed")
+    static var blindsHorizontalClosed: SFSymbol { .init(rawValue: "blinds.horizontal.closed") }
 
     /// 􁑵
     /// Single Localization, 2 Layersets
@@ -590,7 +590,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let blindsHorizontalOpen = SFSymbol(rawValue: "blinds.horizontal.open")
+    static var blindsHorizontalOpen: SFSymbol { .init(rawValue: "blinds.horizontal.open") }
 
     /// 􁑴
     /// Single Localization, 2 Layersets
@@ -598,7 +598,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let blindsVerticalClosed = SFSymbol(rawValue: "blinds.vertical.closed")
+    static var blindsVerticalClosed: SFSymbol { .init(rawValue: "blinds.vertical.closed") }
 
     /// 􁑳
     /// Single Localization, 2 Layersets
@@ -606,7 +606,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let blindsVerticalOpen = SFSymbol(rawValue: "blinds.vertical.open")
+    static var blindsVerticalOpen: SFSymbol { .init(rawValue: "blinds.vertical.open") }
 
     /// 􁐓
     /// Single Localization, 3 Layersets
@@ -615,7 +615,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeClock = SFSymbol(rawValue: "bolt.badge.clock")
+    static var boltBadgeClock: SFSymbol { .init(rawValue: "bolt.badge.clock") }
 
     /// 􁐔
     /// Single Localization, 3 Layersets
@@ -624,7 +624,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeClockFill = SFSymbol(rawValue: "bolt.badge.clock.fill")
+    static var boltBadgeClockFill: SFSymbol { .init(rawValue: "bolt.badge.clock.fill") }
 
     /// 􁊉
     /// Single Localization, 3 Layersets
@@ -633,7 +633,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let boltBrakesignal = SFSymbol(rawValue: "bolt.brakesignal")
+    static var boltBrakesignal: SFSymbol { .init(rawValue: "bolt.brakesignal") }
 
     /// 􁁾
     /// Single Localization, Single Layerset
@@ -645,7 +645,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "truckBox")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "truckBox")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "truckBox")
-    static let boxTruck = SFSymbol(rawValue: "box.truck")
+    static var boxTruck: SFSymbol { .init(rawValue: "box.truck") }
 
     /// 􁂀
     /// 2 Localizations, 3 Layersets
@@ -663,7 +663,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "truckBoxBadgeClock")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "truckBoxBadgeClock")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "truckBoxBadgeClock")
-    static let boxTruckBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "box.truck.badge.clock")
+    static var boxTruckBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "box.truck.badge.clock") }
 
     /// 􁂁
     /// 2 Localizations, 3 Layersets
@@ -681,7 +681,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "truckBoxBadgeClockFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "truckBoxBadgeClockFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "truckBoxBadgeClockFill")
-    static let boxTruckBadgeClockFill = SymbolWith1Localization<Rtl>(rawValue: "box.truck.badge.clock.fill")
+    static var boxTruckBadgeClockFill: SymbolWith1Localization<Rtl> { .init(rawValue: "box.truck.badge.clock.fill") }
 
     /// 􁁿
     /// Single Localization, Single Layerset
@@ -693,7 +693,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "truckBoxFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "truckBoxFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "truckBoxFill")
-    static let boxTruckFill = SFSymbol(rawValue: "box.truck.fill")
+    static var boxTruckFill: SFSymbol { .init(rawValue: "box.truck.fill") }
 
     /// 􀾾
     /// Single Localization, 2 Layersets
@@ -701,7 +701,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brakesignal = SFSymbol(rawValue: "brakesignal")
+    static var brakesignal: SFSymbol { .init(rawValue: "brakesignal") }
 
     /// 􁀷
     /// Single Localization, 2 Layersets
@@ -709,14 +709,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brakesignalDashed = SFSymbol(rawValue: "brakesignal.dashed")
+    static var brakesignalDashed: SFSymbol { .init(rawValue: "brakesignal.dashed") }
 
     /// 􁑟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let brazilianrealsign = SFSymbol(rawValue: "brazilianrealsign")
+    static var brazilianrealsign: SFSymbol { .init(rawValue: "brazilianrealsign") }
 
     /// 􁒉
     /// Single Localization, 2 Layersets
@@ -724,7 +724,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubblesAndSparkles = SFSymbol(rawValue: "bubbles.and.sparkles")
+    static var bubblesAndSparkles: SFSymbol { .init(rawValue: "bubbles.and.sparkles") }
 
     /// 􁒊
     /// Single Localization, 2 Layersets
@@ -732,7 +732,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubblesAndSparklesFill = SFSymbol(rawValue: "bubbles.and.sparkles.fill")
+    static var bubblesAndSparklesFill: SFSymbol { .init(rawValue: "bubbles.and.sparkles.fill") }
 
     /// 􁏰
     /// Single Localization, 2 Layersets
@@ -740,7 +740,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonProgrammable = SFSymbol(rawValue: "button.programmable")
+    static var buttonProgrammable: SFSymbol { .init(rawValue: "button.programmable") }
 
     /// 􁏤
     /// Single Localization, 2 Layersets
@@ -748,7 +748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonProgrammableSquare = SFSymbol(rawValue: "button.programmable.square")
+    static var buttonProgrammableSquare: SFSymbol { .init(rawValue: "button.programmable.square") }
 
     /// 􁏥
     /// Single Localization, 3 Layersets
@@ -757,21 +757,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let buttonProgrammableSquareFill = SFSymbol(rawValue: "button.programmable.square.fill")
+    static var buttonProgrammableSquareFill: SFSymbol { .init(rawValue: "button.programmable.square.fill") }
 
     /// 􁐮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cabinet = SFSymbol(rawValue: "cabinet")
+    static var cabinet: SFSymbol { .init(rawValue: "cabinet") }
 
     /// 􁐯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cabinetFill = SFSymbol(rawValue: "cabinet.fill")
+    static var cabinetFill: SFSymbol { .init(rawValue: "cabinet.fill") }
 
     /// 􁒸
     /// Single Localization, 2 Layersets
@@ -779,7 +779,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carbonDioxideCloud = SFSymbol(rawValue: "carbon.dioxide.cloud")
+    static var carbonDioxideCloud: SFSymbol { .init(rawValue: "carbon.dioxide.cloud") }
 
     /// 􁒹
     /// Single Localization, 3 Layersets
@@ -788,7 +788,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carbonDioxideCloudFill = SFSymbol(rawValue: "carbon.dioxide.cloud.fill")
+    static var carbonDioxideCloudFill: SFSymbol { .init(rawValue: "carbon.dioxide.cloud.fill") }
 
     /// 􁒶
     /// Single Localization, 2 Layersets
@@ -796,7 +796,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carbonMonoxideCloud = SFSymbol(rawValue: "carbon.monoxide.cloud")
+    static var carbonMonoxideCloud: SFSymbol { .init(rawValue: "carbon.monoxide.cloud") }
 
     /// 􁒷
     /// Single Localization, 3 Layersets
@@ -805,21 +805,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carbonMonoxideCloudFill = SFSymbol(rawValue: "carbon.monoxide.cloud.fill")
+    static var carbonMonoxideCloudFill: SFSymbol { .init(rawValue: "carbon.monoxide.cloud.fill") }
 
     /// 􁖎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carrot = SFSymbol(rawValue: "carrot")
+    static var carrot: SFSymbol { .init(rawValue: "carrot") }
 
     /// 􁖏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carrotFill = SFSymbol(rawValue: "carrot.fill")
+    static var carrotFill: SFSymbol { .init(rawValue: "carrot.fill") }
 
     /// 􁚦
     /// 3 Localizations, 3 Layersets
@@ -833,7 +833,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cartBadgeQuestionmark = SymbolWith2Localizations<Ar, Rtl>(rawValue: "cart.badge.questionmark")
+    static var cartBadgeQuestionmark: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "cart.badge.questionmark") }
 
     /// 􁚧
     /// 3 Localizations, 3 Layersets
@@ -847,14 +847,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cartFillBadgeQuestionmark = SymbolWith2Localizations<Ar, Rtl>(rawValue: "cart.fill.badge.questionmark")
+    static var cartFillBadgeQuestionmark: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "cart.fill.badge.questionmark") }
 
     /// 􁑕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cedisign = SFSymbol(rawValue: "cedisign")
+    static var cedisign: SFSymbol { .init(rawValue: "cedisign") }
 
     /// 􀭧
     /// Single Localization, 3 Layersets
@@ -863,77 +863,77 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cellularbars = SFSymbol(rawValue: "cellularbars")
+    static var cellularbars: SFSymbol { .init(rawValue: "cellularbars") }
 
     /// 􁑀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let centsign = SFSymbol(rawValue: "centsign")
+    static var centsign: SFSymbol { .init(rawValue: "centsign") }
 
     /// 􁐶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chair = SFSymbol(rawValue: "chair")
+    static var chair: SFSymbol { .init(rawValue: "chair") }
 
     /// 􁐷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chairFill = SFSymbol(rawValue: "chair.fill")
+    static var chairFill: SFSymbol { .init(rawValue: "chair.fill") }
 
     /// 􁐴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chairLounge = SFSymbol(rawValue: "chair.lounge")
+    static var chairLounge: SFSymbol { .init(rawValue: "chair.lounge") }
 
     /// 􁐵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chairLoungeFill = SFSymbol(rawValue: "chair.lounge.fill")
+    static var chairLoungeFill: SFSymbol { .init(rawValue: "chair.lounge.fill") }
 
     /// 􁌦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chandelier = SFSymbol(rawValue: "chandelier")
+    static var chandelier: SFSymbol { .init(rawValue: "chandelier") }
 
     /// 􁏓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chandelierFill = SFSymbol(rawValue: "chandelier.fill")
+    static var chandelierFill: SFSymbol { .init(rawValue: "chandelier.fill") }
 
     /// 􁓖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let characterDuployan = SFSymbol(rawValue: "character.duployan")
+    static var characterDuployan: SFSymbol { .init(rawValue: "character.duployan") }
 
     /// 􁓕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let characterPhonetic = SFSymbol(rawValue: "character.phonetic")
+    static var characterPhonetic: SFSymbol { .init(rawValue: "character.phonetic") }
 
     /// 􁓗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let characterSutton = SFSymbol(rawValue: "character.sutton")
+    static var characterSutton: SFSymbol { .init(rawValue: "character.sutton") }
 
     /// 􁘳
     /// Single Localization, 3 Layersets
@@ -942,7 +942,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartLineDowntrendXyaxis = SFSymbol(rawValue: "chart.line.downtrend.xyaxis")
+    static var chartLineDowntrendXyaxis: SFSymbol { .init(rawValue: "chart.line.downtrend.xyaxis") }
 
     /// 􁘴
     /// Single Localization, 2 Layersets
@@ -950,7 +950,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartLineDowntrendXyaxisCircle = SFSymbol(rawValue: "chart.line.downtrend.xyaxis.circle")
+    static var chartLineDowntrendXyaxisCircle: SFSymbol { .init(rawValue: "chart.line.downtrend.xyaxis.circle") }
 
     /// 􁘵
     /// Single Localization, 3 Layersets
@@ -959,7 +959,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartLineDowntrendXyaxisCircleFill = SFSymbol(rawValue: "chart.line.downtrend.xyaxis.circle.fill")
+    static var chartLineDowntrendXyaxisCircleFill: SFSymbol { .init(rawValue: "chart.line.downtrend.xyaxis.circle.fill") }
 
     /// 􁘶
     /// Single Localization, 3 Layersets
@@ -968,7 +968,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartLineFlattrendXyaxis = SFSymbol(rawValue: "chart.line.flattrend.xyaxis")
+    static var chartLineFlattrendXyaxis: SFSymbol { .init(rawValue: "chart.line.flattrend.xyaxis") }
 
     /// 􁘷
     /// Single Localization, 2 Layersets
@@ -976,7 +976,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartLineFlattrendXyaxisCircle = SFSymbol(rawValue: "chart.line.flattrend.xyaxis.circle")
+    static var chartLineFlattrendXyaxisCircle: SFSymbol { .init(rawValue: "chart.line.flattrend.xyaxis.circle") }
 
     /// 􁘸
     /// Single Localization, 3 Layersets
@@ -985,7 +985,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartLineFlattrendXyaxisCircleFill = SFSymbol(rawValue: "chart.line.flattrend.xyaxis.circle.fill")
+    static var chartLineFlattrendXyaxisCircleFill: SFSymbol { .init(rawValue: "chart.line.flattrend.xyaxis.circle.fill") }
 
     /// 􁙕
     /// 2 Localizations, 2 Layersets
@@ -997,7 +997,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checklistChecked = SymbolWith1Localization<Rtl>(rawValue: "checklist.checked")
+    static var checklistChecked: SymbolWith1Localization<Rtl> { .init(rawValue: "checklist.checked") }
 
     /// 􁙠
     /// Single Localization, 2 Layersets
@@ -1005,7 +1005,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checklistUnchecked = SFSymbol(rawValue: "checklist.unchecked")
+    static var checklistUnchecked: SFSymbol { .init(rawValue: "checklist.unchecked") }
 
     /// 􁜞
     /// 2 Localizations, 3 Layersets
@@ -1018,7 +1018,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "checkmark.circle.badge.questionmark")
+    static var checkmarkCircleBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "checkmark.circle.badge.questionmark") }
 
     /// 􁜟
     /// 2 Localizations, 3 Layersets
@@ -1031,7 +1031,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgeQuestionmarkFill = SymbolWith1Localization<Ar>(rawValue: "checkmark.circle.badge.questionmark.fill")
+    static var checkmarkCircleBadgeQuestionmarkFill: SymbolWith1Localization<Ar> { .init(rawValue: "checkmark.circle.badge.questionmark.fill") }
 
     /// 􁜢
     /// Single Localization, 3 Layersets
@@ -1040,7 +1040,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgeXmark = SFSymbol(rawValue: "checkmark.circle.badge.xmark")
+    static var checkmarkCircleBadgeXmark: SFSymbol { .init(rawValue: "checkmark.circle.badge.xmark") }
 
     /// 􁜣
     /// Single Localization, 3 Layersets
@@ -1049,7 +1049,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgeXmarkFill = SFSymbol(rawValue: "checkmark.circle.badge.xmark.fill")
+    static var checkmarkCircleBadgeXmarkFill: SFSymbol { .init(rawValue: "checkmark.circle.badge.xmark.fill") }
 
     /// 􁐕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1059,7 +1059,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let checkmarkMessage = SFSymbol(rawValue: "checkmark.message")
+    static var checkmarkMessage: SFSymbol { .init(rawValue: "checkmark.message") }
 
     /// 􁐖
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1070,35 +1070,35 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let checkmarkMessageFill = SFSymbol(rawValue: "checkmark.message.fill")
+    static var checkmarkMessageFill: SFSymbol { .init(rawValue: "checkmark.message.fill") }
 
     /// 􁍄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronBackwardToLine = SFSymbol(rawValue: "chevron.backward.to.line")
+    static var chevronBackwardToLine: SFSymbol { .init(rawValue: "chevron.backward.to.line") }
 
     /// 􁍅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronForwardToLine = SFSymbol(rawValue: "chevron.forward.to.line")
+    static var chevronForwardToLine: SFSymbol { .init(rawValue: "chevron.forward.to.line") }
 
     /// 􁍂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeftToLine = SFSymbol(rawValue: "chevron.left.to.line")
+    static var chevronLeftToLine: SFSymbol { .init(rawValue: "chevron.left.to.line") }
 
     /// 􁍃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronRightToLine = SFSymbol(rawValue: "chevron.right.to.line")
+    static var chevronRightToLine: SFSymbol { .init(rawValue: "chevron.right.to.line") }
 
     /// 􁙪
     /// Single Localization, 2 Layersets
@@ -1106,7 +1106,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleDashedRectangle = SFSymbol(rawValue: "circle.dashed.rectangle")
+    static var circleDashedRectangle: SFSymbol { .init(rawValue: "circle.dashed.rectangle") }
 
     /// 􁙯
     /// Single Localization, 2 Layersets
@@ -1114,7 +1114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleFilledPatternDiagonallineRectangle = SFSymbol(rawValue: "circle.filled.pattern.diagonalline.rectangle")
+    static var circleFilledPatternDiagonallineRectangle: SFSymbol { .init(rawValue: "circle.filled.pattern.diagonalline.rectangle") }
 
     /// 􁙫
     /// Single Localization, 2 Layersets
@@ -1122,7 +1122,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleRectangleDashed = SFSymbol(rawValue: "circle.rectangle.dashed")
+    static var circleRectangleDashed: SFSymbol { .init(rawValue: "circle.rectangle.dashed") }
 
     /// 􁙭
     /// Single Localization, 2 Layersets
@@ -1130,21 +1130,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let circleRectangleFilledPatternDiagonalline = SFSymbol(rawValue: "circle.rectangle.filled.pattern.diagonalline")
+    static var circleRectangleFilledPatternDiagonalline: SFSymbol { .init(rawValue: "circle.rectangle.filled.pattern.diagonalline") }
 
     /// 􀟹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let clipboard = SFSymbol(rawValue: "clipboard")
+    static var clipboard: SFSymbol { .init(rawValue: "clipboard") }
 
     /// 􀟺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let clipboardFill = SFSymbol(rawValue: "clipboard.fill")
+    static var clipboardFill: SFSymbol { .init(rawValue: "clipboard.fill") }
 
     /// 􁙜
     /// Single Localization, 3 Layersets
@@ -1153,7 +1153,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadge = SFSymbol(rawValue: "clock.badge")
+    static var clockBadge: SFSymbol { .init(rawValue: "clock.badge") }
 
     /// 􁙝
     /// Single Localization, 3 Layersets
@@ -1162,7 +1162,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeFill = SFSymbol(rawValue: "clock.badge.fill")
+    static var clockBadgeFill: SFSymbol { .init(rawValue: "clock.badge.fill") }
 
     /// 􁜱
     /// 2 Localizations, 3 Layersets
@@ -1175,7 +1175,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "clock.badge.questionmark")
+    static var clockBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "clock.badge.questionmark") }
 
     /// 􁜲
     /// 2 Localizations, 3 Layersets
@@ -1188,7 +1188,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeQuestionmarkFill = SymbolWith1Localization<Ar>(rawValue: "clock.badge.questionmark.fill")
+    static var clockBadgeQuestionmarkFill: SymbolWith1Localization<Ar> { .init(rawValue: "clock.badge.questionmark.fill") }
 
     /// 􁜒
     /// Single Localization, 3 Layersets
@@ -1197,7 +1197,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeXmark = SFSymbol(rawValue: "clock.badge.xmark")
+    static var clockBadgeXmark: SFSymbol { .init(rawValue: "clock.badge.xmark") }
 
     /// 􁜓
     /// Single Localization, 3 Layersets
@@ -1206,7 +1206,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let clockBadgeXmarkFill = SFSymbol(rawValue: "clock.badge.xmark.fill")
+    static var clockBadgeXmarkFill: SFSymbol { .init(rawValue: "clock.badge.xmark.fill") }
 
     /// 􁛝
     /// Single Localization, 2 Layersets
@@ -1214,7 +1214,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudBoltCircle = SFSymbol(rawValue: "cloud.bolt.circle")
+    static var cloudBoltCircle: SFSymbol { .init(rawValue: "cloud.bolt.circle") }
 
     /// 􁛞
     /// Single Localization, 3 Layersets
@@ -1223,7 +1223,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudBoltCircleFill = SFSymbol(rawValue: "cloud.bolt.circle.fill")
+    static var cloudBoltCircleFill: SFSymbol { .init(rawValue: "cloud.bolt.circle.fill") }
 
     /// 􁛟
     /// Single Localization, 2 Layersets
@@ -1231,7 +1231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudBoltRainCircle = SFSymbol(rawValue: "cloud.bolt.rain.circle")
+    static var cloudBoltRainCircle: SFSymbol { .init(rawValue: "cloud.bolt.rain.circle") }
 
     /// 􁛠
     /// Single Localization, 3 Layersets
@@ -1240,7 +1240,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudBoltRainCircleFill = SFSymbol(rawValue: "cloud.bolt.rain.circle.fill")
+    static var cloudBoltRainCircleFill: SFSymbol { .init(rawValue: "cloud.bolt.rain.circle.fill") }
 
     /// 􁛍
     /// Single Localization, 2 Layersets
@@ -1248,7 +1248,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudCircle = SFSymbol(rawValue: "cloud.circle")
+    static var cloudCircle: SFSymbol { .init(rawValue: "cloud.circle") }
 
     /// 􁛎
     /// Single Localization, 3 Layersets
@@ -1257,7 +1257,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudCircleFill = SFSymbol(rawValue: "cloud.circle.fill")
+    static var cloudCircleFill: SFSymbol { .init(rawValue: "cloud.circle.fill") }
 
     /// 􁛏
     /// Single Localization, 2 Layersets
@@ -1265,7 +1265,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudDrizzleCircle = SFSymbol(rawValue: "cloud.drizzle.circle")
+    static var cloudDrizzleCircle: SFSymbol { .init(rawValue: "cloud.drizzle.circle") }
 
     /// 􁛐
     /// Single Localization, 3 Layersets
@@ -1274,7 +1274,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudDrizzleCircleFill = SFSymbol(rawValue: "cloud.drizzle.circle.fill")
+    static var cloudDrizzleCircleFill: SFSymbol { .init(rawValue: "cloud.drizzle.circle.fill") }
 
     /// 􁛕
     /// Single Localization, 2 Layersets
@@ -1282,7 +1282,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudFogCircle = SFSymbol(rawValue: "cloud.fog.circle")
+    static var cloudFogCircle: SFSymbol { .init(rawValue: "cloud.fog.circle") }
 
     /// 􁛖
     /// Single Localization, 3 Layersets
@@ -1291,7 +1291,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudFogCircleFill = SFSymbol(rawValue: "cloud.fog.circle.fill")
+    static var cloudFogCircleFill: SFSymbol { .init(rawValue: "cloud.fog.circle.fill") }
 
     /// 􁛗
     /// Single Localization, 2 Layersets
@@ -1299,7 +1299,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudHailCircle = SFSymbol(rawValue: "cloud.hail.circle")
+    static var cloudHailCircle: SFSymbol { .init(rawValue: "cloud.hail.circle") }
 
     /// 􁛘
     /// Single Localization, 3 Layersets
@@ -1308,7 +1308,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudHailCircleFill = SFSymbol(rawValue: "cloud.hail.circle.fill")
+    static var cloudHailCircleFill: SFSymbol { .init(rawValue: "cloud.hail.circle.fill") }
 
     /// 􁛓
     /// Single Localization, 2 Layersets
@@ -1316,7 +1316,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudHeavyrainCircle = SFSymbol(rawValue: "cloud.heavyrain.circle")
+    static var cloudHeavyrainCircle: SFSymbol { .init(rawValue: "cloud.heavyrain.circle") }
 
     /// 􁛔
     /// Single Localization, 3 Layersets
@@ -1325,7 +1325,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudHeavyrainCircleFill = SFSymbol(rawValue: "cloud.heavyrain.circle.fill")
+    static var cloudHeavyrainCircleFill: SFSymbol { .init(rawValue: "cloud.heavyrain.circle.fill") }
 
     /// 􁛫
     /// Single Localization, 2 Layersets
@@ -1333,7 +1333,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudMoonBoltCircle = SFSymbol(rawValue: "cloud.moon.bolt.circle")
+    static var cloudMoonBoltCircle: SFSymbol { .init(rawValue: "cloud.moon.bolt.circle") }
 
     /// 􁛬
     /// Single Localization, 3 Layersets
@@ -1342,7 +1342,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudMoonBoltCircleFill = SFSymbol(rawValue: "cloud.moon.bolt.circle.fill")
+    static var cloudMoonBoltCircleFill: SFSymbol { .init(rawValue: "cloud.moon.bolt.circle.fill") }
 
     /// 􁛧
     /// Single Localization, 2 Layersets
@@ -1350,7 +1350,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudMoonCircle = SFSymbol(rawValue: "cloud.moon.circle")
+    static var cloudMoonCircle: SFSymbol { .init(rawValue: "cloud.moon.circle") }
 
     /// 􁛨
     /// Single Localization, 3 Layersets
@@ -1359,7 +1359,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudMoonCircleFill = SFSymbol(rawValue: "cloud.moon.circle.fill")
+    static var cloudMoonCircleFill: SFSymbol { .init(rawValue: "cloud.moon.circle.fill") }
 
     /// 􁛩
     /// Single Localization, 2 Layersets
@@ -1367,7 +1367,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudMoonRainCircle = SFSymbol(rawValue: "cloud.moon.rain.circle")
+    static var cloudMoonRainCircle: SFSymbol { .init(rawValue: "cloud.moon.rain.circle") }
 
     /// 􁛪
     /// Single Localization, 3 Layersets
@@ -1376,7 +1376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudMoonRainCircleFill = SFSymbol(rawValue: "cloud.moon.rain.circle.fill")
+    static var cloudMoonRainCircleFill: SFSymbol { .init(rawValue: "cloud.moon.rain.circle.fill") }
 
     /// 􁛑
     /// Single Localization, 2 Layersets
@@ -1384,7 +1384,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudRainCircle = SFSymbol(rawValue: "cloud.rain.circle")
+    static var cloudRainCircle: SFSymbol { .init(rawValue: "cloud.rain.circle") }
 
     /// 􁛒
     /// Single Localization, 3 Layersets
@@ -1393,7 +1393,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudRainCircleFill = SFSymbol(rawValue: "cloud.rain.circle.fill")
+    static var cloudRainCircleFill: SFSymbol { .init(rawValue: "cloud.rain.circle.fill") }
 
     /// 􁛛
     /// Single Localization, 2 Layersets
@@ -1401,7 +1401,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudSleetCircle = SFSymbol(rawValue: "cloud.sleet.circle")
+    static var cloudSleetCircle: SFSymbol { .init(rawValue: "cloud.sleet.circle") }
 
     /// 􁛜
     /// Single Localization, 3 Layersets
@@ -1410,7 +1410,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudSleetCircleFill = SFSymbol(rawValue: "cloud.sleet.circle.fill")
+    static var cloudSleetCircleFill: SFSymbol { .init(rawValue: "cloud.sleet.circle.fill") }
 
     /// 􁛙
     /// Single Localization, 2 Layersets
@@ -1418,7 +1418,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudSnowCircle = SFSymbol(rawValue: "cloud.snow.circle")
+    static var cloudSnowCircle: SFSymbol { .init(rawValue: "cloud.snow.circle") }
 
     /// 􁛚
     /// Single Localization, 3 Layersets
@@ -1427,7 +1427,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudSnowCircleFill = SFSymbol(rawValue: "cloud.snow.circle.fill")
+    static var cloudSnowCircleFill: SFSymbol { .init(rawValue: "cloud.snow.circle.fill") }
 
     /// 􁛥
     /// Single Localization, 2 Layersets
@@ -1435,7 +1435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudSunBoltCircle = SFSymbol(rawValue: "cloud.sun.bolt.circle")
+    static var cloudSunBoltCircle: SFSymbol { .init(rawValue: "cloud.sun.bolt.circle") }
 
     /// 􁛦
     /// Single Localization, 3 Layersets
@@ -1444,7 +1444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudSunBoltCircleFill = SFSymbol(rawValue: "cloud.sun.bolt.circle.fill")
+    static var cloudSunBoltCircleFill: SFSymbol { .init(rawValue: "cloud.sun.bolt.circle.fill") }
 
     /// 􁛡
     /// Single Localization, 2 Layersets
@@ -1452,7 +1452,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudSunCircle = SFSymbol(rawValue: "cloud.sun.circle")
+    static var cloudSunCircle: SFSymbol { .init(rawValue: "cloud.sun.circle") }
 
     /// 􁛢
     /// Single Localization, 3 Layersets
@@ -1461,7 +1461,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudSunCircleFill = SFSymbol(rawValue: "cloud.sun.circle.fill")
+    static var cloudSunCircleFill: SFSymbol { .init(rawValue: "cloud.sun.circle.fill") }
 
     /// 􁛣
     /// Single Localization, 2 Layersets
@@ -1469,7 +1469,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cloudSunRainCircle = SFSymbol(rawValue: "cloud.sun.rain.circle")
+    static var cloudSunRainCircle: SFSymbol { .init(rawValue: "cloud.sun.rain.circle") }
 
     /// 􁛤
     /// Single Localization, 3 Layersets
@@ -1478,49 +1478,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudSunRainCircleFill = SFSymbol(rawValue: "cloud.sun.rain.circle.fill")
+    static var cloudSunRainCircleFill: SFSymbol { .init(rawValue: "cloud.sun.rain.circle.fill") }
 
     /// 􁑔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let coloncurrencysign = SFSymbol(rawValue: "coloncurrencysign")
+    static var coloncurrencysign: SFSymbol { .init(rawValue: "coloncurrencysign") }
 
     /// 􁔗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let compassDrawing = SFSymbol(rawValue: "compass.drawing")
+    static var compassDrawing: SFSymbol { .init(rawValue: "compass.drawing") }
 
     /// 􁒺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let contactSensor = SFSymbol(rawValue: "contact.sensor")
+    static var contactSensor: SFSymbol { .init(rawValue: "contact.sensor") }
 
     /// 􁒻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let contactSensorFill = SFSymbol(rawValue: "contact.sensor.fill")
+    static var contactSensorFill: SFSymbol { .init(rawValue: "contact.sensor.fill") }
 
     /// 􁕠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cooktop = SFSymbol(rawValue: "cooktop")
+    static var cooktop: SFSymbol { .init(rawValue: "cooktop") }
 
     /// 􁕡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cooktopFill = SFSymbol(rawValue: "cooktop.fill")
+    static var cooktopFill: SFSymbol { .init(rawValue: "cooktop.fill") }
 
     /// 􁔔
     /// Single Localization, 2 Layersets
@@ -1528,14 +1528,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let creditcardViewfinder = SFSymbol(rawValue: "creditcard.viewfinder")
+    static var creditcardViewfinder: SFSymbol { .init(rawValue: "creditcard.viewfinder") }
 
     /// 􁜁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cricketBall = SFSymbol(rawValue: "cricket.ball")
+    static var cricketBall: SFSymbol { .init(rawValue: "cricket.ball") }
 
     /// 􁜃
     /// Single Localization, 2 Layersets
@@ -1543,7 +1543,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cricketBallCircle = SFSymbol(rawValue: "cricket.ball.circle")
+    static var cricketBallCircle: SFSymbol { .init(rawValue: "cricket.ball.circle") }
 
     /// 􁜄
     /// Single Localization, 3 Layersets
@@ -1552,21 +1552,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cricketBallCircleFill = SFSymbol(rawValue: "cricket.ball.circle.fill")
+    static var cricketBallCircleFill: SFSymbol { .init(rawValue: "cricket.ball.circle.fill") }
 
     /// 􁜂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cricketBallFill = SFSymbol(rawValue: "cricket.ball.fill")
+    static var cricketBallFill: SFSymbol { .init(rawValue: "cricket.ball.fill") }
 
     /// 􁑖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cruzeirosign = SFSymbol(rawValue: "cruzeirosign")
+    static var cruzeirosign: SFSymbol { .init(rawValue: "cruzeirosign") }
 
     /// 􁚀
     /// Single Localization, 3 Layersets
@@ -1580,7 +1580,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 26.0, renamed: "pointerArrowSquareFill")
     @available(watchOS, introduced: 9.0, deprecated: 26.0, renamed: "pointerArrowSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowSquareFill")
-    static let cursorarrowSquareFill = SFSymbol(rawValue: "cursorarrow.square.fill")
+    static var cursorarrowSquareFill: SFSymbol { .init(rawValue: "cursorarrow.square.fill") }
 
     /// 􁑸
     /// Single Localization, 3 Layersets
@@ -1589,7 +1589,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let curtainsClosed = SFSymbol(rawValue: "curtains.closed")
+    static var curtainsClosed: SFSymbol { .init(rawValue: "curtains.closed") }
 
     /// 􁑷
     /// Single Localization, 3 Layersets
@@ -1598,7 +1598,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let curtainsOpen = SFSymbol(rawValue: "curtains.open")
+    static var curtainsOpen: SFSymbol { .init(rawValue: "curtains.open") }
 
     /// 􁓧
     /// Single Localization, 2 Layersets
@@ -1606,7 +1606,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dehumidifier = SFSymbol(rawValue: "dehumidifier")
+    static var dehumidifier: SFSymbol { .init(rawValue: "dehumidifier") }
 
     /// 􁓨
     /// Single Localization, 2 Layersets
@@ -1614,7 +1614,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dehumidifierFill = SFSymbol(rawValue: "dehumidifier.fill")
+    static var dehumidifierFill: SFSymbol { .init(rawValue: "dehumidifier.fill") }
 
     /// 􁙣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1624,7 +1624,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Desk View.
-    static let deskview = SFSymbol(rawValue: "deskview")
+    static var deskview: SFSymbol { .init(rawValue: "deskview") }
 
     /// 􁙤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1634,7 +1634,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Desk View.
-    static let deskviewFill = SFSymbol(rawValue: "deskview.fill")
+    static var deskviewFill: SFSymbol { .init(rawValue: "deskview.fill") }
 
     /// 􀪐
     /// Single Localization, 2 Layersets
@@ -1642,7 +1642,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialHigh = SFSymbol(rawValue: "dial.high")
+    static var dialHigh: SFSymbol { .init(rawValue: "dial.high") }
 
     /// 􀪑
     /// Single Localization, 2 Layersets
@@ -1650,7 +1650,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialHighFill = SFSymbol(rawValue: "dial.high.fill")
+    static var dialHighFill: SFSymbol { .init(rawValue: "dial.high.fill") }
 
     /// 􀍺
     /// Single Localization, 2 Layersets
@@ -1658,7 +1658,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialLow = SFSymbol(rawValue: "dial.low")
+    static var dialLow: SFSymbol { .init(rawValue: "dial.low") }
 
     /// 􀍻
     /// Single Localization, 2 Layersets
@@ -1666,7 +1666,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialLowFill = SFSymbol(rawValue: "dial.low.fill")
+    static var dialLowFill: SFSymbol { .init(rawValue: "dial.low.fill") }
 
     /// 􁎴
     /// Single Localization, 2 Layersets
@@ -1674,7 +1674,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialMedium = SFSymbol(rawValue: "dial.medium")
+    static var dialMedium: SFSymbol { .init(rawValue: "dial.medium") }
 
     /// 􁎵
     /// Single Localization, 2 Layersets
@@ -1682,7 +1682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dialMediumFill = SFSymbol(rawValue: "dial.medium.fill")
+    static var dialMediumFill: SFSymbol { .init(rawValue: "dial.medium.fill") }
 
     /// 􁐢
     /// Single Localization, 2 Layersets
@@ -1690,7 +1690,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dishwasher = SFSymbol(rawValue: "dishwasher")
+    static var dishwasher: SFSymbol { .init(rawValue: "dishwasher") }
 
     /// 􁐣
     /// Single Localization, 2 Layersets
@@ -1698,7 +1698,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dishwasherFill = SFSymbol(rawValue: "dishwasher.fill")
+    static var dishwasherFill: SFSymbol { .init(rawValue: "dishwasher.fill") }
 
     /// 􁘊
     /// Single Localization, 3 Layersets
@@ -1707,7 +1707,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let distributeHorizontalCenter = SFSymbol(rawValue: "distribute.horizontal.center")
+    static var distributeHorizontalCenter: SFSymbol { .init(rawValue: "distribute.horizontal.center") }
 
     /// 􁘋
     /// Single Localization, 3 Layersets
@@ -1716,7 +1716,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let distributeHorizontalCenterFill = SFSymbol(rawValue: "distribute.horizontal.center.fill")
+    static var distributeHorizontalCenterFill: SFSymbol { .init(rawValue: "distribute.horizontal.center.fill") }
 
     /// 􁘈
     /// Single Localization, 2 Layersets
@@ -1724,7 +1724,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontalLeft = SFSymbol(rawValue: "distribute.horizontal.left")
+    static var distributeHorizontalLeft: SFSymbol { .init(rawValue: "distribute.horizontal.left") }
 
     /// 􁘉
     /// Single Localization, 2 Layersets
@@ -1732,7 +1732,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontalLeftFill = SFSymbol(rawValue: "distribute.horizontal.left.fill")
+    static var distributeHorizontalLeftFill: SFSymbol { .init(rawValue: "distribute.horizontal.left.fill") }
 
     /// 􁘌
     /// Single Localization, 2 Layersets
@@ -1740,7 +1740,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontalRight = SFSymbol(rawValue: "distribute.horizontal.right")
+    static var distributeHorizontalRight: SFSymbol { .init(rawValue: "distribute.horizontal.right") }
 
     /// 􁘍
     /// Single Localization, 2 Layersets
@@ -1748,7 +1748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontalRightFill = SFSymbol(rawValue: "distribute.horizontal.right.fill")
+    static var distributeHorizontalRightFill: SFSymbol { .init(rawValue: "distribute.horizontal.right.fill") }
 
     /// 􁘆
     /// Single Localization, 2 Layersets
@@ -1756,7 +1756,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVerticalBottom = SFSymbol(rawValue: "distribute.vertical.bottom")
+    static var distributeVerticalBottom: SFSymbol { .init(rawValue: "distribute.vertical.bottom") }
 
     /// 􁘇
     /// Single Localization, 2 Layersets
@@ -1764,7 +1764,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVerticalBottomFill = SFSymbol(rawValue: "distribute.vertical.bottom.fill")
+    static var distributeVerticalBottomFill: SFSymbol { .init(rawValue: "distribute.vertical.bottom.fill") }
 
     /// 􁘄
     /// Single Localization, 3 Layersets
@@ -1773,7 +1773,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let distributeVerticalCenter = SFSymbol(rawValue: "distribute.vertical.center")
+    static var distributeVerticalCenter: SFSymbol { .init(rawValue: "distribute.vertical.center") }
 
     /// 􁘅
     /// Single Localization, 3 Layersets
@@ -1782,7 +1782,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let distributeVerticalCenterFill = SFSymbol(rawValue: "distribute.vertical.center.fill")
+    static var distributeVerticalCenterFill: SFSymbol { .init(rawValue: "distribute.vertical.center.fill") }
 
     /// 􁘂
     /// Single Localization, 2 Layersets
@@ -1790,7 +1790,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVerticalTop = SFSymbol(rawValue: "distribute.vertical.top")
+    static var distributeVerticalTop: SFSymbol { .init(rawValue: "distribute.vertical.top") }
 
     /// 􁘃
     /// Single Localization, 2 Layersets
@@ -1798,7 +1798,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVerticalTopFill = SFSymbol(rawValue: "distribute.vertical.top.fill")
+    static var distributeVerticalTopFill: SFSymbol { .init(rawValue: "distribute.vertical.top.fill") }
 
     /// 􁙡
     /// Single Localization, 3 Layersets
@@ -1812,7 +1812,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "documentBadgeArrowUp")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "documentBadgeArrowUp")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeArrowUp")
-    static let docBadgeArrowUp = SFSymbol(rawValue: "doc.badge.arrow.up")
+    static var docBadgeArrowUp: SFSymbol { .init(rawValue: "doc.badge.arrow.up") }
 
     /// 􁙢
     /// Single Localization, 3 Layersets
@@ -1826,14 +1826,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "documentBadgeArrowUpFill")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "documentBadgeArrowUpFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeArrowUpFill")
-    static let docBadgeArrowUpFill = SFSymbol(rawValue: "doc.badge.arrow.up.fill")
+    static var docBadgeArrowUpFill: SFSymbol { .init(rawValue: "doc.badge.arrow.up.fill") }
 
     /// 􁎢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dollarsign = SFSymbol(rawValue: "dollarsign")
+    static var dollarsign: SFSymbol { .init(rawValue: "dollarsign") }
 
     /// 􁎣
     /// Single Localization, 2 Layersets
@@ -1846,14 +1846,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "dollarsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "dollarsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "dollarsignArrowTriangleheadCounterclockwiseRotate90")
-    static let dollarsignArrowCirclepath = SFSymbol(rawValue: "dollarsign.arrow.circlepath")
+    static var dollarsignArrowCirclepath: SFSymbol { .init(rawValue: "dollarsign.arrow.circlepath") }
 
     /// 􁑈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dongsign = SFSymbol(rawValue: "dongsign")
+    static var dongsign: SFSymbol { .init(rawValue: "dongsign") }
 
     /// 􁏧
     /// Single Localization, 2 Layersets
@@ -1861,7 +1861,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorFrenchClosed = SFSymbol(rawValue: "door.french.closed")
+    static var doorFrenchClosed: SFSymbol { .init(rawValue: "door.french.closed") }
 
     /// 􁏦
     /// Single Localization, 2 Layersets
@@ -1869,7 +1869,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorFrenchOpen = SFSymbol(rawValue: "door.french.open")
+    static var doorFrenchOpen: SFSymbol { .init(rawValue: "door.french.open") }
 
     /// 􁏡
     /// Single Localization, 2 Layersets
@@ -1877,7 +1877,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorGarageClosed = SFSymbol(rawValue: "door.garage.closed")
+    static var doorGarageClosed: SFSymbol { .init(rawValue: "door.garage.closed") }
 
     /// 􁘡
     /// Single Localization, 3 Layersets
@@ -1886,7 +1886,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let doorGarageClosedTrianglebadgeExclamationmark = SFSymbol(rawValue: "door.garage.closed.trianglebadge.exclamationmark")
+    static var doorGarageClosedTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "door.garage.closed.trianglebadge.exclamationmark") }
 
     /// 􁏭
     /// Single Localization, 2 Layersets
@@ -1894,7 +1894,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorGarageDoubleBayClosed = SFSymbol(rawValue: "door.garage.double.bay.closed")
+    static var doorGarageDoubleBayClosed: SFSymbol { .init(rawValue: "door.garage.double.bay.closed") }
 
     /// 􁘣
     /// Single Localization, 3 Layersets
@@ -1903,7 +1903,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let doorGarageDoubleBayClosedTrianglebadgeExclamationmark = SFSymbol(rawValue: "door.garage.double.bay.closed.trianglebadge.exclamationmark")
+    static var doorGarageDoubleBayClosedTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "door.garage.double.bay.closed.trianglebadge.exclamationmark") }
 
     /// 􁏬
     /// Single Localization, 2 Layersets
@@ -1911,7 +1911,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorGarageDoubleBayOpen = SFSymbol(rawValue: "door.garage.double.bay.open")
+    static var doorGarageDoubleBayOpen: SFSymbol { .init(rawValue: "door.garage.double.bay.open") }
 
     /// 􁘢
     /// Single Localization, 3 Layersets
@@ -1920,7 +1920,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let doorGarageDoubleBayOpenTrianglebadgeExclamationmark = SFSymbol(rawValue: "door.garage.double.bay.open.trianglebadge.exclamationmark")
+    static var doorGarageDoubleBayOpenTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "door.garage.double.bay.open.trianglebadge.exclamationmark") }
 
     /// 􁏠
     /// Single Localization, 2 Layersets
@@ -1928,7 +1928,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorGarageOpen = SFSymbol(rawValue: "door.garage.open")
+    static var doorGarageOpen: SFSymbol { .init(rawValue: "door.garage.open") }
 
     /// 􁘠
     /// Single Localization, 3 Layersets
@@ -1937,7 +1937,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let doorGarageOpenTrianglebadgeExclamationmark = SFSymbol(rawValue: "door.garage.open.trianglebadge.exclamationmark")
+    static var doorGarageOpenTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "door.garage.open.trianglebadge.exclamationmark") }
 
     /// 􁏝
     /// Single Localization, 2 Layersets
@@ -1945,7 +1945,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorLeftHandClosed = SFSymbol(rawValue: "door.left.hand.closed")
+    static var doorLeftHandClosed: SFSymbol { .init(rawValue: "door.left.hand.closed") }
 
     /// 􁏜
     /// Single Localization, 2 Layersets
@@ -1953,7 +1953,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorLeftHandOpen = SFSymbol(rawValue: "door.left.hand.open")
+    static var doorLeftHandOpen: SFSymbol { .init(rawValue: "door.left.hand.open") }
 
     /// 􁏩
     /// Single Localization, 2 Layersets
@@ -1961,7 +1961,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorRightHandClosed = SFSymbol(rawValue: "door.right.hand.closed")
+    static var doorRightHandClosed: SFSymbol { .init(rawValue: "door.right.hand.closed") }
 
     /// 􁏨
     /// Single Localization, 2 Layersets
@@ -1969,7 +1969,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorRightHandOpen = SFSymbol(rawValue: "door.right.hand.open")
+    static var doorRightHandOpen: SFSymbol { .init(rawValue: "door.right.hand.open") }
 
     /// 􁏟
     /// Single Localization, 2 Layersets
@@ -1977,7 +1977,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorSlidingLeftHandClosed = SFSymbol(rawValue: "door.sliding.left.hand.closed")
+    static var doorSlidingLeftHandClosed: SFSymbol { .init(rawValue: "door.sliding.left.hand.closed") }
 
     /// 􁏞
     /// Single Localization, 2 Layersets
@@ -1985,7 +1985,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorSlidingLeftHandOpen = SFSymbol(rawValue: "door.sliding.left.hand.open")
+    static var doorSlidingLeftHandOpen: SFSymbol { .init(rawValue: "door.sliding.left.hand.open") }
 
     /// 􁏫
     /// Single Localization, 2 Layersets
@@ -1993,7 +1993,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorSlidingRightHandClosed = SFSymbol(rawValue: "door.sliding.right.hand.closed")
+    static var doorSlidingRightHandClosed: SFSymbol { .init(rawValue: "door.sliding.right.hand.closed") }
 
     /// 􁏪
     /// Single Localization, 2 Layersets
@@ -2001,21 +2001,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let doorSlidingRightHandOpen = SFSymbol(rawValue: "door.sliding.right.hand.open")
+    static var doorSlidingRightHandOpen: SFSymbol { .init(rawValue: "door.sliding.right.hand.open") }
 
     /// 􁘯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dropDegreesign = SFSymbol(rawValue: "drop.degreesign")
+    static var dropDegreesign: SFSymbol { .init(rawValue: "drop.degreesign") }
 
     /// 􁘰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dropDegreesignFill = SFSymbol(rawValue: "drop.degreesign.fill")
+    static var dropDegreesignFill: SFSymbol { .init(rawValue: "drop.degreesign.fill") }
 
     /// 􁚂
     /// 2 Localizations, 2 Layersets
@@ -2027,7 +2027,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dropDegreesignSlash = SymbolWith1Localization<Rtl>(rawValue: "drop.degreesign.slash")
+    static var dropDegreesignSlash: SymbolWith1Localization<Rtl> { .init(rawValue: "drop.degreesign.slash") }
 
     /// 􁚃
     /// 2 Localizations, 2 Layersets
@@ -2039,7 +2039,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dropDegreesignSlashFill = SymbolWith1Localization<Rtl>(rawValue: "drop.degreesign.slash.fill")
+    static var dropDegreesignSlashFill: SymbolWith1Localization<Rtl> { .init(rawValue: "drop.degreesign.slash.fill") }
 
     /// 􁓀
     /// Single Localization, 2 Layersets
@@ -2047,7 +2047,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dropKeypadRectangle = SFSymbol(rawValue: "drop.keypad.rectangle")
+    static var dropKeypadRectangle: SFSymbol { .init(rawValue: "drop.keypad.rectangle") }
 
     /// 􁓁
     /// Single Localization, 3 Layersets
@@ -2056,7 +2056,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dropKeypadRectangleFill = SFSymbol(rawValue: "drop.keypad.rectangle.fill")
+    static var dropKeypadRectangleFill: SFSymbol { .init(rawValue: "drop.keypad.rectangle.fill") }
 
     /// 􁖒
     /// Single Localization, 2 Layersets
@@ -2064,7 +2064,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dryer = SFSymbol(rawValue: "dryer")
+    static var dryer: SFSymbol { .init(rawValue: "dryer") }
 
     /// 􁖓
     /// Single Localization, 2 Layersets
@@ -2072,21 +2072,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dryerFill = SFSymbol(rawValue: "dryer.fill")
+    static var dryerFill: SFSymbol { .init(rawValue: "dryer.fill") }
 
     /// 􁖌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dumbbell = SFSymbol(rawValue: "dumbbell")
+    static var dumbbell: SFSymbol { .init(rawValue: "dumbbell") }
 
     /// 􁖍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dumbbellFill = SFSymbol(rawValue: "dumbbell.fill")
+    static var dumbbellFill: SFSymbol { .init(rawValue: "dumbbell.fill") }
 
     /// 􁒘
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2097,7 +2097,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let ellipsisMessage = SFSymbol(rawValue: "ellipsis.message")
+    static var ellipsisMessage: SFSymbol { .init(rawValue: "ellipsis.message") }
 
     /// 􁒙
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2108,7 +2108,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let ellipsisMessageFill = SFSymbol(rawValue: "ellipsis.message.fill")
+    static var ellipsisMessageFill: SFSymbol { .init(rawValue: "ellipsis.message.fill") }
 
     /// 􁒴
     /// Single Localization, 2 Layersets
@@ -2116,7 +2116,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let entryLeverKeypad = SFSymbol(rawValue: "entry.lever.keypad")
+    static var entryLeverKeypad: SFSymbol { .init(rawValue: "entry.lever.keypad") }
 
     /// 􁒵
     /// Single Localization, 2 Layersets
@@ -2124,7 +2124,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let entryLeverKeypadFill = SFSymbol(rawValue: "entry.lever.keypad.fill")
+    static var entryLeverKeypadFill: SFSymbol { .init(rawValue: "entry.lever.keypad.fill") }
 
     /// 􁙏
     /// Single Localization, 3 Layersets
@@ -2133,7 +2133,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let entryLeverKeypadTrianglebadgeExclamationmark = SFSymbol(rawValue: "entry.lever.keypad.trianglebadge.exclamationmark")
+    static var entryLeverKeypadTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "entry.lever.keypad.trianglebadge.exclamationmark") }
 
     /// 􁙐
     /// Single Localization, 3 Layersets
@@ -2142,7 +2142,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let entryLeverKeypadTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "entry.lever.keypad.trianglebadge.exclamationmark.fill")
+    static var entryLeverKeypadTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "entry.lever.keypad.trianglebadge.exclamationmark.fill") }
 
     /// 􁎧
     /// Single Localization, 3 Layersets
@@ -2151,21 +2151,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeOpenBadgeClock = SFSymbol(rawValue: "envelope.open.badge.clock")
+    static var envelopeOpenBadgeClock: SFSymbol { .init(rawValue: "envelope.open.badge.clock") }
 
     /// 􁝀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eraser = SFSymbol(rawValue: "eraser")
+    static var eraser: SFSymbol { .init(rawValue: "eraser") }
 
     /// 􁝁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eraserFill = SFSymbol(rawValue: "eraser.fill")
+    static var eraserFill: SFSymbol { .init(rawValue: "eraser.fill") }
 
     /// 􁚜
     /// Single Localization, 2 Layersets
@@ -2173,7 +2173,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eraserLineDashed = SFSymbol(rawValue: "eraser.line.dashed")
+    static var eraserLineDashed: SFSymbol { .init(rawValue: "eraser.line.dashed") }
 
     /// 􁚝
     /// Single Localization, 2 Layersets
@@ -2181,14 +2181,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eraserLineDashedFill = SFSymbol(rawValue: "eraser.line.dashed.fill")
+    static var eraserLineDashedFill: SFSymbol { .init(rawValue: "eraser.line.dashed.fill") }
 
     /// 􁑇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eurosign = SFSymbol(rawValue: "eurosign")
+    static var eurosign: SFSymbol { .init(rawValue: "eurosign") }
 
     /// 􀾿
     /// Single Localization, 3 Layersets
@@ -2197,7 +2197,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let exclamationmarkBrakesignal = SFSymbol(rawValue: "exclamationmark.brakesignal")
+    static var exclamationmarkBrakesignal: SFSymbol { .init(rawValue: "exclamationmark.brakesignal") }
 
     /// 􁙥
     /// Single Localization, 2 Layersets
@@ -2205,7 +2205,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let exclamationmarkLock = SFSymbol(rawValue: "exclamationmark.lock")
+    static var exclamationmarkLock: SFSymbol { .init(rawValue: "exclamationmark.lock") }
 
     /// 􁙦
     /// Single Localization, 3 Layersets
@@ -2214,7 +2214,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let exclamationmarkLockFill = SFSymbol(rawValue: "exclamationmark.lock.fill")
+    static var exclamationmarkLockFill: SFSymbol { .init(rawValue: "exclamationmark.lock.fill") }
 
     /// 􁑣
     /// 2 Localizations, Single Layerset
@@ -2225,7 +2225,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let exclamationmarkQuestionmark = SymbolWith1Localization<Ar>(rawValue: "exclamationmark.questionmark")
+    static var exclamationmarkQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "exclamationmark.questionmark") }
 
     /// 􁘥
     /// Single Localization, 3 Layersets
@@ -2234,7 +2234,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveBadgeExclamationmark = SFSymbol(rawValue: "externaldrive.badge.exclamationmark")
+    static var externaldriveBadgeExclamationmark: SFSymbol { .init(rawValue: "externaldrive.badge.exclamationmark") }
 
     /// 􀭟
     /// 2 Localizations, 3 Layersets
@@ -2247,7 +2247,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "externaldrive.badge.questionmark")
+    static var externaldriveBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "externaldrive.badge.questionmark") }
 
     /// 􁘦
     /// Single Localization, 3 Layersets
@@ -2256,7 +2256,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveFillBadgeExclamationmark = SFSymbol(rawValue: "externaldrive.fill.badge.exclamationmark")
+    static var externaldriveFillBadgeExclamationmark: SFSymbol { .init(rawValue: "externaldrive.fill.badge.exclamationmark") }
 
     /// 􀭠
     /// 2 Localizations, 3 Layersets
@@ -2269,7 +2269,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveFillBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "externaldrive.fill.badge.questionmark")
+    static var externaldriveFillBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "externaldrive.fill.badge.questionmark") }
 
     /// 􁘨
     /// Single Localization, 3 Layersets
@@ -2278,7 +2278,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveFillTrianglebadgeExclamationmark = SFSymbol(rawValue: "externaldrive.fill.trianglebadge.exclamationmark")
+    static var externaldriveFillTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "externaldrive.fill.trianglebadge.exclamationmark") }
 
     /// 􁘧
     /// Single Localization, 3 Layersets
@@ -2287,7 +2287,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let externaldriveTrianglebadgeExclamationmark = SFSymbol(rawValue: "externaldrive.trianglebadge.exclamationmark")
+    static var externaldriveTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "externaldrive.trianglebadge.exclamationmark") }
 
     /// 􀙌
     /// Single Localization, 3 Layersets
@@ -2296,35 +2296,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let faceSmilingInverse = SFSymbol(rawValue: "face.smiling.inverse")
+    static var faceSmilingInverse: SFSymbol { .init(rawValue: "face.smiling.inverse") }
 
     /// 􁌜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fanAndLightCeiling = SFSymbol(rawValue: "fan.and.light.ceiling")
+    static var fanAndLightCeiling: SFSymbol { .init(rawValue: "fan.and.light.ceiling") }
 
     /// 􁎺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fanAndLightCeilingFill = SFSymbol(rawValue: "fan.and.light.ceiling.fill")
+    static var fanAndLightCeilingFill: SFSymbol { .init(rawValue: "fan.and.light.ceiling.fill") }
 
     /// 􁌛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fanCeiling = SFSymbol(rawValue: "fan.ceiling")
+    static var fanCeiling: SFSymbol { .init(rawValue: "fan.ceiling") }
 
     /// 􁎹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fanCeilingFill = SFSymbol(rawValue: "fan.ceiling.fill")
+    static var fanCeilingFill: SFSymbol { .init(rawValue: "fan.ceiling.fill") }
 
     /// 􁌙
     /// Single Localization, 2 Layersets
@@ -2332,7 +2332,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanDesk = SFSymbol(rawValue: "fan.desk")
+    static var fanDesk: SFSymbol { .init(rawValue: "fan.desk") }
 
     /// 􁒚
     /// Single Localization, 3 Layersets
@@ -2341,7 +2341,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fanDeskFill = SFSymbol(rawValue: "fan.desk.fill")
+    static var fanDeskFill: SFSymbol { .init(rawValue: "fan.desk.fill") }
 
     /// 􁌚
     /// Single Localization, 2 Layersets
@@ -2349,7 +2349,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanFloor = SFSymbol(rawValue: "fan.floor")
+    static var fanFloor: SFSymbol { .init(rawValue: "fan.floor") }
 
     /// 􁒛
     /// Single Localization, 3 Layersets
@@ -2358,7 +2358,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fanFloorFill = SFSymbol(rawValue: "fan.floor.fill")
+    static var fanFloorFill: SFSymbol { .init(rawValue: "fan.floor.fill") }
 
     /// 􁔄
     /// Single Localization, 2 Layersets
@@ -2366,7 +2366,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanOscillation = SFSymbol(rawValue: "fan.oscillation")
+    static var fanOscillation: SFSymbol { .init(rawValue: "fan.oscillation") }
 
     /// 􁔅
     /// Single Localization, 2 Layersets
@@ -2374,7 +2374,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanOscillationFill = SFSymbol(rawValue: "fan.oscillation.fill")
+    static var fanOscillationFill: SFSymbol { .init(rawValue: "fan.oscillation.fill") }
 
     /// 􁝚
     /// Single Localization, 2 Layersets
@@ -2387,7 +2387,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "fanSlash")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "fanSlash")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "fanSlash")
-    static let fanbladesSlash = SFSymbol(rawValue: "fanblades.slash")
+    static var fanbladesSlash: SFSymbol { .init(rawValue: "fanblades.slash") }
 
     /// 􁝛
     /// Single Localization, 2 Layersets
@@ -2400,35 +2400,35 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "fanSlashFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "fanSlashFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "fanSlashFill")
-    static let fanbladesSlashFill = SFSymbol(rawValue: "fanblades.slash.fill")
+    static var fanbladesSlashFill: SFSymbol { .init(rawValue: "fanblades.slash.fill") }
 
     /// 􀪍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let faxmachineFill = SFSymbol(rawValue: "faxmachine.fill")
+    static var faxmachineFill: SFSymbol { .init(rawValue: "faxmachine.fill") }
 
     /// 􁗇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure2AndChildHoldinghands = SFSymbol(rawValue: "figure.2.and.child.holdinghands")
+    static var figure2AndChildHoldinghands: SFSymbol { .init(rawValue: "figure.2.and.child.holdinghands") }
 
     /// 􁗆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure2ArmsOpen = SFSymbol(rawValue: "figure.2.arms.open")
+    static var figure2ArmsOpen: SFSymbol { .init(rawValue: "figure.2.arms.open") }
 
     /// 􁒐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureAmericanFootball = SFSymbol(rawValue: "figure.american.football")
+    static var figureAmericanFootball: SFSymbol { .init(rawValue: "figure.american.football") }
 
     /// 􁘁
     /// Single Localization, 3 Layersets
@@ -2437,126 +2437,126 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let figureAndChildHoldinghands = SFSymbol(rawValue: "figure.and.child.holdinghands")
+    static var figureAndChildHoldinghands: SFSymbol { .init(rawValue: "figure.and.child.holdinghands") }
 
     /// 􁒑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureArchery = SFSymbol(rawValue: "figure.archery")
+    static var figureArchery: SFSymbol { .init(rawValue: "figure.archery") }
 
     /// 􁗅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureArmsOpen = SFSymbol(rawValue: "figure.arms.open")
+    static var figureArmsOpen: SFSymbol { .init(rawValue: "figure.arms.open") }
 
     /// 􁒒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureAustralianFootball = SFSymbol(rawValue: "figure.australian.football")
+    static var figureAustralianFootball: SFSymbol { .init(rawValue: "figure.australian.football") }
 
     /// 􁔙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBadminton = SFSymbol(rawValue: "figure.badminton")
+    static var figureBadminton: SFSymbol { .init(rawValue: "figure.badminton") }
 
     /// 􁌏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBarre = SFSymbol(rawValue: "figure.barre")
+    static var figureBarre: SFSymbol { .init(rawValue: "figure.barre") }
 
     /// 􁔚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBaseball = SFSymbol(rawValue: "figure.baseball")
+    static var figureBaseball: SFSymbol { .init(rawValue: "figure.baseball") }
 
     /// 􁔛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBasketball = SFSymbol(rawValue: "figure.basketball")
+    static var figureBasketball: SFSymbol { .init(rawValue: "figure.basketball") }
 
     /// 􁔜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBowling = SFSymbol(rawValue: "figure.bowling")
+    static var figureBowling: SFSymbol { .init(rawValue: "figure.bowling") }
 
     /// 􁔝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureBoxing = SFSymbol(rawValue: "figure.boxing")
+    static var figureBoxing: SFSymbol { .init(rawValue: "figure.boxing") }
 
     /// 􁔞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureClimbing = SFSymbol(rawValue: "figure.climbing")
+    static var figureClimbing: SFSymbol { .init(rawValue: "figure.climbing") }
 
     /// 􁔟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureCooldown = SFSymbol(rawValue: "figure.cooldown")
+    static var figureCooldown: SFSymbol { .init(rawValue: "figure.cooldown") }
 
     /// 􁌐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureCoreTraining = SFSymbol(rawValue: "figure.core.training")
+    static var figureCoreTraining: SFSymbol { .init(rawValue: "figure.core.training") }
 
     /// 􁔠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureCricket = SFSymbol(rawValue: "figure.cricket")
+    static var figureCricket: SFSymbol { .init(rawValue: "figure.cricket") }
 
     /// 􁌑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureCrossTraining = SFSymbol(rawValue: "figure.cross.training")
+    static var figureCrossTraining: SFSymbol { .init(rawValue: "figure.cross.training") }
 
     /// 􁔢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureCurling = SFSymbol(rawValue: "figure.curling")
+    static var figureCurling: SFSymbol { .init(rawValue: "figure.curling") }
 
     /// 􁌒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureDance = SFSymbol(rawValue: "figure.dance")
+    static var figureDance: SFSymbol { .init(rawValue: "figure.dance") }
 
     /// 􁔣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureDiscSports = SFSymbol(rawValue: "figure.disc.sports")
+    static var figureDiscSports: SFSymbol { .init(rawValue: "figure.disc.sports") }
 
     /// 􁙂
     /// Single Localization, 2 Layersets
@@ -2569,28 +2569,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "figureStandDressLineVerticalFigure")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "figureStandDressLineVerticalFigure")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureStandDressLineVerticalFigure")
-    static let figureDressLineVerticalFigure = SFSymbol(rawValue: "figure.dress.line.vertical.figure")
+    static var figureDressLineVerticalFigure: SFSymbol { .init(rawValue: "figure.dress.line.vertical.figure") }
 
     /// 􁌌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureElliptical = SFSymbol(rawValue: "figure.elliptical")
+    static var figureElliptical: SFSymbol { .init(rawValue: "figure.elliptical") }
 
     /// 􁔥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureEquestrianSports = SFSymbol(rawValue: "figure.equestrian.sports")
+    static var figureEquestrianSports: SFSymbol { .init(rawValue: "figure.equestrian.sports") }
 
     /// 􀵮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureFall = SFSymbol(rawValue: "figure.fall")
+    static var figureFall: SFSymbol { .init(rawValue: "figure.fall") }
 
     /// 􀵯
     /// Single Localization, 2 Layersets
@@ -2598,7 +2598,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureFallCircle = SFSymbol(rawValue: "figure.fall.circle")
+    static var figureFallCircle: SFSymbol { .init(rawValue: "figure.fall.circle") }
 
     /// 􀵰
     /// Single Localization, 3 Layersets
@@ -2607,182 +2607,182 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureFallCircleFill = SFSymbol(rawValue: "figure.fall.circle.fill")
+    static var figureFallCircleFill: SFSymbol { .init(rawValue: "figure.fall.circle.fill") }
 
     /// 􁔦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureFencing = SFSymbol(rawValue: "figure.fencing")
+    static var figureFencing: SFSymbol { .init(rawValue: "figure.fencing") }
 
     /// 􁔧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureFishing = SFSymbol(rawValue: "figure.fishing")
+    static var figureFishing: SFSymbol { .init(rawValue: "figure.fishing") }
 
     /// 􁕑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureFlexibility = SFSymbol(rawValue: "figure.flexibility")
+    static var figureFlexibility: SFSymbol { .init(rawValue: "figure.flexibility") }
 
     /// 􁔩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureGolf = SFSymbol(rawValue: "figure.golf")
+    static var figureGolf: SFSymbol { .init(rawValue: "figure.golf") }
 
     /// 􁔪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureGymnastics = SFSymbol(rawValue: "figure.gymnastics")
+    static var figureGymnastics: SFSymbol { .init(rawValue: "figure.gymnastics") }
 
     /// 􁔫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHandCycling = SFSymbol(rawValue: "figure.hand.cycling")
+    static var figureHandCycling: SFSymbol { .init(rawValue: "figure.hand.cycling") }
 
     /// 􁔬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHandball = SFSymbol(rawValue: "figure.handball")
+    static var figureHandball: SFSymbol { .init(rawValue: "figure.handball") }
 
     /// 􁌎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHighintensityIntervaltraining = SFSymbol(rawValue: "figure.highintensity.intervaltraining")
+    static var figureHighintensityIntervaltraining: SFSymbol { .init(rawValue: "figure.highintensity.intervaltraining") }
 
     /// 􁔭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHiking = SFSymbol(rawValue: "figure.hiking")
+    static var figureHiking: SFSymbol { .init(rawValue: "figure.hiking") }
 
     /// 􁔮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHockey = SFSymbol(rawValue: "figure.hockey")
+    static var figureHockey: SFSymbol { .init(rawValue: "figure.hockey") }
 
     /// 􁔯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureHunting = SFSymbol(rawValue: "figure.hunting")
+    static var figureHunting: SFSymbol { .init(rawValue: "figure.hunting") }
 
     /// 􁌊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureIndoorCycle = SFSymbol(rawValue: "figure.indoor.cycle")
+    static var figureIndoorCycle: SFSymbol { .init(rawValue: "figure.indoor.cycle") }
 
     /// 􁔰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureJumprope = SFSymbol(rawValue: "figure.jumprope")
+    static var figureJumprope: SFSymbol { .init(rawValue: "figure.jumprope") }
 
     /// 􁔱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureKickboxing = SFSymbol(rawValue: "figure.kickboxing")
+    static var figureKickboxing: SFSymbol { .init(rawValue: "figure.kickboxing") }
 
     /// 􁔲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureLacrosse = SFSymbol(rawValue: "figure.lacrosse")
+    static var figureLacrosse: SFSymbol { .init(rawValue: "figure.lacrosse") }
 
     /// 􁔳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureMartialArts = SFSymbol(rawValue: "figure.martial.arts")
+    static var figureMartialArts: SFSymbol { .init(rawValue: "figure.martial.arts") }
 
     /// 􁔴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureMindAndBody = SFSymbol(rawValue: "figure.mind.and.body")
+    static var figureMindAndBody: SFSymbol { .init(rawValue: "figure.mind.and.body") }
 
     /// 􁔵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureMixedCardio = SFSymbol(rawValue: "figure.mixed.cardio")
+    static var figureMixedCardio: SFSymbol { .init(rawValue: "figure.mixed.cardio") }
 
     /// 􁌇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureOpenWaterSwim = SFSymbol(rawValue: "figure.open.water.swim")
+    static var figureOpenWaterSwim: SFSymbol { .init(rawValue: "figure.open.water.swim") }
 
     /// 􁌉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureOutdoorCycle = SFSymbol(rawValue: "figure.outdoor.cycle")
+    static var figureOutdoorCycle: SFSymbol { .init(rawValue: "figure.outdoor.cycle") }
 
     /// 􁔷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figurePickleball = SFSymbol(rawValue: "figure.pickleball")
+    static var figurePickleball: SFSymbol { .init(rawValue: "figure.pickleball") }
 
     /// 􁌓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figurePilates = SFSymbol(rawValue: "figure.pilates")
+    static var figurePilates: SFSymbol { .init(rawValue: "figure.pilates") }
 
     /// 􁔸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figurePlay = SFSymbol(rawValue: "figure.play")
+    static var figurePlay: SFSymbol { .init(rawValue: "figure.play") }
 
     /// 􁌆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figurePoolSwim = SFSymbol(rawValue: "figure.pool.swim")
+    static var figurePoolSwim: SFSymbol { .init(rawValue: "figure.pool.swim") }
 
     /// 􁔹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRacquetball = SFSymbol(rawValue: "figure.racquetball")
+    static var figureRacquetball: SFSymbol { .init(rawValue: "figure.racquetball") }
 
     /// 􁌈
     /// Single Localization, 2 Layersets
@@ -2790,14 +2790,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let figureRollRunningpace = SFSymbol(rawValue: "figure.roll.runningpace")
+    static var figureRollRunningpace: SFSymbol { .init(rawValue: "figure.roll.runningpace") }
 
     /// 􁔺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRolling = SFSymbol(rawValue: "figure.rolling")
+    static var figureRolling: SFSymbol { .init(rawValue: "figure.rolling") }
 
     /// 􁌋
     /// Single Localization, Single Layerset
@@ -2809,21 +2809,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "figureIndoorRowing")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "figureIndoorRowing")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureIndoorRowing")
-    static let figureRower = SFSymbol(rawValue: "figure.rower")
+    static var figureRower: SFSymbol { .init(rawValue: "figure.rower") }
 
     /// 􁔻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRugby = SFSymbol(rawValue: "figure.rugby")
+    static var figureRugby: SFSymbol { .init(rawValue: "figure.rugby") }
 
     /// 􀐳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRun = SFSymbol(rawValue: "figure.run")
+    static var figureRun: SFSymbol { .init(rawValue: "figure.run") }
 
     /// 􀐴
     /// Single Localization, 2 Layersets
@@ -2831,7 +2831,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRunCircle = SFSymbol(rawValue: "figure.run.circle")
+    static var figureRunCircle: SFSymbol { .init(rawValue: "figure.run.circle") }
 
     /// 􀐵
     /// Single Localization, 3 Layersets
@@ -2840,14 +2840,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRunCircleFill = SFSymbol(rawValue: "figure.run.circle.fill")
+    static var figureRunCircleFill: SFSymbol { .init(rawValue: "figure.run.circle.fill") }
 
     /// 􁔼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSailing = SFSymbol(rawValue: "figure.sailing")
+    static var figureSailing: SFSymbol { .init(rawValue: "figure.sailing") }
 
     /// 􁔽
     /// Single Localization, Single Layerset
@@ -2859,28 +2859,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "figureSkateboarding")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "figureSkateboarding")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSkateboarding")
-    static let figureSkating = SFSymbol(rawValue: "figure.skating")
+    static var figureSkating: SFSymbol { .init(rawValue: "figure.skating") }
 
     /// 􁔡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSkiingCrosscountry = SFSymbol(rawValue: "figure.skiing.crosscountry")
+    static var figureSkiingCrosscountry: SFSymbol { .init(rawValue: "figure.skiing.crosscountry") }
 
     /// 􁔤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSkiingDownhill = SFSymbol(rawValue: "figure.skiing.downhill")
+    static var figureSkiingDownhill: SFSymbol { .init(rawValue: "figure.skiing.downhill") }
 
     /// 􁔾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSnowboarding = SFSymbol(rawValue: "figure.snowboarding")
+    static var figureSnowboarding: SFSymbol { .init(rawValue: "figure.snowboarding") }
 
     /// 􁔿
     /// Single Localization, Single Layerset
@@ -2892,105 +2892,105 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "figureIndoorSoccer")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "figureIndoorSoccer")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureIndoorSoccer")
-    static let figureSoccer = SFSymbol(rawValue: "figure.soccer")
+    static var figureSoccer: SFSymbol { .init(rawValue: "figure.soccer") }
 
     /// 􁕀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSocialdance = SFSymbol(rawValue: "figure.socialdance")
+    static var figureSocialdance: SFSymbol { .init(rawValue: "figure.socialdance") }
 
     /// 􁕁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSoftball = SFSymbol(rawValue: "figure.softball")
+    static var figureSoftball: SFSymbol { .init(rawValue: "figure.softball") }
 
     /// 􁕂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSquash = SFSymbol(rawValue: "figure.squash")
+    static var figureSquash: SFSymbol { .init(rawValue: "figure.squash") }
 
     /// 􁌍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStairStepper = SFSymbol(rawValue: "figure.stair.stepper")
+    static var figureStairStepper: SFSymbol { .init(rawValue: "figure.stair.stepper") }
 
     /// 􁕃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStairs = SFSymbol(rawValue: "figure.stairs")
+    static var figureStairs: SFSymbol { .init(rawValue: "figure.stairs") }
 
     /// 􁕄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStepTraining = SFSymbol(rawValue: "figure.step.training")
+    static var figureStepTraining: SFSymbol { .init(rawValue: "figure.step.training") }
 
     /// 􁔨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStrengthtrainingFunctional = SFSymbol(rawValue: "figure.strengthtraining.functional")
+    static var figureStrengthtrainingFunctional: SFSymbol { .init(rawValue: "figure.strengthtraining.functional") }
 
     /// 􁐃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStrengthtrainingTraditional = SFSymbol(rawValue: "figure.strengthtraining.traditional")
+    static var figureStrengthtrainingTraditional: SFSymbol { .init(rawValue: "figure.strengthtraining.traditional") }
 
     /// 􁕅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSurfing = SFSymbol(rawValue: "figure.surfing")
+    static var figureSurfing: SFSymbol { .init(rawValue: "figure.surfing") }
 
     /// 􁌔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureTableTennis = SFSymbol(rawValue: "figure.table.tennis")
+    static var figureTableTennis: SFSymbol { .init(rawValue: "figure.table.tennis") }
 
     /// 􁕆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureTaichi = SFSymbol(rawValue: "figure.taichi")
+    static var figureTaichi: SFSymbol { .init(rawValue: "figure.taichi") }
 
     /// 􁒋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureTennis = SFSymbol(rawValue: "figure.tennis")
+    static var figureTennis: SFSymbol { .init(rawValue: "figure.tennis") }
 
     /// 􁕇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureTrackAndField = SFSymbol(rawValue: "figure.track.and.field")
+    static var figureTrackAndField: SFSymbol { .init(rawValue: "figure.track.and.field") }
 
     /// 􁕈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureVolleyball = SFSymbol(rawValue: "figure.volleyball")
+    static var figureVolleyball: SFSymbol { .init(rawValue: "figure.volleyball") }
 
     /// 􁏚
     /// Single Localization, 2 Layersets
@@ -2998,7 +2998,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkArrival = SFSymbol(rawValue: "figure.walk.arrival")
+    static var figureWalkArrival: SFSymbol { .init(rawValue: "figure.walk.arrival") }
 
     /// 􁏛
     /// Single Localization, 2 Layersets
@@ -3006,7 +3006,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkDeparture = SFSymbol(rawValue: "figure.walk.departure")
+    static var figureWalkDeparture: SFSymbol { .init(rawValue: "figure.walk.departure") }
 
     /// 􁐑
     /// Single Localization, 2 Layersets
@@ -3014,63 +3014,63 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkMotion = SFSymbol(rawValue: "figure.walk.motion")
+    static var figureWalkMotion: SFSymbol { .init(rawValue: "figure.walk.motion") }
 
     /// 􁕉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWaterFitness = SFSymbol(rawValue: "figure.water.fitness")
+    static var figureWaterFitness: SFSymbol { .init(rawValue: "figure.water.fitness") }
 
     /// 􁕊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWaterpolo = SFSymbol(rawValue: "figure.waterpolo")
+    static var figureWaterpolo: SFSymbol { .init(rawValue: "figure.waterpolo") }
 
     /// 􁕌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWrestling = SFSymbol(rawValue: "figure.wrestling")
+    static var figureWrestling: SFSymbol { .init(rawValue: "figure.wrestling") }
 
     /// 􁒌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureYoga = SFSymbol(rawValue: "figure.yoga")
+    static var figureYoga: SFSymbol { .init(rawValue: "figure.yoga") }
 
     /// 􁒖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let filmStack = SFSymbol(rawValue: "film.stack")
+    static var filmStack: SFSymbol { .init(rawValue: "film.stack") }
 
     /// 􁒗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let filmStackFill = SFSymbol(rawValue: "film.stack.fill")
+    static var filmStackFill: SFSymbol { .init(rawValue: "film.stack.fill") }
 
     /// 􁐸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fireplace = SFSymbol(rawValue: "fireplace")
+    static var fireplace: SFSymbol { .init(rawValue: "fireplace") }
 
     /// 􁐹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fireplaceFill = SFSymbol(rawValue: "fireplace.fill")
+    static var fireplaceFill: SFSymbol { .init(rawValue: "fireplace.fill") }
 
     /// 􁙾
     /// Single Localization, 2 Layersets
@@ -3078,7 +3078,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let firewall = SFSymbol(rawValue: "firewall")
+    static var firewall: SFSymbol { .init(rawValue: "firewall") }
 
     /// 􁙿
     /// Single Localization, 3 Layersets
@@ -3087,21 +3087,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let firewallFill = SFSymbol(rawValue: "firewall.fill")
+    static var firewallFill: SFSymbol { .init(rawValue: "firewall.fill") }
 
     /// 􁖐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fish = SFSymbol(rawValue: "fish")
+    static var fish: SFSymbol { .init(rawValue: "fish") }
 
     /// 􁖑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fishFill = SFSymbol(rawValue: "fish.fill")
+    static var fishFill: SFSymbol { .init(rawValue: "fish.fill") }
 
     /// 􁜅
     /// Single Localization, 2 Layersets
@@ -3109,7 +3109,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flag2CrossedCircle = SFSymbol(rawValue: "flag.2.crossed.circle")
+    static var flag2CrossedCircle: SFSymbol { .init(rawValue: "flag.2.crossed.circle") }
 
     /// 􁜆
     /// Single Localization, 3 Layersets
@@ -3118,7 +3118,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flag2CrossedCircleFill = SFSymbol(rawValue: "flag.2.crossed.circle.fill")
+    static var flag2CrossedCircleFill: SFSymbol { .init(rawValue: "flag.2.crossed.circle.fill") }
 
     /// 􁙌
     /// Single Localization, Single Layerset
@@ -3130,7 +3130,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "flagPatternCheckered")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "flagPatternCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "flagPatternCheckered")
-    static let flagCheckered = SFSymbol(rawValue: "flag.checkered")
+    static var flagCheckered: SFSymbol { .init(rawValue: "flag.checkered") }
 
     /// 􁜔
     /// Single Localization, 2 Layersets
@@ -3143,28 +3143,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "flagPatternCheckered2Crossed")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "flagPatternCheckered2Crossed")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "flagPatternCheckered2Crossed")
-    static let flagCheckered2Crossed = SFSymbol(rawValue: "flag.checkered.2.crossed")
+    static var flagCheckered2Crossed: SFSymbol { .init(rawValue: "flag.checkered.2.crossed") }
 
     /// 􁓯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fleuron = SFSymbol(rawValue: "fleuron")
+    static var fleuron: SFSymbol { .init(rawValue: "fleuron") }
 
     /// 􁓔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fleuronFill = SFSymbol(rawValue: "fleuron.fill")
+    static var fleuronFill: SFSymbol { .init(rawValue: "fleuron.fill") }
 
     /// 􁑄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let florinsign = SFSymbol(rawValue: "florinsign")
+    static var florinsign: SFSymbol { .init(rawValue: "florinsign") }
 
     /// 􁊌
     /// Single Localization, 2 Layersets
@@ -3172,7 +3172,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fluidBrakesignal = SFSymbol(rawValue: "fluid.brakesignal")
+    static var fluidBrakesignal: SFSymbol { .init(rawValue: "fluid.brakesignal") }
 
     /// 􁗋
     /// Single Localization, Single Layerset
@@ -3184,7 +3184,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "americanFootball")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "americanFootball")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "americanFootball")
-    static let football = SFSymbol(rawValue: "football")
+    static var football: SFSymbol { .init(rawValue: "football") }
 
     /// 􁚿
     /// Single Localization, 2 Layersets
@@ -3197,7 +3197,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "americanFootballCircle")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "americanFootballCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "americanFootballCircle")
-    static let footballCircle = SFSymbol(rawValue: "football.circle")
+    static var footballCircle: SFSymbol { .init(rawValue: "football.circle") }
 
     /// 􁛀
     /// Single Localization, 3 Layersets
@@ -3211,7 +3211,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "americanFootballCircleFill")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "americanFootballCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "americanFootballCircleFill")
-    static let footballCircleFill = SFSymbol(rawValue: "football.circle.fill")
+    static var footballCircleFill: SFSymbol { .init(rawValue: "football.circle.fill") }
 
     /// 􁗌
     /// Single Localization, Single Layerset
@@ -3223,7 +3223,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "americanFootballFill")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "americanFootballFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "americanFootballFill")
-    static let footballFill = SFSymbol(rawValue: "football.fill")
+    static var footballFill: SFSymbol { .init(rawValue: "football.fill") }
 
     /// 􁋰
     /// Single Localization, 2 Layersets
@@ -3231,7 +3231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let forwardEndCircle = SFSymbol(rawValue: "forward.end.circle")
+    static var forwardEndCircle: SFSymbol { .init(rawValue: "forward.end.circle") }
 
     /// 􁋱
     /// Single Localization, 3 Layersets
@@ -3240,42 +3240,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let forwardEndCircleFill = SFSymbol(rawValue: "forward.end.circle.fill")
+    static var forwardEndCircleFill: SFSymbol { .init(rawValue: "forward.end.circle.fill") }
 
     /// 􁕔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fossilShell = SFSymbol(rawValue: "fossil.shell")
+    static var fossilShell: SFSymbol { .init(rawValue: "fossil.shell") }
 
     /// 􁕕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fossilShellFill = SFSymbol(rawValue: "fossil.shell.fill")
+    static var fossilShellFill: SFSymbol { .init(rawValue: "fossil.shell.fill") }
 
     /// 􁑃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let francsign = SFSymbol(rawValue: "francsign")
+    static var francsign: SFSymbol { .init(rawValue: "francsign") }
 
     /// 􁐅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fryingPan = SFSymbol(rawValue: "frying.pan")
+    static var fryingPan: SFSymbol { .init(rawValue: "frying.pan") }
 
     /// 􁐆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fryingPanFill = SFSymbol(rawValue: "frying.pan.fill")
+    static var fryingPanFill: SFSymbol { .init(rawValue: "frying.pan.fill") }
 
     /// 􁐘
     /// Single Localization, 2 Layersets
@@ -3288,7 +3288,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedleBottom100percent")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedleBottom100percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedleBottom100percent")
-    static let gaugeHigh = SFSymbol(rawValue: "gauge.high")
+    static var gaugeHigh: SFSymbol { .init(rawValue: "gauge.high") }
 
     /// 􁐗
     /// Single Localization, 2 Layersets
@@ -3301,7 +3301,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedleBottom0percent")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedleBottom0percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedleBottom0percent")
-    static let gaugeLow = SFSymbol(rawValue: "gauge.low")
+    static var gaugeLow: SFSymbol { .init(rawValue: "gauge.low") }
 
     /// 􀍽
     /// Single Localization, 2 Layersets
@@ -3314,7 +3314,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedleBottom50percent")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedleBottom50percent")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedleBottom50percent")
-    static let gaugeMedium = SFSymbol(rawValue: "gauge.medium")
+    static var gaugeMedium: SFSymbol { .init(rawValue: "gauge.medium") }
 
     /// 􀓧
     /// Single Localization, 3 Layersets
@@ -3328,7 +3328,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgeMinus")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgeMinus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgeMinus")
-    static let gaugeMediumBadgeMinus = SFSymbol(rawValue: "gauge.medium.badge.minus")
+    static var gaugeMediumBadgeMinus: SFSymbol { .init(rawValue: "gauge.medium.badge.minus") }
 
     /// 􀓓
     /// Single Localization, 3 Layersets
@@ -3342,7 +3342,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgePlus")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgePlus")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "gaugeWithDotsNeedleBottom50percentBadgePlus")
-    static let gaugeMediumBadgePlus = SFSymbol(rawValue: "gauge.medium.badge.plus")
+    static var gaugeMediumBadgePlus: SFSymbol { .init(rawValue: "gauge.medium.badge.plus") }
 
     /// 􁓹
     /// 2 Localizations, 3 Layersets
@@ -3355,7 +3355,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gearBadge = SymbolWith1Localization<Rtl>(rawValue: "gear.badge")
+    static var gearBadge: SymbolWith1Localization<Rtl> { .init(rawValue: "gear.badge") }
 
     /// 􁐂
     /// Single Localization, 2 Layersets
@@ -3368,42 +3368,42 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "gearshapeArrowTrianglehead2ClockwiseRotate90")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "gearshapeArrowTrianglehead2ClockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "gearshapeArrowTrianglehead2ClockwiseRotate90")
-    static let gearshapeArrowTriangle2Circlepath = SFSymbol(rawValue: "gearshape.arrow.triangle.2.circlepath")
+    static var gearshapeArrowTriangle2Circlepath: SFSymbol { .init(rawValue: "gearshape.arrow.triangle.2.circlepath") }
 
     /// 􁇲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeCentralSouthAsia = SFSymbol(rawValue: "globe.central.south.asia")
+    static var globeCentralSouthAsia: SFSymbol { .init(rawValue: "globe.central.south.asia") }
 
     /// 􁇳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeCentralSouthAsiaFill = SFSymbol(rawValue: "globe.central.south.asia.fill")
+    static var globeCentralSouthAsiaFill: SFSymbol { .init(rawValue: "globe.central.south.asia.fill") }
 
     /// 􁔖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeDesk = SFSymbol(rawValue: "globe.desk")
+    static var globeDesk: SFSymbol { .init(rawValue: "globe.desk") }
 
     /// 􁕓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeDeskFill = SFSymbol(rawValue: "globe.desk.fill")
+    static var globeDeskFill: SFSymbol { .init(rawValue: "globe.desk.fill") }
 
     /// 􁑓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let guaranisign = SFSymbol(rawValue: "guaranisign")
+    static var guaranisign: SFSymbol { .init(rawValue: "guaranisign") }
 
     /// 􁝌
     /// Single Localization, 3 Layersets
@@ -3417,7 +3417,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 16.1, renamed: "handRaisedApp")
     @available(watchOS, introduced: 9.0, deprecated: 9.1, renamed: "handRaisedApp")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "handRaisedApp")
-    static let handApp = SFSymbol(rawValue: "hand.app")
+    static var handApp: SFSymbol { .init(rawValue: "hand.app") }
 
     /// 􁝍
     /// Single Localization, 3 Layersets
@@ -3431,21 +3431,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 16.1, renamed: "handRaisedAppFill")
     @available(watchOS, introduced: 9.0, deprecated: 9.1, renamed: "handRaisedAppFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "handRaisedAppFill")
-    static let handAppFill = SFSymbol(rawValue: "hand.app.fill")
+    static var handAppFill: SFSymbol { .init(rawValue: "hand.app.fill") }
 
     /// 􁗩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handRaisedFingersSpread = SFSymbol(rawValue: "hand.raised.fingers.spread")
+    static var handRaisedFingersSpread: SFSymbol { .init(rawValue: "hand.raised.fingers.spread") }
 
     /// 􁗪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handRaisedFingersSpreadFill = SFSymbol(rawValue: "hand.raised.fingers.spread.fill")
+    static var handRaisedFingersSpreadFill: SFSymbol { .init(rawValue: "hand.raised.fingers.spread.fill") }
 
     /// 􀾲
     /// Single Localization, 3 Layersets
@@ -3454,7 +3454,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightHighBeam = SFSymbol(rawValue: "headlight.high.beam")
+    static var headlightHighBeam: SFSymbol { .init(rawValue: "headlight.high.beam") }
 
     /// 􀾳
     /// Single Localization, 3 Layersets
@@ -3463,7 +3463,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightHighBeamFill = SFSymbol(rawValue: "headlight.high.beam.fill")
+    static var headlightHighBeamFill: SFSymbol { .init(rawValue: "headlight.high.beam.fill") }
 
     /// 􀾴
     /// Single Localization, 3 Layersets
@@ -3472,7 +3472,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightLowBeam = SFSymbol(rawValue: "headlight.low.beam")
+    static var headlightLowBeam: SFSymbol { .init(rawValue: "headlight.low.beam") }
 
     /// 􀾵
     /// Single Localization, 3 Layersets
@@ -3481,7 +3481,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightLowBeamFill = SFSymbol(rawValue: "headlight.low.beam.fill")
+    static var headlightLowBeamFill: SFSymbol { .init(rawValue: "headlight.low.beam.fill") }
 
     /// 􁎏
     /// Single Localization, 3 Layersets
@@ -3490,7 +3490,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hearingdeviceAndSignalMeter = SFSymbol(rawValue: "hearingdevice.and.signal.meter")
+    static var hearingdeviceAndSignalMeter: SFSymbol { .init(rawValue: "hearingdevice.and.signal.meter") }
 
     /// 􁎐
     /// Single Localization, 3 Layersets
@@ -3499,7 +3499,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hearingdeviceAndSignalMeterFill = SFSymbol(rawValue: "hearingdevice.and.signal.meter.fill")
+    static var hearingdeviceAndSignalMeterFill: SFSymbol { .init(rawValue: "hearingdevice.and.signal.meter.fill") }
 
     /// 􁉗
     /// Single Localization, 3 Layersets
@@ -3508,7 +3508,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hearingdeviceEarFill = SFSymbol(rawValue: "hearingdevice.ear.fill")
+    static var hearingdeviceEarFill: SFSymbol { .init(rawValue: "hearingdevice.ear.fill") }
 
     /// 􁓩
     /// Single Localization, 2 Layersets
@@ -3516,7 +3516,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heaterVertical = SFSymbol(rawValue: "heater.vertical")
+    static var heaterVertical: SFSymbol { .init(rawValue: "heater.vertical") }
 
     /// 􁓪
     /// Single Localization, 2 Layersets
@@ -3524,28 +3524,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heaterVerticalFill = SFSymbol(rawValue: "heater.vertical.fill")
+    static var heaterVerticalFill: SFSymbol { .init(rawValue: "heater.vertical.fill") }
 
     /// 􁒬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hifireceiver = SFSymbol(rawValue: "hifireceiver")
+    static var hifireceiver: SFSymbol { .init(rawValue: "hifireceiver") }
 
     /// 􁒭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hifireceiverFill = SFSymbol(rawValue: "hifireceiver.fill")
+    static var hifireceiverFill: SFSymbol { .init(rawValue: "hifireceiver.fill") }
 
     /// 􁛽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hockeyPuck = SFSymbol(rawValue: "hockey.puck")
+    static var hockeyPuck: SFSymbol { .init(rawValue: "hockey.puck") }
 
     /// 􁛿
     /// Single Localization, 2 Layersets
@@ -3553,7 +3553,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hockeyPuckCircle = SFSymbol(rawValue: "hockey.puck.circle")
+    static var hockeyPuckCircle: SFSymbol { .init(rawValue: "hockey.puck.circle") }
 
     /// 􁜀
     /// Single Localization, 3 Layersets
@@ -3562,14 +3562,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hockeyPuckCircleFill = SFSymbol(rawValue: "hockey.puck.circle.fill")
+    static var hockeyPuckCircleFill: SFSymbol { .init(rawValue: "hockey.puck.circle.fill") }
 
     /// 􁛾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hockeyPuckFill = SFSymbol(rawValue: "hockey.puck.fill")
+    static var hockeyPuckFill: SFSymbol { .init(rawValue: "hockey.puck.fill") }
 
     /// 􁋌
     /// Single Localization, 2 Layersets
@@ -3577,21 +3577,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let holdBrakesignal = SFSymbol(rawValue: "hold.brakesignal")
+    static var holdBrakesignal: SFSymbol { .init(rawValue: "hold.brakesignal") }
 
     /// 􁑑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hryvniasign = SFSymbol(rawValue: "hryvniasign")
+    static var hryvniasign: SFSymbol { .init(rawValue: "hryvniasign") }
 
     /// 􁘘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let humidifier = SFSymbol(rawValue: "humidifier")
+    static var humidifier: SFSymbol { .init(rawValue: "humidifier") }
 
     /// 􁔆
     /// Single Localization, 2 Layersets
@@ -3599,7 +3599,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let humidifierAndDroplets = SFSymbol(rawValue: "humidifier.and.droplets")
+    static var humidifierAndDroplets: SFSymbol { .init(rawValue: "humidifier.and.droplets") }
 
     /// 􁔇
     /// Single Localization, 2 Layersets
@@ -3607,14 +3607,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let humidifierAndDropletsFill = SFSymbol(rawValue: "humidifier.and.droplets.fill")
+    static var humidifierAndDropletsFill: SFSymbol { .init(rawValue: "humidifier.and.droplets.fill") }
 
     /// 􁘙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let humidifierFill = SFSymbol(rawValue: "humidifier.fill")
+    static var humidifierFill: SFSymbol { .init(rawValue: "humidifier.fill") }
 
     /// 􁛷
     /// Single Localization, 2 Layersets
@@ -3622,7 +3622,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hurricaneCircle = SFSymbol(rawValue: "hurricane.circle")
+    static var hurricaneCircle: SFSymbol { .init(rawValue: "hurricane.circle") }
 
     /// 􁛸
     /// Single Localization, 3 Layersets
@@ -3631,14 +3631,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hurricaneCircleFill = SFSymbol(rawValue: "hurricane.circle.fill")
+    static var hurricaneCircleFill: SFSymbol { .init(rawValue: "hurricane.circle.fill") }
 
     /// 􁑉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let indianrupeesign = SFSymbol(rawValue: "indianrupeesign")
+    static var indianrupeesign: SFSymbol { .init(rawValue: "indianrupeesign") }
 
     /// 􁌴
     /// 2 Localizations, 2 Layersets
@@ -3650,7 +3650,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let infoBubble = SymbolWith1Localization<Rtl_v5>(rawValue: "info.bubble")
+    static var infoBubble: SymbolWith1Localization<Rtl_v5> { .init(rawValue: "info.bubble") }
 
     /// 􁌵
     /// 2 Localizations, 3 Layersets
@@ -3663,7 +3663,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let infoBubbleFill = SymbolWith1Localization<Rtl_v5>(rawValue: "info.bubble.fill")
+    static var infoBubbleFill: SymbolWith1Localization<Rtl_v5> { .init(rawValue: "info.bubble.fill") }
 
     /// 􁊇
     /// Single Localization, 3 Layersets
@@ -3672,7 +3672,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let infoSquare = SFSymbol(rawValue: "info.square")
+    static var infoSquare: SFSymbol { .init(rawValue: "info.square") }
 
     /// 􁊈
     /// Single Localization, 3 Layersets
@@ -3681,7 +3681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let infoSquareFill = SFSymbol(rawValue: "info.square.fill")
+    static var infoSquareFill: SFSymbol { .init(rawValue: "info.square.fill") }
 
     /// 􁚏
     /// Single Localization, 3 Layersets
@@ -3690,7 +3690,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyboardBadgeEllipsisFill = SFSymbol(rawValue: "keyboard.badge.ellipsis.fill")
+    static var keyboardBadgeEllipsisFill: SFSymbol { .init(rawValue: "keyboard.badge.ellipsis.fill") }
 
     /// 􁔕
     /// Single Localization, 2 Layersets
@@ -3698,7 +3698,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyboardBadgeEye = SFSymbol(rawValue: "keyboard.badge.eye")
+    static var keyboardBadgeEye: SFSymbol { .init(rawValue: "keyboard.badge.eye") }
 
     /// 􁚐
     /// Single Localization, 2 Layersets
@@ -3706,21 +3706,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyboardBadgeEyeFill = SFSymbol(rawValue: "keyboard.badge.eye.fill")
+    static var keyboardBadgeEyeFill: SFSymbol { .init(rawValue: "keyboard.badge.eye.fill") }
 
     /// 􁚑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardChevronCompactDownFill = SFSymbol(rawValue: "keyboard.chevron.compact.down.fill")
+    static var keyboardChevronCompactDownFill: SFSymbol { .init(rawValue: "keyboard.chevron.compact.down.fill") }
 
     /// 􁚒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyboardChevronCompactLeftFill = SFSymbol(rawValue: "keyboard.chevron.compact.left.fill")
+    static var keyboardChevronCompactLeftFill: SFSymbol { .init(rawValue: "keyboard.chevron.compact.left.fill") }
 
     /// 􁚓
     /// Single Localization, 3 Layersets
@@ -3729,7 +3729,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyboardOnehandedLeftFill = SFSymbol(rawValue: "keyboard.onehanded.left.fill")
+    static var keyboardOnehandedLeftFill: SFSymbol { .init(rawValue: "keyboard.onehanded.left.fill") }
 
     /// 􁚔
     /// Single Localization, 3 Layersets
@@ -3738,77 +3738,77 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyboardOnehandedRightFill = SFSymbol(rawValue: "keyboard.onehanded.right.fill")
+    static var keyboardOnehandedRightFill: SFSymbol { .init(rawValue: "keyboard.onehanded.right.fill") }
 
     /// 􁑍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let kipsign = SFSymbol(rawValue: "kipsign")
+    static var kipsign: SFSymbol { .init(rawValue: "kipsign") }
 
     /// 􁌡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampCeiling = SFSymbol(rawValue: "lamp.ceiling")
+    static var lampCeiling: SFSymbol { .init(rawValue: "lamp.ceiling") }
 
     /// 􁎻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampCeilingFill = SFSymbol(rawValue: "lamp.ceiling.fill")
+    static var lampCeilingFill: SFSymbol { .init(rawValue: "lamp.ceiling.fill") }
 
     /// 􁒨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampCeilingInverse = SFSymbol(rawValue: "lamp.ceiling.inverse")
+    static var lampCeilingInverse: SFSymbol { .init(rawValue: "lamp.ceiling.inverse") }
 
     /// 􁎶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampDesk = SFSymbol(rawValue: "lamp.desk")
+    static var lampDesk: SFSymbol { .init(rawValue: "lamp.desk") }
 
     /// 􁌞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampDeskFill = SFSymbol(rawValue: "lamp.desk.fill")
+    static var lampDeskFill: SFSymbol { .init(rawValue: "lamp.desk.fill") }
 
     /// 􁎿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampFloor = SFSymbol(rawValue: "lamp.floor")
+    static var lampFloor: SFSymbol { .init(rawValue: "lamp.floor") }
 
     /// 􁌠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampFloorFill = SFSymbol(rawValue: "lamp.floor.fill")
+    static var lampFloorFill: SFSymbol { .init(rawValue: "lamp.floor.fill") }
 
     /// 􁏀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampTable = SFSymbol(rawValue: "lamp.table")
+    static var lampTable: SFSymbol { .init(rawValue: "lamp.table") }
 
     /// 􁌟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lampTableFill = SFSymbol(rawValue: "lamp.table.fill")
+    static var lampTableFill: SFSymbol { .init(rawValue: "lamp.table.fill") }
 
     /// 􁘞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3823,28 +3823,28 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 16.1, renamed: "macbookAndIpad")
     @available(watchOS, introduced: 9.0, deprecated: 9.1, renamed: "macbookAndIpad")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "macbookAndIpad")
-    static let laptopcomputerAndIpad = SFSymbol(rawValue: "laptopcomputer.and.ipad")
+    static var laptopcomputerAndIpad: SFSymbol { .init(rawValue: "laptopcomputer.and.ipad") }
 
     /// 􁑝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let larisign = SFSymbol(rawValue: "larisign")
+    static var larisign: SFSymbol { .init(rawValue: "larisign") }
 
     /// 􁊘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let laurelLeading = SFSymbol(rawValue: "laurel.leading")
+    static var laurelLeading: SFSymbol { .init(rawValue: "laurel.leading") }
 
     /// 􁊙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let laurelTrailing = SFSymbol(rawValue: "laurel.trailing")
+    static var laurelTrailing: SFSymbol { .init(rawValue: "laurel.trailing") }
 
     /// 􁒰
     /// Single Localization, 3 Layersets
@@ -3853,7 +3853,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightBeaconMax = SFSymbol(rawValue: "light.beacon.max")
+    static var lightBeaconMax: SFSymbol { .init(rawValue: "light.beacon.max") }
 
     /// 􁒱
     /// Single Localization, 3 Layersets
@@ -3862,7 +3862,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightBeaconMaxFill = SFSymbol(rawValue: "light.beacon.max.fill")
+    static var lightBeaconMaxFill: SFSymbol { .init(rawValue: "light.beacon.max.fill") }
 
     /// 􁜮
     /// Single Localization, 3 Layersets
@@ -3871,7 +3871,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightBeaconMin = SFSymbol(rawValue: "light.beacon.min")
+    static var lightBeaconMin: SFSymbol { .init(rawValue: "light.beacon.min") }
 
     /// 􁜯
     /// Single Localization, 3 Layersets
@@ -3880,28 +3880,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightBeaconMinFill = SFSymbol(rawValue: "light.beacon.min.fill")
+    static var lightBeaconMinFill: SFSymbol { .init(rawValue: "light.beacon.min.fill") }
 
     /// 􁎼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightCylindricalCeiling = SFSymbol(rawValue: "light.cylindrical.ceiling")
+    static var lightCylindricalCeiling: SFSymbol { .init(rawValue: "light.cylindrical.ceiling") }
 
     /// 􁌤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightCylindricalCeilingFill = SFSymbol(rawValue: "light.cylindrical.ceiling.fill")
+    static var lightCylindricalCeilingFill: SFSymbol { .init(rawValue: "light.cylindrical.ceiling.fill") }
 
     /// 􁒪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightCylindricalCeilingInverse = SFSymbol(rawValue: "light.cylindrical.ceiling.inverse")
+    static var lightCylindricalCeilingInverse: SFSymbol { .init(rawValue: "light.cylindrical.ceiling.inverse") }
 
     /// 􁎽
     /// Single Localization, 2 Layersets
@@ -3909,7 +3909,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightPanel = SFSymbol(rawValue: "light.panel")
+    static var lightPanel: SFSymbol { .init(rawValue: "light.panel") }
 
     /// 􁌣
     /// Single Localization, 2 Layersets
@@ -3917,77 +3917,77 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightPanelFill = SFSymbol(rawValue: "light.panel.fill")
+    static var lightPanelFill: SFSymbol { .init(rawValue: "light.panel.fill") }
 
     /// 􁎾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessed = SFSymbol(rawValue: "light.recessed")
+    static var lightRecessed: SFSymbol { .init(rawValue: "light.recessed") }
 
     /// 􁏘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessed3 = SFSymbol(rawValue: "light.recessed.3")
+    static var lightRecessed3: SFSymbol { .init(rawValue: "light.recessed.3") }
 
     /// 􁏙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessed3Fill = SFSymbol(rawValue: "light.recessed.3.fill")
+    static var lightRecessed3Fill: SFSymbol { .init(rawValue: "light.recessed.3.fill") }
 
     /// 􁒫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessed3Inverse = SFSymbol(rawValue: "light.recessed.3.inverse")
+    static var lightRecessed3Inverse: SFSymbol { .init(rawValue: "light.recessed.3.inverse") }
 
     /// 􁌢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessedFill = SFSymbol(rawValue: "light.recessed.fill")
+    static var lightRecessedFill: SFSymbol { .init(rawValue: "light.recessed.fill") }
 
     /// 􁒩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRecessedInverse = SFSymbol(rawValue: "light.recessed.inverse")
+    static var lightRecessedInverse: SFSymbol { .init(rawValue: "light.recessed.inverse") }
 
     /// 􁒜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRibbon = SFSymbol(rawValue: "light.ribbon")
+    static var lightRibbon: SFSymbol { .init(rawValue: "light.ribbon") }
 
     /// 􁒝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightRibbonFill = SFSymbol(rawValue: "light.ribbon.fill")
+    static var lightRibbonFill: SFSymbol { .init(rawValue: "light.ribbon.fill") }
 
     /// 􁌥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightStrip2 = SFSymbol(rawValue: "light.strip.2")
+    static var lightStrip2: SFSymbol { .init(rawValue: "light.strip.2") }
 
     /// 􁏒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightStrip2Fill = SFSymbol(rawValue: "light.strip.2.fill")
+    static var lightStrip2Fill: SFSymbol { .init(rawValue: "light.strip.2.fill") }
 
     /// 􁓼
     /// Single Localization, 3 Layersets
@@ -3996,7 +3996,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightbulb2 = SFSymbol(rawValue: "lightbulb.2")
+    static var lightbulb2: SFSymbol { .init(rawValue: "lightbulb.2") }
 
     /// 􁓽
     /// Single Localization, 2 Layersets
@@ -4004,14 +4004,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulb2Fill = SFSymbol(rawValue: "lightbulb.2.fill")
+    static var lightbulb2Fill: SFSymbol { .init(rawValue: "lightbulb.2.fill") }
 
     /// 􁎦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightbulbLed = SFSymbol(rawValue: "lightbulb.led")
+    static var lightbulbLed: SFSymbol { .init(rawValue: "lightbulb.led") }
 
     /// 􁌝
     /// Single Localization, 3 Layersets
@@ -4020,14 +4020,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightbulbLedFill = SFSymbol(rawValue: "lightbulb.led.fill")
+    static var lightbulbLedFill: SFSymbol { .init(rawValue: "lightbulb.led.fill") }
 
     /// 􁏁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightbulbLedWide = SFSymbol(rawValue: "lightbulb.led.wide")
+    static var lightbulbLedWide: SFSymbol { .init(rawValue: "lightbulb.led.wide") }
 
     /// 􁏂
     /// Single Localization, 3 Layersets
@@ -4036,7 +4036,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightbulbLedWideFill = SFSymbol(rawValue: "lightbulb.led.wide.fill")
+    static var lightbulbLedWideFill: SFSymbol { .init(rawValue: "lightbulb.led.wide.fill") }
 
     /// 􁏯
     /// Single Localization, 2 Layersets
@@ -4044,7 +4044,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightswitchOff = SFSymbol(rawValue: "lightswitch.off")
+    static var lightswitchOff: SFSymbol { .init(rawValue: "lightswitch.off") }
 
     /// 􁏼
     /// Single Localization, 3 Layersets
@@ -4053,7 +4053,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightswitchOffFill = SFSymbol(rawValue: "lightswitch.off.fill")
+    static var lightswitchOffFill: SFSymbol { .init(rawValue: "lightswitch.off.fill") }
 
     /// 􁎒
     /// Single Localization, 2 Layersets
@@ -4061,7 +4061,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightswitchOffSquare = SFSymbol(rawValue: "lightswitch.off.square")
+    static var lightswitchOffSquare: SFSymbol { .init(rawValue: "lightswitch.off.square") }
 
     /// 􁌨
     /// Single Localization, 3 Layersets
@@ -4070,7 +4070,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightswitchOffSquareFill = SFSymbol(rawValue: "lightswitch.off.square.fill")
+    static var lightswitchOffSquareFill: SFSymbol { .init(rawValue: "lightswitch.off.square.fill") }
 
     /// 􁏮
     /// Single Localization, 2 Layersets
@@ -4078,7 +4078,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightswitchOn = SFSymbol(rawValue: "lightswitch.on")
+    static var lightswitchOn: SFSymbol { .init(rawValue: "lightswitch.on") }
 
     /// 􁏻
     /// Single Localization, 3 Layersets
@@ -4087,7 +4087,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightswitchOnFill = SFSymbol(rawValue: "lightswitch.on.fill")
+    static var lightswitchOnFill: SFSymbol { .init(rawValue: "lightswitch.on.fill") }
 
     /// 􁎑
     /// Single Localization, 2 Layersets
@@ -4095,7 +4095,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightswitchOnSquare = SFSymbol(rawValue: "lightswitch.on.square")
+    static var lightswitchOnSquare: SFSymbol { .init(rawValue: "lightswitch.on.square") }
 
     /// 􁌧
     /// Single Localization, 3 Layersets
@@ -4104,14 +4104,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightswitchOnSquareFill = SFSymbol(rawValue: "lightswitch.on.square.fill")
+    static var lightswitchOnSquareFill: SFSymbol { .init(rawValue: "lightswitch.on.square.fill") }
 
     /// 􁑏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lirasign = SFSymbol(rawValue: "lirasign")
+    static var lirasign: SFSymbol { .init(rawValue: "lirasign") }
 
     /// 􀼏
     /// Single Localization, 3 Layersets
@@ -4120,7 +4120,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listBulletClipboard = SFSymbol(rawValue: "list.bullet.clipboard")
+    static var listBulletClipboard: SFSymbol { .init(rawValue: "list.bullet.clipboard") }
 
     /// 􀼐
     /// Single Localization, 3 Layersets
@@ -4129,7 +4129,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let listBulletClipboardFill = SFSymbol(rawValue: "list.bullet.clipboard.fill")
+    static var listBulletClipboardFill: SFSymbol { .init(rawValue: "list.bullet.clipboard.fill") }
 
     /// 􁕜
     /// Single Localization, 3 Layersets
@@ -4138,7 +4138,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4)
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let listClipboard = SFSymbol(rawValue: "list.clipboard")
+    static var listClipboard: SFSymbol { .init(rawValue: "list.clipboard") }
 
     /// 􁕝
     /// Single Localization, 2 Layersets
@@ -4146,7 +4146,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let listClipboardFill = SFSymbol(rawValue: "list.clipboard.fill")
+    static var listClipboardFill: SFSymbol { .init(rawValue: "list.clipboard.fill") }
 
     /// 􁗛
     /// Single Localization, 2 Layersets
@@ -4154,7 +4154,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let lizard = SFSymbol(rawValue: "lizard")
+    static var lizard: SFSymbol { .init(rawValue: "lizard") }
 
     /// 􁗜
     /// Single Localization, 2 Layersets
@@ -4162,7 +4162,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let lizardFill = SFSymbol(rawValue: "lizard.fill")
+    static var lizardFill: SFSymbol { .init(rawValue: "lizard.fill") }
 
     /// 􁙇
     /// Single Localization, 3 Layersets
@@ -4171,7 +4171,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let locationSlashCircle = SFSymbol(rawValue: "location.slash.circle")
+    static var locationSlashCircle: SFSymbol { .init(rawValue: "location.slash.circle") }
 
     /// 􁙈
     /// Single Localization, 3 Layersets
@@ -4180,7 +4180,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationSlashCircleFill = SFSymbol(rawValue: "location.slash.circle.fill")
+    static var locationSlashCircleFill: SFSymbol { .init(rawValue: "location.slash.circle.fill") }
 
     /// 􁜗
     /// Single Localization, 3 Layersets
@@ -4189,7 +4189,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockOpenTrianglebadgeExclamationmark = SFSymbol(rawValue: "lock.open.trianglebadge.exclamationmark")
+    static var lockOpenTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "lock.open.trianglebadge.exclamationmark") }
 
     /// 􁜘
     /// Single Localization, 3 Layersets
@@ -4198,7 +4198,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockOpenTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "lock.open.trianglebadge.exclamationmark.fill")
+    static var lockOpenTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "lock.open.trianglebadge.exclamationmark.fill") }
 
     /// 􁙍
     /// Single Localization, 3 Layersets
@@ -4207,7 +4207,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockTrianglebadgeExclamationmark = SFSymbol(rawValue: "lock.trianglebadge.exclamationmark")
+    static var lockTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "lock.trianglebadge.exclamationmark") }
 
     /// 􁙎
     /// Single Localization, 3 Layersets
@@ -4216,7 +4216,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "lock.trianglebadge.exclamationmark.fill")
+    static var lockTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "lock.trianglebadge.exclamationmark.fill") }
 
     /// 􁏍
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4225,7 +4225,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Studio.
-    static let macstudio = SFSymbol(rawValue: "macstudio")
+    static var macstudio: SFSymbol { .init(rawValue: "macstudio") }
 
     /// 􁏎
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4234,42 +4234,42 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Studio.
-    static let macstudioFill = SFSymbol(rawValue: "macstudio.fill")
+    static var macstudioFill: SFSymbol { .init(rawValue: "macstudio.fill") }
 
     /// 􁑚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let manatsign = SFSymbol(rawValue: "manatsign")
+    static var manatsign: SFSymbol { .init(rawValue: "manatsign") }
 
     /// 􁏋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medal = SFSymbol(rawValue: "medal")
+    static var medal: SFSymbol { .init(rawValue: "medal") }
 
     /// 􁏌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medalFill = SFSymbol(rawValue: "medal.fill")
+    static var medalFill: SFSymbol { .init(rawValue: "medal.fill") }
 
     /// 􁒇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medicalThermometer = SFSymbol(rawValue: "medical.thermometer")
+    static var medicalThermometer: SFSymbol { .init(rawValue: "medical.thermometer") }
 
     /// 􁒈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medicalThermometerFill = SFSymbol(rawValue: "medical.thermometer.fill")
+    static var medicalThermometerFill: SFSymbol { .init(rawValue: "medical.thermometer.fill") }
 
     /// 􁋬
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -4284,7 +4284,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadge = SymbolWith1Localization<Rtl>(rawValue: "message.badge")
+    static var messageBadge: SymbolWith1Localization<Rtl> { .init(rawValue: "message.badge") }
 
     /// 􁗗
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -4298,7 +4298,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeCircle = SymbolWith1Localization<Rtl>(rawValue: "message.badge.circle")
+    static var messageBadgeCircle: SymbolWith1Localization<Rtl> { .init(rawValue: "message.badge.circle") }
 
     /// 􁗘
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -4313,7 +4313,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeCircleFill = SymbolWith1Localization<Rtl>(rawValue: "message.badge.circle.fill")
+    static var messageBadgeCircleFill: SymbolWith1Localization<Rtl> { .init(rawValue: "message.badge.circle.fill") }
 
     /// 􁏊
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -4328,7 +4328,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeFill = SymbolWith1Localization<Rtl>(rawValue: "message.badge.fill")
+    static var messageBadgeFill: SymbolWith1Localization<Rtl> { .init(rawValue: "message.badge.fill") }
 
     /// 􁋭
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -4343,7 +4343,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeFilledFill = SymbolWith1Localization<Rtl>(rawValue: "message.badge.filled.fill")
+    static var messageBadgeFilledFill: SymbolWith1Localization<Rtl> { .init(rawValue: "message.badge.filled.fill") }
 
     /// 􁎔
     /// Single Localization, 3 Layersets
@@ -4357,7 +4357,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "microphoneAndSignalMeter")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "microphoneAndSignalMeter")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneAndSignalMeter")
-    static let micAndSignalMeter = SFSymbol(rawValue: "mic.and.signal.meter")
+    static var micAndSignalMeter: SFSymbol { .init(rawValue: "mic.and.signal.meter") }
 
     /// 􁎓
     /// Single Localization, 3 Layersets
@@ -4371,7 +4371,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "microphoneAndSignalMeterFill")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "microphoneAndSignalMeterFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneAndSignalMeterFill")
-    static let micAndSignalMeterFill = SFSymbol(rawValue: "mic.and.signal.meter.fill")
+    static var micAndSignalMeterFill: SFSymbol { .init(rawValue: "mic.and.signal.meter.fill") }
 
     /// 􁙃
     /// Single Localization, 3 Layersets
@@ -4385,7 +4385,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "microphoneBadgeXmark")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "microphoneBadgeXmark")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneBadgeXmark")
-    static let micBadgeXmark = SFSymbol(rawValue: "mic.badge.xmark")
+    static var micBadgeXmark: SFSymbol { .init(rawValue: "mic.badge.xmark") }
 
     /// 􁙄
     /// Single Localization, 3 Layersets
@@ -4399,14 +4399,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "microphoneBadgeXmarkFill")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "microphoneBadgeXmarkFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "microphoneBadgeXmarkFill")
-    static let micFillBadgeXmark = SFSymbol(rawValue: "mic.fill.badge.xmark")
+    static var micFillBadgeXmark: SFSymbol { .init(rawValue: "mic.fill.badge.xmark") }
 
     /// 􁈹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let microbe = SFSymbol(rawValue: "microbe")
+    static var microbe: SFSymbol { .init(rawValue: "microbe") }
 
     /// 􁚶
     /// Single Localization, 2 Layersets
@@ -4414,7 +4414,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let microbeCircle = SFSymbol(rawValue: "microbe.circle")
+    static var microbeCircle: SFSymbol { .init(rawValue: "microbe.circle") }
 
     /// 􁚷
     /// Single Localization, 3 Layersets
@@ -4423,35 +4423,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microbeCircleFill = SFSymbol(rawValue: "microbe.circle.fill")
+    static var microbeCircleFill: SFSymbol { .init(rawValue: "microbe.circle.fill") }
 
     /// 􁒅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let microbeFill = SFSymbol(rawValue: "microbe.fill")
+    static var microbeFill: SFSymbol { .init(rawValue: "microbe.fill") }
 
     /// 􁐨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let microwave = SFSymbol(rawValue: "microwave")
+    static var microwave: SFSymbol { .init(rawValue: "microwave") }
 
     /// 􁐩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let microwaveFill = SFSymbol(rawValue: "microwave.fill")
+    static var microwaveFill: SFSymbol { .init(rawValue: "microwave.fill") }
 
     /// 􁑘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let millsign = SFSymbol(rawValue: "millsign")
+    static var millsign: SFSymbol { .init(rawValue: "millsign") }
 
     /// 􁉱
     /// Single Localization, 3 Layersets
@@ -4460,7 +4460,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mirrorSideLeft = SFSymbol(rawValue: "mirror.side.left")
+    static var mirrorSideLeft: SFSymbol { .init(rawValue: "mirror.side.left") }
 
     /// 􁉲
     /// Single Localization, 3 Layersets
@@ -4469,7 +4469,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mirrorSideRight = SFSymbol(rawValue: "mirror.side.right")
+    static var mirrorSideRight: SFSymbol { .init(rawValue: "mirror.side.right") }
 
     /// 􁑯
     /// Single Localization, 3 Layersets
@@ -4478,7 +4478,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonHaze = SFSymbol(rawValue: "moon.haze")
+    static var moonHaze: SFSymbol { .init(rawValue: "moon.haze") }
 
     /// 􁜷
     /// Single Localization, 2 Layersets
@@ -4486,7 +4486,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonHazeCircle = SFSymbol(rawValue: "moon.haze.circle")
+    static var moonHazeCircle: SFSymbol { .init(rawValue: "moon.haze.circle") }
 
     /// 􁜸
     /// Single Localization, 3 Layersets
@@ -4495,7 +4495,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonHazeCircleFill = SFSymbol(rawValue: "moon.haze.circle.fill")
+    static var moonHazeCircleFill: SFSymbol { .init(rawValue: "moon.haze.circle.fill") }
 
     /// 􁑰
     /// Single Localization, 3 Layersets
@@ -4504,7 +4504,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonHazeFill = SFSymbol(rawValue: "moon.haze.fill")
+    static var moonHazeFill: SFSymbol { .init(rawValue: "moon.haze.fill") }
 
     /// 􁛋
     /// Single Localization, 2 Layersets
@@ -4512,7 +4512,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonStarsCircle = SFSymbol(rawValue: "moon.stars.circle")
+    static var moonStarsCircle: SFSymbol { .init(rawValue: "moon.stars.circle") }
 
     /// 􁛌
     /// Single Localization, 3 Layersets
@@ -4521,7 +4521,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonStarsCircleFill = SFSymbol(rawValue: "moon.stars.circle.fill")
+    static var moonStarsCircleFill: SFSymbol { .init(rawValue: "moon.stars.circle.fill") }
 
     /// 􀡊
     /// Single Localization, 2 Layersets
@@ -4529,7 +4529,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseFirstQuarter = SFSymbol(rawValue: "moonphase.first.quarter")
+    static var moonphaseFirstQuarter: SFSymbol { .init(rawValue: "moonphase.first.quarter") }
 
     /// 􁐋
     /// Single Localization, 2 Layersets
@@ -4537,7 +4537,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseFirstQuarterInverse = SFSymbol(rawValue: "moonphase.first.quarter.inverse")
+    static var moonphaseFirstQuarterInverse: SFSymbol { .init(rawValue: "moonphase.first.quarter.inverse") }
 
     /// 􀡌
     /// Single Localization, 2 Layersets
@@ -4545,14 +4545,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseFullMoon = SFSymbol(rawValue: "moonphase.full.moon")
+    static var moonphaseFullMoon: SFSymbol { .init(rawValue: "moonphase.full.moon") }
 
     /// 􁐍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let moonphaseFullMoonInverse = SFSymbol(rawValue: "moonphase.full.moon.inverse")
+    static var moonphaseFullMoonInverse: SFSymbol { .init(rawValue: "moonphase.full.moon.inverse") }
 
     /// 􀡎
     /// Single Localization, 2 Layersets
@@ -4560,7 +4560,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseLastQuarter = SFSymbol(rawValue: "moonphase.last.quarter")
+    static var moonphaseLastQuarter: SFSymbol { .init(rawValue: "moonphase.last.quarter") }
 
     /// 􁐏
     /// Single Localization, 2 Layersets
@@ -4568,14 +4568,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseLastQuarterInverse = SFSymbol(rawValue: "moonphase.last.quarter.inverse")
+    static var moonphaseLastQuarterInverse: SFSymbol { .init(rawValue: "moonphase.last.quarter.inverse") }
 
     /// 􀡈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let moonphaseNewMoon = SFSymbol(rawValue: "moonphase.new.moon")
+    static var moonphaseNewMoon: SFSymbol { .init(rawValue: "moonphase.new.moon") }
 
     /// 􁐉
     /// Single Localization, 2 Layersets
@@ -4583,7 +4583,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseNewMoonInverse = SFSymbol(rawValue: "moonphase.new.moon.inverse")
+    static var moonphaseNewMoonInverse: SFSymbol { .init(rawValue: "moonphase.new.moon.inverse") }
 
     /// 􀡏
     /// Single Localization, 2 Layersets
@@ -4591,7 +4591,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaningCrescent = SFSymbol(rawValue: "moonphase.waning.crescent")
+    static var moonphaseWaningCrescent: SFSymbol { .init(rawValue: "moonphase.waning.crescent") }
 
     /// 􁐐
     /// Single Localization, 2 Layersets
@@ -4599,7 +4599,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaningCrescentInverse = SFSymbol(rawValue: "moonphase.waning.crescent.inverse")
+    static var moonphaseWaningCrescentInverse: SFSymbol { .init(rawValue: "moonphase.waning.crescent.inverse") }
 
     /// 􀡍
     /// Single Localization, 2 Layersets
@@ -4607,7 +4607,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaningGibbous = SFSymbol(rawValue: "moonphase.waning.gibbous")
+    static var moonphaseWaningGibbous: SFSymbol { .init(rawValue: "moonphase.waning.gibbous") }
 
     /// 􁐎
     /// Single Localization, 2 Layersets
@@ -4615,7 +4615,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaningGibbousInverse = SFSymbol(rawValue: "moonphase.waning.gibbous.inverse")
+    static var moonphaseWaningGibbousInverse: SFSymbol { .init(rawValue: "moonphase.waning.gibbous.inverse") }
 
     /// 􀡉
     /// Single Localization, 2 Layersets
@@ -4623,7 +4623,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaxingCrescent = SFSymbol(rawValue: "moonphase.waxing.crescent")
+    static var moonphaseWaxingCrescent: SFSymbol { .init(rawValue: "moonphase.waxing.crescent") }
 
     /// 􁐊
     /// Single Localization, 2 Layersets
@@ -4631,7 +4631,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaxingCrescentInverse = SFSymbol(rawValue: "moonphase.waxing.crescent.inverse")
+    static var moonphaseWaxingCrescentInverse: SFSymbol { .init(rawValue: "moonphase.waxing.crescent.inverse") }
 
     /// 􀡋
     /// Single Localization, 2 Layersets
@@ -4639,7 +4639,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaxingGibbous = SFSymbol(rawValue: "moonphase.waxing.gibbous")
+    static var moonphaseWaxingGibbous: SFSymbol { .init(rawValue: "moonphase.waxing.gibbous") }
 
     /// 􁐌
     /// Single Localization, 2 Layersets
@@ -4647,14 +4647,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonphaseWaxingGibbousInverse = SFSymbol(rawValue: "moonphase.waxing.gibbous.inverse")
+    static var moonphaseWaxingGibbousInverse: SFSymbol { .init(rawValue: "moonphase.waxing.gibbous.inverse") }
 
     /// 􁑒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let nairasign = SFSymbol(rawValue: "nairasign")
+    static var nairasign: SFSymbol { .init(rawValue: "nairasign") }
 
     /// 􁝊
     /// Single Localization, 2 Layersets
@@ -4662,7 +4662,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nosignApp = SFSymbol(rawValue: "nosign.app")
+    static var nosignApp: SFSymbol { .init(rawValue: "nosign.app") }
 
     /// 􁝋
     /// Single Localization, 3 Layersets
@@ -4671,42 +4671,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let nosignAppFill = SFSymbol(rawValue: "nosign.app.fill")
+    static var nosignAppFill: SFSymbol { .init(rawValue: "nosign.app.fill") }
 
     /// 􁓘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let numbersign = SFSymbol(rawValue: "numbersign")
+    static var numbersign: SFSymbol { .init(rawValue: "numbersign") }
 
     /// 􁔶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let oar2Crossed = SFSymbol(rawValue: "oar.2.crossed")
+    static var oar2Crossed: SFSymbol { .init(rawValue: "oar.2.crossed") }
 
     /// 􁘤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let opticaldiscFill = SFSymbol(rawValue: "opticaldisc.fill")
+    static var opticaldiscFill: SFSymbol { .init(rawValue: "opticaldisc.fill") }
 
     /// 􁐤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let oven = SFSymbol(rawValue: "oven")
+    static var oven: SFSymbol { .init(rawValue: "oven") }
 
     /// 􁐥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ovenFill = SFSymbol(rawValue: "oven.fill")
+    static var ovenFill: SFSymbol { .init(rawValue: "oven.fill") }
 
     /// 􀾼
     /// Single Localization, 3 Layersets
@@ -4715,7 +4715,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let parkinglight = SFSymbol(rawValue: "parkinglight")
+    static var parkinglight: SFSymbol { .init(rawValue: "parkinglight") }
 
     /// 􀾽
     /// Single Localization, 3 Layersets
@@ -4724,7 +4724,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let parkinglightFill = SFSymbol(rawValue: "parkinglight.fill")
+    static var parkinglightFill: SFSymbol { .init(rawValue: "parkinglight.fill") }
 
     /// 􀿀
     /// Single Localization, 3 Layersets
@@ -4733,7 +4733,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let parkingsignBrakesignal = SFSymbol(rawValue: "parkingsign.brakesignal")
+    static var parkingsignBrakesignal: SFSymbol { .init(rawValue: "parkingsign.brakesignal") }
 
     /// 􁉐
     /// Single Localization, 3 Layersets
@@ -4742,7 +4742,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let parkingsignBrakesignalSlash = SFSymbol(rawValue: "parkingsign.brakesignal.slash")
+    static var parkingsignBrakesignalSlash: SFSymbol { .init(rawValue: "parkingsign.brakesignal.slash") }
 
     /// 􁓵
     /// Single Localization, 3 Layersets
@@ -4751,7 +4751,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let partyPopper = SFSymbol(rawValue: "party.popper")
+    static var partyPopper: SFSymbol { .init(rawValue: "party.popper") }
 
     /// 􁓶
     /// Single Localization, 3 Layersets
@@ -4760,7 +4760,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let partyPopperFill = SFSymbol(rawValue: "party.popper.fill")
+    static var partyPopperFill: SFSymbol { .init(rawValue: "party.popper.fill") }
 
     /// 􁓡
     /// Single Localization, 3 Layersets
@@ -4769,7 +4769,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pedestrianGateClosed = SFSymbol(rawValue: "pedestrian.gate.closed")
+    static var pedestrianGateClosed: SFSymbol { .init(rawValue: "pedestrian.gate.closed") }
 
     /// 􁓢
     /// Single Localization, 3 Layersets
@@ -4778,21 +4778,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pedestrianGateOpen = SFSymbol(rawValue: "pedestrian.gate.open")
+    static var pedestrianGateOpen: SFSymbol { .init(rawValue: "pedestrian.gate.open") }
 
     /// 􁖆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pencilAndRuler = SFSymbol(rawValue: "pencil.and.ruler")
+    static var pencilAndRuler: SFSymbol { .init(rawValue: "pencil.and.ruler") }
 
     /// 􁖇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pencilAndRulerFill = SFSymbol(rawValue: "pencil.and.ruler.fill")
+    static var pencilAndRulerFill: SFSymbol { .init(rawValue: "pencil.and.ruler.fill") }
 
     /// 􁚛
     /// Single Localization, 2 Layersets
@@ -4800,7 +4800,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pencilLine = SFSymbol(rawValue: "pencil.line")
+    static var pencilLine: SFSymbol { .init(rawValue: "pencil.line") }
 
     /// 􁙚
     /// Single Localization, 2 Layersets
@@ -4808,7 +4808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2BadgeGearshape = SFSymbol(rawValue: "person.2.badge.gearshape")
+    static var person2BadgeGearshape: SFSymbol { .init(rawValue: "person.2.badge.gearshape") }
 
     /// 􁙛
     /// Single Localization, 2 Layersets
@@ -4816,7 +4816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2BadgeGearshapeFill = SFSymbol(rawValue: "person.2.badge.gearshape.fill")
+    static var person2BadgeGearshapeFill: SFSymbol { .init(rawValue: "person.2.badge.gearshape.fill") }
 
     /// 􁙙
     /// Single Localization, 2 Layersets
@@ -4829,7 +4829,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "person2ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "person2ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "person2ArrowTriangleheadCounterclockwise")
-    static let person2Gobackward = SFSymbol(rawValue: "person.2.gobackward")
+    static var person2Gobackward: SFSymbol { .init(rawValue: "person.2.gobackward") }
 
     /// 􁝞
     /// Single Localization, 2 Layersets
@@ -4837,7 +4837,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2Slash = SFSymbol(rawValue: "person.2.slash")
+    static var person2Slash: SFSymbol { .init(rawValue: "person.2.slash") }
 
     /// 􁝟
     /// Single Localization, 2 Layersets
@@ -4845,7 +4845,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2SlashFill = SFSymbol(rawValue: "person.2.slash.fill")
+    static var person2SlashFill: SFSymbol { .init(rawValue: "person.2.slash.fill") }
 
     /// 􁙁
     /// Single Localization, 2 Layersets
@@ -4853,7 +4853,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personAndBackgroundDotted = SFSymbol(rawValue: "person.and.background.dotted")
+    static var personAndBackgroundDotted: SFSymbol { .init(rawValue: "person.and.background.dotted") }
 
     /// 􁙓
     /// Single Localization, 3 Layersets
@@ -4862,7 +4862,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personBadgeShieldCheckmark = SFSymbol(rawValue: "person.badge.shield.checkmark")
+    static var personBadgeShieldCheckmark: SFSymbol { .init(rawValue: "person.badge.shield.checkmark") }
 
     /// 􁙔
     /// Single Localization, 3 Layersets
@@ -4871,21 +4871,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personBadgeShieldCheckmarkFill = SFSymbol(rawValue: "person.badge.shield.checkmark.fill")
+    static var personBadgeShieldCheckmarkFill: SFSymbol { .init(rawValue: "person.badge.shield.checkmark.fill") }
 
     /// 􁗡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personBust = SFSymbol(rawValue: "person.bust")
+    static var personBust: SFSymbol { .init(rawValue: "person.bust") }
 
     /// 􁗢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personBustFill = SFSymbol(rawValue: "person.bust.fill")
+    static var personBustFill: SFSymbol { .init(rawValue: "person.bust.fill") }
 
     /// 􁖚
     /// Single Localization, 3 Layersets
@@ -4894,7 +4894,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropRectangleBadgePlus = SFSymbol(rawValue: "person.crop.rectangle.badge.plus")
+    static var personCropRectangleBadgePlus: SFSymbol { .init(rawValue: "person.crop.rectangle.badge.plus") }
 
     /// 􁖛
     /// Single Localization, 3 Layersets
@@ -4903,7 +4903,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropRectangleBadgePlusFill = SFSymbol(rawValue: "person.crop.rectangle.badge.plus.fill")
+    static var personCropRectangleBadgePlusFill: SFSymbol { .init(rawValue: "person.crop.rectangle.badge.plus.fill") }
 
     /// 􁒃
     /// Single Localization, 2 Layersets
@@ -4911,7 +4911,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personLineDottedPerson = SFSymbol(rawValue: "person.line.dotted.person")
+    static var personLineDottedPerson: SFSymbol { .init(rawValue: "person.line.dotted.person") }
 
     /// 􁒄
     /// Single Localization, 2 Layersets
@@ -4919,21 +4919,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personLineDottedPersonFill = SFSymbol(rawValue: "person.line.dotted.person.fill")
+    static var personLineDottedPersonFill: SFSymbol { .init(rawValue: "person.line.dotted.person.fill") }
 
     /// 􁑋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pesetasign = SFSymbol(rawValue: "pesetasign")
+    static var pesetasign: SFSymbol { .init(rawValue: "pesetasign") }
 
     /// 􁑌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pesosign = SFSymbol(rawValue: "pesosign")
+    static var pesosign: SFSymbol { .init(rawValue: "pesosign") }
 
     /// 􀍃
     /// Single Localization, 2 Layersets
@@ -4941,7 +4941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneArrowDownLeftFill = SFSymbol(rawValue: "phone.arrow.down.left.fill")
+    static var phoneArrowDownLeftFill: SFSymbol { .init(rawValue: "phone.arrow.down.left.fill") }
 
     /// 􀍅
     /// Single Localization, 2 Layersets
@@ -4949,7 +4949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneArrowRightFill = SFSymbol(rawValue: "phone.arrow.right.fill")
+    static var phoneArrowRightFill: SFSymbol { .init(rawValue: "phone.arrow.right.fill") }
 
     /// 􁏽
     /// Single Localization, 2 Layersets
@@ -4957,7 +4957,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneArrowUpRightCircle = SFSymbol(rawValue: "phone.arrow.up.right.circle")
+    static var phoneArrowUpRightCircle: SFSymbol { .init(rawValue: "phone.arrow.up.right.circle") }
 
     /// 􁏾
     /// Single Localization, 3 Layersets
@@ -4966,7 +4966,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneArrowUpRightCircleFill = SFSymbol(rawValue: "phone.arrow.up.right.circle.fill")
+    static var phoneArrowUpRightCircleFill: SFSymbol { .init(rawValue: "phone.arrow.up.right.circle.fill") }
 
     /// 􀍁
     /// Single Localization, 2 Layersets
@@ -4974,7 +4974,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneArrowUpRightFill = SFSymbol(rawValue: "phone.arrow.up.right.fill")
+    static var phoneArrowUpRightFill: SFSymbol { .init(rawValue: "phone.arrow.up.right.fill") }
 
     /// 􁙗
     /// Single Localization, 3 Layersets
@@ -4983,7 +4983,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBadgeCheckmark = SFSymbol(rawValue: "phone.badge.checkmark")
+    static var phoneBadgeCheckmark: SFSymbol { .init(rawValue: "phone.badge.checkmark") }
 
     /// 􀬜
     /// Single Localization, 2 Layersets
@@ -4991,7 +4991,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneConnectionFill = SFSymbol(rawValue: "phone.connection.fill")
+    static var phoneConnectionFill: SFSymbol { .init(rawValue: "phone.connection.fill") }
 
     /// 􁂅
     /// Single Localization, 3 Layersets
@@ -5000,7 +5000,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneDownWavesLeftAndRight = SFSymbol(rawValue: "phone.down.waves.left.and.right")
+    static var phoneDownWavesLeftAndRight: SFSymbol { .init(rawValue: "phone.down.waves.left.and.right") }
 
     /// 􁙘
     /// Single Localization, 3 Layersets
@@ -5009,21 +5009,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneFillBadgeCheckmark = SFSymbol(rawValue: "phone.fill.badge.checkmark")
+    static var phoneFillBadgeCheckmark: SFSymbol { .init(rawValue: "phone.fill.badge.checkmark") }
 
     /// 􀏯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let photoStack = SFSymbol(rawValue: "photo.stack")
+    static var photoStack: SFSymbol { .init(rawValue: "photo.stack") }
 
     /// 􀏰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let photoStackFill = SFSymbol(rawValue: "photo.stack.fill")
+    static var photoStackFill: SFSymbol { .init(rawValue: "photo.stack.fill") }
 
     /// 􁚭
     /// Single Localization, 2 Layersets
@@ -5031,7 +5031,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let pill = SFSymbol(rawValue: "pill")
+    static var pill: SFSymbol { .init(rawValue: "pill") }
 
     /// 􁚯
     /// Single Localization, 3 Layersets
@@ -5040,7 +5040,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pillCircle = SFSymbol(rawValue: "pill.circle")
+    static var pillCircle: SFSymbol { .init(rawValue: "pill.circle") }
 
     /// 􁚰
     /// Single Localization, 3 Layersets
@@ -5049,7 +5049,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pillCircleFill = SFSymbol(rawValue: "pill.circle.fill")
+    static var pillCircleFill: SFSymbol { .init(rawValue: "pill.circle.fill") }
 
     /// 􁚮
     /// Single Localization, 2 Layersets
@@ -5057,7 +5057,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let pillFill = SFSymbol(rawValue: "pill.fill")
+    static var pillFill: SFSymbol { .init(rawValue: "pill.fill") }
 
     /// 􁓝
     /// Single Localization, 2 Layersets
@@ -5065,7 +5065,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pipeAndDrop = SFSymbol(rawValue: "pipe.and.drop")
+    static var pipeAndDrop: SFSymbol { .init(rawValue: "pipe.and.drop") }
 
     /// 􁓞
     /// Single Localization, 2 Layersets
@@ -5073,7 +5073,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pipeAndDropFill = SFSymbol(rawValue: "pipe.and.drop.fill")
+    static var pipeAndDropFill: SFSymbol { .init(rawValue: "pipe.and.drop.fill") }
 
     /// 􁏳
     /// Single Localization, 2 Layersets
@@ -5081,7 +5081,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playDesktopcomputer = SFSymbol(rawValue: "play.desktopcomputer")
+    static var playDesktopcomputer: SFSymbol { .init(rawValue: "play.desktopcomputer") }
 
     /// 􁏴
     /// Single Localization, 2 Layersets
@@ -5089,7 +5089,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playDisplay = SFSymbol(rawValue: "play.display")
+    static var playDisplay: SFSymbol { .init(rawValue: "play.display") }
 
     /// 􁏵
     /// Single Localization, 2 Layersets
@@ -5097,7 +5097,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playLaptopcomputer = SFSymbol(rawValue: "play.laptopcomputer")
+    static var playLaptopcomputer: SFSymbol { .init(rawValue: "play.laptopcomputer") }
 
     /// 􁚞
     /// Single Localization, 2 Layersets
@@ -5105,7 +5105,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playpauseCircle = SFSymbol(rawValue: "playpause.circle")
+    static var playpauseCircle: SFSymbol { .init(rawValue: "playpause.circle") }
 
     /// 􁚟
     /// Single Localization, 3 Layersets
@@ -5114,7 +5114,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let playpauseCircleFill = SFSymbol(rawValue: "playpause.circle.fill")
+    static var playpauseCircleFill: SFSymbol { .init(rawValue: "playpause.circle.fill") }
 
     /// 􀾈
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -5123,14 +5123,14 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Sony’s PlayStation.
-    static let playstationLogo = SFSymbol(rawValue: "playstation.logo")
+    static var playstationLogo: SFSymbol { .init(rawValue: "playstation.logo") }
 
     /// 􁐇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let popcorn = SFSymbol(rawValue: "popcorn")
+    static var popcorn: SFSymbol { .init(rawValue: "popcorn") }
 
     /// 􁚱
     /// Single Localization, 2 Layersets
@@ -5138,7 +5138,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let popcornCircle = SFSymbol(rawValue: "popcorn.circle")
+    static var popcornCircle: SFSymbol { .init(rawValue: "popcorn.circle") }
 
     /// 􁚲
     /// Single Localization, 3 Layersets
@@ -5147,14 +5147,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let popcornCircleFill = SFSymbol(rawValue: "popcorn.circle.fill")
+    static var popcornCircleFill: SFSymbol { .init(rawValue: "popcorn.circle.fill") }
 
     /// 􁐈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let popcornFill = SFSymbol(rawValue: "popcorn.fill")
+    static var popcornFill: SFSymbol { .init(rawValue: "popcorn.fill") }
 
     /// 􁌲
     /// Single Localization, 2 Layersets
@@ -5162,7 +5162,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletStrip = SFSymbol(rawValue: "poweroutlet.strip")
+    static var poweroutletStrip: SFSymbol { .init(rawValue: "poweroutlet.strip") }
 
     /// 􁓜
     /// Single Localization, 3 Layersets
@@ -5171,7 +5171,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletStripFill = SFSymbol(rawValue: "poweroutlet.strip.fill")
+    static var poweroutletStripFill: SFSymbol { .init(rawValue: "poweroutlet.strip.fill") }
 
     /// 􁌽
     /// Single Localization, 2 Layersets
@@ -5179,7 +5179,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeA = SFSymbol(rawValue: "poweroutlet.type.a")
+    static var poweroutletTypeA: SFSymbol { .init(rawValue: "poweroutlet.type.a") }
 
     /// 􁍀
     /// Single Localization, 3 Layersets
@@ -5188,7 +5188,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeAFill = SFSymbol(rawValue: "poweroutlet.type.a.fill")
+    static var poweroutletTypeAFill: SFSymbol { .init(rawValue: "poweroutlet.type.a.fill") }
 
     /// 􀽤
     /// Single Localization, 2 Layersets
@@ -5196,7 +5196,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeASquare = SFSymbol(rawValue: "poweroutlet.type.a.square")
+    static var poweroutletTypeASquare: SFSymbol { .init(rawValue: "poweroutlet.type.a.square") }
 
     /// 􁌩
     /// Single Localization, 3 Layersets
@@ -5205,7 +5205,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeASquareFill = SFSymbol(rawValue: "poweroutlet.type.a.square.fill")
+    static var poweroutletTypeASquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.a.square.fill") }
 
     /// 􁌾
     /// Single Localization, 2 Layersets
@@ -5213,7 +5213,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeB = SFSymbol(rawValue: "poweroutlet.type.b")
+    static var poweroutletTypeB: SFSymbol { .init(rawValue: "poweroutlet.type.b") }
 
     /// 􁍁
     /// Single Localization, 3 Layersets
@@ -5222,7 +5222,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeBFill = SFSymbol(rawValue: "poweroutlet.type.b.fill")
+    static var poweroutletTypeBFill: SFSymbol { .init(rawValue: "poweroutlet.type.b.fill") }
 
     /// 􀽥
     /// Single Localization, 2 Layersets
@@ -5230,7 +5230,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeBSquare = SFSymbol(rawValue: "poweroutlet.type.b.square")
+    static var poweroutletTypeBSquare: SFSymbol { .init(rawValue: "poweroutlet.type.b.square") }
 
     /// 􁌼
     /// Single Localization, 3 Layersets
@@ -5239,7 +5239,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeBSquareFill = SFSymbol(rawValue: "poweroutlet.type.b.square.fill")
+    static var poweroutletTypeBSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.b.square.fill") }
 
     /// 􁍆
     /// Single Localization, 2 Layersets
@@ -5247,7 +5247,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeC = SFSymbol(rawValue: "poweroutlet.type.c")
+    static var poweroutletTypeC: SFSymbol { .init(rawValue: "poweroutlet.type.c") }
 
     /// 􁍇
     /// Single Localization, 3 Layersets
@@ -5256,7 +5256,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeCFill = SFSymbol(rawValue: "poweroutlet.type.c.fill")
+    static var poweroutletTypeCFill: SFSymbol { .init(rawValue: "poweroutlet.type.c.fill") }
 
     /// 􀽦
     /// Single Localization, 2 Layersets
@@ -5264,7 +5264,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeCSquare = SFSymbol(rawValue: "poweroutlet.type.c.square")
+    static var poweroutletTypeCSquare: SFSymbol { .init(rawValue: "poweroutlet.type.c.square") }
 
     /// 􁌫
     /// Single Localization, 3 Layersets
@@ -5273,7 +5273,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeCSquareFill = SFSymbol(rawValue: "poweroutlet.type.c.square.fill")
+    static var poweroutletTypeCSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.c.square.fill") }
 
     /// 􁍈
     /// Single Localization, 2 Layersets
@@ -5281,7 +5281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeD = SFSymbol(rawValue: "poweroutlet.type.d")
+    static var poweroutletTypeD: SFSymbol { .init(rawValue: "poweroutlet.type.d") }
 
     /// 􁍉
     /// Single Localization, 3 Layersets
@@ -5290,7 +5290,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeDFill = SFSymbol(rawValue: "poweroutlet.type.d.fill")
+    static var poweroutletTypeDFill: SFSymbol { .init(rawValue: "poweroutlet.type.d.fill") }
 
     /// 􀽧
     /// Single Localization, 2 Layersets
@@ -5298,7 +5298,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeDSquare = SFSymbol(rawValue: "poweroutlet.type.d.square")
+    static var poweroutletTypeDSquare: SFSymbol { .init(rawValue: "poweroutlet.type.d.square") }
 
     /// 􁍊
     /// Single Localization, 3 Layersets
@@ -5307,7 +5307,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeDSquareFill = SFSymbol(rawValue: "poweroutlet.type.d.square.fill")
+    static var poweroutletTypeDSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.d.square.fill") }
 
     /// 􁍋
     /// Single Localization, 2 Layersets
@@ -5315,7 +5315,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeE = SFSymbol(rawValue: "poweroutlet.type.e")
+    static var poweroutletTypeE: SFSymbol { .init(rawValue: "poweroutlet.type.e") }
 
     /// 􁍌
     /// Single Localization, 3 Layersets
@@ -5324,7 +5324,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeEFill = SFSymbol(rawValue: "poweroutlet.type.e.fill")
+    static var poweroutletTypeEFill: SFSymbol { .init(rawValue: "poweroutlet.type.e.fill") }
 
     /// 􀽨
     /// Single Localization, 2 Layersets
@@ -5332,7 +5332,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeESquare = SFSymbol(rawValue: "poweroutlet.type.e.square")
+    static var poweroutletTypeESquare: SFSymbol { .init(rawValue: "poweroutlet.type.e.square") }
 
     /// 􁍍
     /// Single Localization, 3 Layersets
@@ -5341,7 +5341,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeESquareFill = SFSymbol(rawValue: "poweroutlet.type.e.square.fill")
+    static var poweroutletTypeESquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.e.square.fill") }
 
     /// 􁍎
     /// Single Localization, 2 Layersets
@@ -5349,7 +5349,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeF = SFSymbol(rawValue: "poweroutlet.type.f")
+    static var poweroutletTypeF: SFSymbol { .init(rawValue: "poweroutlet.type.f") }
 
     /// 􁍏
     /// Single Localization, 3 Layersets
@@ -5358,7 +5358,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeFFill = SFSymbol(rawValue: "poweroutlet.type.f.fill")
+    static var poweroutletTypeFFill: SFSymbol { .init(rawValue: "poweroutlet.type.f.fill") }
 
     /// 􀽩
     /// Single Localization, 2 Layersets
@@ -5366,7 +5366,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeFSquare = SFSymbol(rawValue: "poweroutlet.type.f.square")
+    static var poweroutletTypeFSquare: SFSymbol { .init(rawValue: "poweroutlet.type.f.square") }
 
     /// 􁍐
     /// Single Localization, 3 Layersets
@@ -5375,7 +5375,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeFSquareFill = SFSymbol(rawValue: "poweroutlet.type.f.square.fill")
+    static var poweroutletTypeFSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.f.square.fill") }
 
     /// 􁍑
     /// Single Localization, 2 Layersets
@@ -5383,7 +5383,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeG = SFSymbol(rawValue: "poweroutlet.type.g")
+    static var poweroutletTypeG: SFSymbol { .init(rawValue: "poweroutlet.type.g") }
 
     /// 􁍒
     /// Single Localization, 3 Layersets
@@ -5392,7 +5392,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeGFill = SFSymbol(rawValue: "poweroutlet.type.g.fill")
+    static var poweroutletTypeGFill: SFSymbol { .init(rawValue: "poweroutlet.type.g.fill") }
 
     /// 􀽪
     /// Single Localization, 2 Layersets
@@ -5400,7 +5400,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeGSquare = SFSymbol(rawValue: "poweroutlet.type.g.square")
+    static var poweroutletTypeGSquare: SFSymbol { .init(rawValue: "poweroutlet.type.g.square") }
 
     /// 􁌯
     /// Single Localization, 3 Layersets
@@ -5409,7 +5409,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeGSquareFill = SFSymbol(rawValue: "poweroutlet.type.g.square.fill")
+    static var poweroutletTypeGSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.g.square.fill") }
 
     /// 􁍓
     /// Single Localization, 2 Layersets
@@ -5417,7 +5417,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeH = SFSymbol(rawValue: "poweroutlet.type.h")
+    static var poweroutletTypeH: SFSymbol { .init(rawValue: "poweroutlet.type.h") }
 
     /// 􁍔
     /// Single Localization, 3 Layersets
@@ -5426,7 +5426,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeHFill = SFSymbol(rawValue: "poweroutlet.type.h.fill")
+    static var poweroutletTypeHFill: SFSymbol { .init(rawValue: "poweroutlet.type.h.fill") }
 
     /// 􀽫
     /// Single Localization, 2 Layersets
@@ -5434,7 +5434,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeHSquare = SFSymbol(rawValue: "poweroutlet.type.h.square")
+    static var poweroutletTypeHSquare: SFSymbol { .init(rawValue: "poweroutlet.type.h.square") }
 
     /// 􁍕
     /// Single Localization, 3 Layersets
@@ -5443,7 +5443,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeHSquareFill = SFSymbol(rawValue: "poweroutlet.type.h.square.fill")
+    static var poweroutletTypeHSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.h.square.fill") }
 
     /// 􁍖
     /// Single Localization, 2 Layersets
@@ -5451,7 +5451,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeI = SFSymbol(rawValue: "poweroutlet.type.i")
+    static var poweroutletTypeI: SFSymbol { .init(rawValue: "poweroutlet.type.i") }
 
     /// 􁍗
     /// Single Localization, 3 Layersets
@@ -5460,7 +5460,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeIFill = SFSymbol(rawValue: "poweroutlet.type.i.fill")
+    static var poweroutletTypeIFill: SFSymbol { .init(rawValue: "poweroutlet.type.i.fill") }
 
     /// 􀽬
     /// Single Localization, 2 Layersets
@@ -5468,7 +5468,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeISquare = SFSymbol(rawValue: "poweroutlet.type.i.square")
+    static var poweroutletTypeISquare: SFSymbol { .init(rawValue: "poweroutlet.type.i.square") }
 
     /// 􁍘
     /// Single Localization, 3 Layersets
@@ -5477,7 +5477,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeISquareFill = SFSymbol(rawValue: "poweroutlet.type.i.square.fill")
+    static var poweroutletTypeISquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.i.square.fill") }
 
     /// 􁍙
     /// Single Localization, 2 Layersets
@@ -5485,7 +5485,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeJ = SFSymbol(rawValue: "poweroutlet.type.j")
+    static var poweroutletTypeJ: SFSymbol { .init(rawValue: "poweroutlet.type.j") }
 
     /// 􁍚
     /// Single Localization, 3 Layersets
@@ -5494,7 +5494,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeJFill = SFSymbol(rawValue: "poweroutlet.type.j.fill")
+    static var poweroutletTypeJFill: SFSymbol { .init(rawValue: "poweroutlet.type.j.fill") }
 
     /// 􀽭
     /// Single Localization, 2 Layersets
@@ -5502,7 +5502,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeJSquare = SFSymbol(rawValue: "poweroutlet.type.j.square")
+    static var poweroutletTypeJSquare: SFSymbol { .init(rawValue: "poweroutlet.type.j.square") }
 
     /// 􁌱
     /// Single Localization, 3 Layersets
@@ -5511,7 +5511,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeJSquareFill = SFSymbol(rawValue: "poweroutlet.type.j.square.fill")
+    static var poweroutletTypeJSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.j.square.fill") }
 
     /// 􁍛
     /// Single Localization, 2 Layersets
@@ -5519,7 +5519,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeK = SFSymbol(rawValue: "poweroutlet.type.k")
+    static var poweroutletTypeK: SFSymbol { .init(rawValue: "poweroutlet.type.k") }
 
     /// 􁍜
     /// Single Localization, 3 Layersets
@@ -5528,7 +5528,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeKFill = SFSymbol(rawValue: "poweroutlet.type.k.fill")
+    static var poweroutletTypeKFill: SFSymbol { .init(rawValue: "poweroutlet.type.k.fill") }
 
     /// 􀽮
     /// Single Localization, 2 Layersets
@@ -5536,7 +5536,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeKSquare = SFSymbol(rawValue: "poweroutlet.type.k.square")
+    static var poweroutletTypeKSquare: SFSymbol { .init(rawValue: "poweroutlet.type.k.square") }
 
     /// 􁌮
     /// Single Localization, 3 Layersets
@@ -5545,7 +5545,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeKSquareFill = SFSymbol(rawValue: "poweroutlet.type.k.square.fill")
+    static var poweroutletTypeKSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.k.square.fill") }
 
     /// 􁍝
     /// Single Localization, 2 Layersets
@@ -5553,7 +5553,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeL = SFSymbol(rawValue: "poweroutlet.type.l")
+    static var poweroutletTypeL: SFSymbol { .init(rawValue: "poweroutlet.type.l") }
 
     /// 􁍞
     /// Single Localization, 3 Layersets
@@ -5562,7 +5562,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeLFill = SFSymbol(rawValue: "poweroutlet.type.l.fill")
+    static var poweroutletTypeLFill: SFSymbol { .init(rawValue: "poweroutlet.type.l.fill") }
 
     /// 􀽯
     /// Single Localization, 2 Layersets
@@ -5570,7 +5570,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeLSquare = SFSymbol(rawValue: "poweroutlet.type.l.square")
+    static var poweroutletTypeLSquare: SFSymbol { .init(rawValue: "poweroutlet.type.l.square") }
 
     /// 􁍟
     /// Single Localization, 3 Layersets
@@ -5579,7 +5579,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeLSquareFill = SFSymbol(rawValue: "poweroutlet.type.l.square.fill")
+    static var poweroutletTypeLSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.l.square.fill") }
 
     /// 􁌪
     /// Single Localization, 2 Layersets
@@ -5587,7 +5587,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeM = SFSymbol(rawValue: "poweroutlet.type.m")
+    static var poweroutletTypeM: SFSymbol { .init(rawValue: "poweroutlet.type.m") }
 
     /// 􁌬
     /// Single Localization, 3 Layersets
@@ -5596,7 +5596,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeMFill = SFSymbol(rawValue: "poweroutlet.type.m.fill")
+    static var poweroutletTypeMFill: SFSymbol { .init(rawValue: "poweroutlet.type.m.fill") }
 
     /// 􁁻
     /// Single Localization, 2 Layersets
@@ -5604,7 +5604,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeMSquare = SFSymbol(rawValue: "poweroutlet.type.m.square")
+    static var poweroutletTypeMSquare: SFSymbol { .init(rawValue: "poweroutlet.type.m.square") }
 
     /// 􁌳
     /// Single Localization, 3 Layersets
@@ -5613,7 +5613,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeMSquareFill = SFSymbol(rawValue: "poweroutlet.type.m.square.fill")
+    static var poweroutletTypeMSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.m.square.fill") }
 
     /// 􁌭
     /// Single Localization, 2 Layersets
@@ -5621,7 +5621,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeN = SFSymbol(rawValue: "poweroutlet.type.n")
+    static var poweroutletTypeN: SFSymbol { .init(rawValue: "poweroutlet.type.n") }
 
     /// 􁌰
     /// Single Localization, 3 Layersets
@@ -5630,7 +5630,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeNFill = SFSymbol(rawValue: "poweroutlet.type.n.fill")
+    static var poweroutletTypeNFill: SFSymbol { .init(rawValue: "poweroutlet.type.n.fill") }
 
     /// 􁁼
     /// Single Localization, 2 Layersets
@@ -5638,7 +5638,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeNSquare = SFSymbol(rawValue: "poweroutlet.type.n.square")
+    static var poweroutletTypeNSquare: SFSymbol { .init(rawValue: "poweroutlet.type.n.square") }
 
     /// 􁍠
     /// Single Localization, 3 Layersets
@@ -5647,7 +5647,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeNSquareFill = SFSymbol(rawValue: "poweroutlet.type.n.square.fill")
+    static var poweroutletTypeNSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.n.square.fill") }
 
     /// 􁍡
     /// Single Localization, 2 Layersets
@@ -5655,7 +5655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeO = SFSymbol(rawValue: "poweroutlet.type.o")
+    static var poweroutletTypeO: SFSymbol { .init(rawValue: "poweroutlet.type.o") }
 
     /// 􁍢
     /// Single Localization, 3 Layersets
@@ -5664,7 +5664,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeOFill = SFSymbol(rawValue: "poweroutlet.type.o.fill")
+    static var poweroutletTypeOFill: SFSymbol { .init(rawValue: "poweroutlet.type.o.fill") }
 
     /// 􁁽
     /// Single Localization, 2 Layersets
@@ -5672,7 +5672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let poweroutletTypeOSquare = SFSymbol(rawValue: "poweroutlet.type.o.square")
+    static var poweroutletTypeOSquare: SFSymbol { .init(rawValue: "poweroutlet.type.o.square") }
 
     /// 􁍣
     /// Single Localization, 3 Layersets
@@ -5681,7 +5681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let poweroutletTypeOSquareFill = SFSymbol(rawValue: "poweroutlet.type.o.square.fill")
+    static var poweroutletTypeOSquareFill: SFSymbol { .init(rawValue: "poweroutlet.type.o.square.fill") }
 
     /// 􁌶
     /// 2 Localizations, 2 Layersets
@@ -5693,7 +5693,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let questionmarkBubble = SymbolWith1Localization<Ar>(rawValue: "questionmark.bubble")
+    static var questionmarkBubble: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.bubble") }
 
     /// 􁌷
     /// 2 Localizations, 3 Layersets
@@ -5706,7 +5706,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let questionmarkBubbleFill = SymbolWith1Localization<Ar>(rawValue: "questionmark.bubble.fill")
+    static var questionmarkBubbleFill: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.bubble.fill") }
 
     /// 􁖖
     /// Single Localization, 3 Layersets
@@ -5715,7 +5715,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let quotelevel = SFSymbol(rawValue: "quotelevel")
+    static var quotelevel: SFSymbol { .init(rawValue: "quotelevel") }
 
     /// 􁋪
     /// Single Localization, 2 Layersets
@@ -5723,7 +5723,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let recordingtapeCircle = SFSymbol(rawValue: "recordingtape.circle")
+    static var recordingtapeCircle: SFSymbol { .init(rawValue: "recordingtape.circle") }
 
     /// 􁋫
     /// Single Localization, 3 Layersets
@@ -5732,7 +5732,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let recordingtapeCircleFill = SFSymbol(rawValue: "recordingtape.circle.fill")
+    static var recordingtapeCircleFill: SFSymbol { .init(rawValue: "recordingtape.circle.fill") }
 
     /// 􁚠
     /// Single Localization, 2 Layersets
@@ -5740,7 +5740,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitAndArrowForward = SFSymbol(rawValue: "rectangle.portrait.and.arrow.forward")
+    static var rectanglePortraitAndArrowForward: SFSymbol { .init(rawValue: "rectangle.portrait.and.arrow.forward") }
 
     /// 􁚡
     /// Single Localization, 2 Layersets
@@ -5748,7 +5748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let rectanglePortraitAndArrowForwardFill = SFSymbol(rawValue: "rectangle.portrait.and.arrow.forward.fill")
+    static var rectanglePortraitAndArrowForwardFill: SFSymbol { .init(rawValue: "rectangle.portrait.and.arrow.forward.fill") }
 
     /// 􁉕
     /// Single Localization, 3 Layersets
@@ -5757,7 +5757,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectanglePortraitOnRectanglePortraitAngled = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait.angled")
+    static var rectanglePortraitOnRectanglePortraitAngled: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait.angled") }
 
     /// 􁉖
     /// Single Localization, 2 Layersets
@@ -5765,42 +5765,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitOnRectanglePortraitAngledFill = SFSymbol(rawValue: "rectangle.portrait.on.rectangle.portrait.angled.fill")
+    static var rectanglePortraitOnRectanglePortraitAngledFill: SFSymbol { .init(rawValue: "rectangle.portrait.on.rectangle.portrait.angled.fill") }
 
     /// 􁐞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let refrigerator = SFSymbol(rawValue: "refrigerator")
+    static var refrigerator: SFSymbol { .init(rawValue: "refrigerator") }
 
     /// 􁐟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let refrigeratorFill = SFSymbol(rawValue: "refrigerator.fill")
+    static var refrigeratorFill: SFSymbol { .init(rawValue: "refrigerator.fill") }
 
     /// 􁕷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let roadLanes = SFSymbol(rawValue: "road.lanes")
+    static var roadLanes: SFSymbol { .init(rawValue: "road.lanes") }
 
     /// 􁕺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let roadLanesCurvedLeft = SFSymbol(rawValue: "road.lanes.curved.left")
+    static var roadLanesCurvedLeft: SFSymbol { .init(rawValue: "road.lanes.curved.left") }
 
     /// 􁕻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let roadLanesCurvedRight = SFSymbol(rawValue: "road.lanes.curved.right")
+    static var roadLanesCurvedRight: SFSymbol { .init(rawValue: "road.lanes.curved.right") }
 
     /// 􁑺
     /// Single Localization, 2 Layersets
@@ -5808,7 +5808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rollerShadeClosed = SFSymbol(rawValue: "roller.shade.closed")
+    static var rollerShadeClosed: SFSymbol { .init(rawValue: "roller.shade.closed") }
 
     /// 􁑹
     /// Single Localization, 2 Layersets
@@ -5816,7 +5816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rollerShadeOpen = SFSymbol(rawValue: "roller.shade.open")
+    static var rollerShadeOpen: SFSymbol { .init(rawValue: "roller.shade.open") }
 
     /// 􁑼
     /// Single Localization, 2 Layersets
@@ -5824,7 +5824,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let romanShadeClosed = SFSymbol(rawValue: "roman.shade.closed")
+    static var romanShadeClosed: SFSymbol { .init(rawValue: "roman.shade.closed") }
 
     /// 􁑻
     /// Single Localization, 2 Layersets
@@ -5832,35 +5832,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let romanShadeOpen = SFSymbol(rawValue: "roman.shade.open")
+    static var romanShadeOpen: SFSymbol { .init(rawValue: "roman.shade.open") }
 
     /// 􁑆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rublesign = SFSymbol(rawValue: "rublesign")
+    static var rublesign: SFSymbol { .init(rawValue: "rublesign") }
 
     /// 􁑛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rupeesign = SFSymbol(rawValue: "rupeesign")
+    static var rupeesign: SFSymbol { .init(rawValue: "rupeesign") }
 
     /// 􁋴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sailboat = SFSymbol(rawValue: "sailboat")
+    static var sailboat: SFSymbol { .init(rawValue: "sailboat") }
 
     /// 􁋵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sailboatFill = SFSymbol(rawValue: "sailboat.fill")
+    static var sailboatFill: SFSymbol { .init(rawValue: "sailboat.fill") }
 
     /// 􁔉
     /// Single Localization, 3 Layersets
@@ -5869,7 +5869,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sensor = SFSymbol(rawValue: "sensor")
+    static var sensor: SFSymbol { .init(rawValue: "sensor") }
 
     /// 􁔊
     /// Single Localization, 3 Layersets
@@ -5878,7 +5878,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sensorFill = SFSymbol(rawValue: "sensor.fill")
+    static var sensorFill: SFSymbol { .init(rawValue: "sensor.fill") }
 
     /// 􁅁
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5893,7 +5893,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "sharedwithyou")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "sharedwithyou")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sharedwithyou")
-    static let sharedWithYou = SFSymbol(rawValue: "shared.with.you")
+    static var sharedWithYou: SFSymbol { .init(rawValue: "shared.with.you") }
 
     /// 􁇦
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5908,7 +5908,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "sharedwithyouSlash")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "sharedwithyouSlash")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sharedwithyouSlash")
-    static let sharedWithYouSlash = SFSymbol(rawValue: "shared.with.you.slash")
+    static var sharedWithYouSlash: SFSymbol { .init(rawValue: "shared.with.you.slash") }
 
     /// 􁈴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5918,7 +5918,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shazam.
-    static let shazamLogo = SFSymbol(rawValue: "shazam.logo")
+    static var shazamLogo: SFSymbol { .init(rawValue: "shazam.logo") }
 
     /// 􁈵
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5929,14 +5929,14 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shazam.
-    static let shazamLogoFill = SFSymbol(rawValue: "shazam.logo.fill")
+    static var shazamLogoFill: SFSymbol { .init(rawValue: "shazam.logo.fill") }
 
     /// 􁑙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shekelsign = SFSymbol(rawValue: "shekelsign")
+    static var shekelsign: SFSymbol { .init(rawValue: "shekelsign") }
 
     /// 􀟄
     /// Single Localization, 2 Layersets
@@ -5944,7 +5944,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shippingboxAndArrowBackward = SFSymbol(rawValue: "shippingbox.and.arrow.backward")
+    static var shippingboxAndArrowBackward: SFSymbol { .init(rawValue: "shippingbox.and.arrow.backward") }
 
     /// 􀟅
     /// Single Localization, 2 Layersets
@@ -5952,14 +5952,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shippingboxAndArrowBackwardFill = SFSymbol(rawValue: "shippingbox.and.arrow.backward.fill")
+    static var shippingboxAndArrowBackwardFill: SFSymbol { .init(rawValue: "shippingbox.and.arrow.backward.fill") }
 
     /// 􁔈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shoeprintsFill = SFSymbol(rawValue: "shoeprints.fill")
+    static var shoeprintsFill: SFSymbol { .init(rawValue: "shoeprints.fill") }
 
     /// 􁓂
     /// Single Localization, 3 Layersets
@@ -5968,7 +5968,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shower = SFSymbol(rawValue: "shower")
+    static var shower: SFSymbol { .init(rawValue: "shower") }
 
     /// 􁓃
     /// Single Localization, 3 Layersets
@@ -5977,7 +5977,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let showerFill = SFSymbol(rawValue: "shower.fill")
+    static var showerFill: SFSymbol { .init(rawValue: "shower.fill") }
 
     /// 􁓍
     /// Single Localization, 3 Layersets
@@ -5986,7 +5986,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let showerHandheld = SFSymbol(rawValue: "shower.handheld")
+    static var showerHandheld: SFSymbol { .init(rawValue: "shower.handheld") }
 
     /// 􁓎
     /// Single Localization, 3 Layersets
@@ -5995,7 +5995,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let showerHandheldFill = SFSymbol(rawValue: "shower.handheld.fill")
+    static var showerHandheldFill: SFSymbol { .init(rawValue: "shower.handheld.fill") }
 
     /// 􁓆
     /// Single Localization, 3 Layersets
@@ -6004,7 +6004,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let showerSidejet = SFSymbol(rawValue: "shower.sidejet")
+    static var showerSidejet: SFSymbol { .init(rawValue: "shower.sidejet") }
 
     /// 􁓇
     /// Single Localization, 3 Layersets
@@ -6013,21 +6013,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let showerSidejetFill = SFSymbol(rawValue: "shower.sidejet.fill")
+    static var showerSidejetFill: SFSymbol { .init(rawValue: "shower.sidejet.fill") }
 
     /// 􁐪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sink = SFSymbol(rawValue: "sink")
+    static var sink: SFSymbol { .init(rawValue: "sink") }
 
     /// 􁐫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sinkFill = SFSymbol(rawValue: "sink.fill")
+    static var sinkFill: SFSymbol { .init(rawValue: "sink.fill") }
 
     /// 􁚌
     /// Single Localization, 2 Layersets
@@ -6040,7 +6040,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "sliderHorizontal2ArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "sliderHorizontal2ArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sliderHorizontal2ArrowTriangleheadCounterclockwise")
-    static let sliderHorizontal2Gobackward = SFSymbol(rawValue: "slider.horizontal.2.gobackward")
+    static var sliderHorizontal2Gobackward: SFSymbol { .init(rawValue: "slider.horizontal.2.gobackward") }
 
     /// 􁚋
     /// Single Localization, 3 Layersets
@@ -6049,7 +6049,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sliderHorizontal2SquareBadgeArrowDown = SFSymbol(rawValue: "slider.horizontal.2.square.badge.arrow.down")
+    static var sliderHorizontal2SquareBadgeArrowDown: SFSymbol { .init(rawValue: "slider.horizontal.2.square.badge.arrow.down") }
 
     /// 􁚊
     /// Single Localization, 3 Layersets
@@ -6058,7 +6058,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sliderHorizontal2SquareOnSquare = SFSymbol(rawValue: "slider.horizontal.2.square.on.square")
+    static var sliderHorizontal2SquareOnSquare: SFSymbol { .init(rawValue: "slider.horizontal.2.square.on.square") }
 
     /// 􁐄
     /// Single Localization, 2 Layersets
@@ -6066,7 +6066,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowSquareAndSquareFilled = SFSymbol(rawValue: "slider.horizontal.below.square.and.square.filled")
+    static var sliderHorizontalBelowSquareAndSquareFilled: SFSymbol { .init(rawValue: "slider.horizontal.below.square.and.square.filled") }
 
     /// 􁛭
     /// Single Localization, 2 Layersets
@@ -6074,7 +6074,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let smokeCircle = SFSymbol(rawValue: "smoke.circle")
+    static var smokeCircle: SFSymbol { .init(rawValue: "smoke.circle") }
 
     /// 􁛮
     /// Single Localization, 3 Layersets
@@ -6083,14 +6083,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let smokeCircleFill = SFSymbol(rawValue: "smoke.circle.fill")
+    static var smokeCircleFill: SFSymbol { .init(rawValue: "smoke.circle.fill") }
 
     /// 􀦥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let soccerball = SFSymbol(rawValue: "soccerball")
+    static var soccerball: SFSymbol { .init(rawValue: "soccerball") }
 
     /// 􁚸
     /// Single Localization, 2 Layersets
@@ -6098,7 +6098,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let soccerballCircle = SFSymbol(rawValue: "soccerball.circle")
+    static var soccerballCircle: SFSymbol { .init(rawValue: "soccerball.circle") }
 
     /// 􁚹
     /// Single Localization, 3 Layersets
@@ -6107,7 +6107,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let soccerballCircleFill = SFSymbol(rawValue: "soccerball.circle.fill")
+    static var soccerballCircleFill: SFSymbol { .init(rawValue: "soccerball.circle.fill") }
 
     /// 􁜽
     /// Single Localization, 3 Layersets
@@ -6116,7 +6116,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let soccerballCircleFillInverse = SFSymbol(rawValue: "soccerball.circle.fill.inverse")
+    static var soccerballCircleFillInverse: SFSymbol { .init(rawValue: "soccerball.circle.fill.inverse") }
 
     /// 􁚺
     /// Single Localization, 2 Layersets
@@ -6124,35 +6124,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let soccerballCircleInverse = SFSymbol(rawValue: "soccerball.circle.inverse")
+    static var soccerballCircleInverse: SFSymbol { .init(rawValue: "soccerball.circle.inverse") }
 
     /// 􁗈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let soccerballInverse = SFSymbol(rawValue: "soccerball.inverse")
+    static var soccerballInverse: SFSymbol { .init(rawValue: "soccerball.inverse") }
 
     /// 􁐲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sofa = SFSymbol(rawValue: "sofa")
+    static var sofa: SFSymbol { .init(rawValue: "sofa") }
 
     /// 􁐳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sofaFill = SFSymbol(rawValue: "sofa.fill")
+    static var sofaFill: SFSymbol { .init(rawValue: "sofa.fill") }
 
     /// 􁁺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let space = SFSymbol(rawValue: "space")
+    static var space: SFSymbol { .init(rawValue: "space") }
 
     /// 􁜌
     /// Single Localization, 2 Layersets
@@ -6160,7 +6160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerMinus = SFSymbol(rawValue: "speaker.minus")
+    static var speakerMinus: SFSymbol { .init(rawValue: "speaker.minus") }
 
     /// 􁜍
     /// Single Localization, 2 Layersets
@@ -6168,7 +6168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerMinusFill = SFSymbol(rawValue: "speaker.minus.fill")
+    static var speakerMinusFill: SFSymbol { .init(rawValue: "speaker.minus.fill") }
 
     /// 􁜊
     /// Single Localization, 2 Layersets
@@ -6176,7 +6176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerPlus = SFSymbol(rawValue: "speaker.plus")
+    static var speakerPlus: SFSymbol { .init(rawValue: "speaker.plus") }
 
     /// 􁜋
     /// Single Localization, 2 Layersets
@@ -6184,7 +6184,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerPlusFill = SFSymbol(rawValue: "speaker.plus.fill")
+    static var speakerPlusFill: SFSymbol { .init(rawValue: "speaker.plus.fill") }
 
     /// 􀽅
     /// Single Localization, 2 Layersets
@@ -6192,7 +6192,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerSquare = SFSymbol(rawValue: "speaker.square")
+    static var speakerSquare: SFSymbol { .init(rawValue: "speaker.square") }
 
     /// 􀽆
     /// Single Localization, 3 Layersets
@@ -6201,7 +6201,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerSquareFill = SFSymbol(rawValue: "speaker.square.fill")
+    static var speakerSquareFill: SFSymbol { .init(rawValue: "speaker.square.fill") }
 
     /// 􁗮
     /// 2 Localizations, 3 Layersets
@@ -6219,7 +6219,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "speakerWave2Bubble")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "speakerWave2Bubble")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave2Bubble")
-    static let speakerWave2BubbleLeft = SymbolWith1Localization<Rtl>(rawValue: "speaker.wave.2.bubble.left")
+    static var speakerWave2BubbleLeft: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.wave.2.bubble.left") }
 
     /// 􁗯
     /// 2 Localizations, 3 Layersets
@@ -6237,21 +6237,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "speakerWave2BubbleFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "speakerWave2BubbleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "speakerWave2BubbleFill")
-    static let speakerWave2BubbleLeftFill = SymbolWith1Localization<Rtl>(rawValue: "speaker.wave.2.bubble.left.fill")
+    static var speakerWave2BubbleLeftFill: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.wave.2.bubble.left.fill") }
 
     /// 􁒾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let spigot = SFSymbol(rawValue: "spigot")
+    static var spigot: SFSymbol { .init(rawValue: "spigot") }
 
     /// 􁒿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let spigotFill = SFSymbol(rawValue: "spigot.fill")
+    static var spigotFill: SFSymbol { .init(rawValue: "spigot.fill") }
 
     /// 􁜇
     /// Single Localization, 2 Layersets
@@ -6259,7 +6259,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sportscourtCircle = SFSymbol(rawValue: "sportscourt.circle")
+    static var sportscourtCircle: SFSymbol { .init(rawValue: "sportscourt.circle") }
 
     /// 􁜈
     /// Single Localization, 3 Layersets
@@ -6268,14 +6268,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sportscourtCircleFill = SFSymbol(rawValue: "sportscourt.circle.fill")
+    static var sportscourtCircleFill: SFSymbol { .init(rawValue: "sportscourt.circle.fill") }
 
     /// 􁔌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sprinkler = SFSymbol(rawValue: "sprinkler")
+    static var sprinkler: SFSymbol { .init(rawValue: "sprinkler") }
 
     /// 􁒼
     /// Single Localization, 3 Layersets
@@ -6284,7 +6284,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sprinklerAndDroplets = SFSymbol(rawValue: "sprinkler.and.droplets")
+    static var sprinklerAndDroplets: SFSymbol { .init(rawValue: "sprinkler.and.droplets") }
 
     /// 􁒽
     /// Single Localization, 3 Layersets
@@ -6293,14 +6293,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sprinklerAndDropletsFill = SFSymbol(rawValue: "sprinkler.and.droplets.fill")
+    static var sprinklerAndDropletsFill: SFSymbol { .init(rawValue: "sprinkler.and.droplets.fill") }
 
     /// 􁔍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sprinklerFill = SFSymbol(rawValue: "sprinkler.fill")
+    static var sprinklerFill: SFSymbol { .init(rawValue: "sprinkler.fill") }
 
     /// 􀯭
     /// Single Localization, 3 Layersets
@@ -6309,7 +6309,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square2Layers3d = SFSymbol(rawValue: "square.2.layers.3d")
+    static var square2Layers3d: SFSymbol { .init(rawValue: "square.2.layers.3d") }
 
     /// 􀯯
     /// Single Localization, 3 Layersets
@@ -6318,7 +6318,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square2Layers3dBottomFilled = SFSymbol(rawValue: "square.2.layers.3d.bottom.filled")
+    static var square2Layers3dBottomFilled: SFSymbol { .init(rawValue: "square.2.layers.3d.bottom.filled") }
 
     /// 􀯮
     /// Single Localization, 3 Layersets
@@ -6327,7 +6327,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square2Layers3dTopFilled = SFSymbol(rawValue: "square.2.layers.3d.top.filled")
+    static var square2Layers3dTopFilled: SFSymbol { .init(rawValue: "square.2.layers.3d.top.filled") }
 
     /// 􀯰
     /// Single Localization, 3 Layersets
@@ -6336,7 +6336,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square3Layers3d = SFSymbol(rawValue: "square.3.layers.3d")
+    static var square3Layers3d: SFSymbol { .init(rawValue: "square.3.layers.3d") }
 
     /// 􀯳
     /// Single Localization, 3 Layersets
@@ -6345,7 +6345,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square3Layers3dBottomFilled = SFSymbol(rawValue: "square.3.layers.3d.bottom.filled")
+    static var square3Layers3dBottomFilled: SFSymbol { .init(rawValue: "square.3.layers.3d.bottom.filled") }
 
     /// 􀯲
     /// Single Localization, 3 Layersets
@@ -6354,7 +6354,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square3Layers3dMiddleFilled = SFSymbol(rawValue: "square.3.layers.3d.middle.filled")
+    static var square3Layers3dMiddleFilled: SFSymbol { .init(rawValue: "square.3.layers.3d.middle.filled") }
 
     /// 􁌅
     /// Single Localization, 2 Layersets
@@ -6362,7 +6362,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let square3Layers3dSlash = SFSymbol(rawValue: "square.3.layers.3d.slash")
+    static var square3Layers3dSlash: SFSymbol { .init(rawValue: "square.3.layers.3d.slash") }
 
     /// 􀯱
     /// Single Localization, 3 Layersets
@@ -6371,7 +6371,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let square3Layers3dTopFilled = SFSymbol(rawValue: "square.3.layers.3d.top.filled")
+    static var square3Layers3dTopFilled: SFSymbol { .init(rawValue: "square.3.layers.3d.top.filled") }
 
     /// 􁗙
     /// Single Localization, 2 Layersets
@@ -6379,7 +6379,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareAndPencilCircle = SFSymbol(rawValue: "square.and.pencil.circle")
+    static var squareAndPencilCircle: SFSymbol { .init(rawValue: "square.and.pencil.circle") }
 
     /// 􁗚
     /// Single Localization, 3 Layersets
@@ -6388,7 +6388,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndPencilCircleFill = SFSymbol(rawValue: "square.and.pencil.circle.fill")
+    static var squareAndPencilCircleFill: SFSymbol { .init(rawValue: "square.and.pencil.circle.fill") }
 
     /// 􁒡
     /// Single Localization, 2 Layersets
@@ -6401,14 +6401,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledBottomthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledBottomthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledBottomthirdSquare")
-    static let squareBottomthirdInsetFilled = SFSymbol(rawValue: "square.bottomthird.inset.filled")
+    static var squareBottomthirdInsetFilled: SFSymbol { .init(rawValue: "square.bottomthird.inset.filled") }
 
     /// 􁊓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareDotted = SFSymbol(rawValue: "square.dotted")
+    static var squareDotted: SFSymbol { .init(rawValue: "square.dotted") }
 
     /// 􁒤
     /// Single Localization, 2 Layersets
@@ -6421,7 +6421,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledLeadingthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledLeadingthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeadingthirdSquare")
-    static let squareLeadingthirdInsetFilled = SFSymbol(rawValue: "square.leadingthird.inset.filled")
+    static var squareLeadingthirdInsetFilled: SFSymbol { .init(rawValue: "square.leadingthird.inset.filled") }
 
     /// 􁒢
     /// Single Localization, 2 Layersets
@@ -6434,7 +6434,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledLeftthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledLeftthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledLeftthirdSquare")
-    static let squareLeftthirdInsetFilled = SFSymbol(rawValue: "square.leftthird.inset.filled")
+    static var squareLeftthirdInsetFilled: SFSymbol { .init(rawValue: "square.leftthird.inset.filled") }
 
     /// 􁙰
     /// Single Localization, 3 Layersets
@@ -6443,7 +6443,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareOnSquareBadgePersonCrop = SFSymbol(rawValue: "square.on.square.badge.person.crop")
+    static var squareOnSquareBadgePersonCrop: SFSymbol { .init(rawValue: "square.on.square.badge.person.crop") }
 
     /// 􁙱
     /// Single Localization, 3 Layersets
@@ -6452,7 +6452,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareOnSquareBadgePersonCropFill = SFSymbol(rawValue: "square.on.square.badge.person.crop.fill")
+    static var squareOnSquareBadgePersonCropFill: SFSymbol { .init(rawValue: "square.on.square.badge.person.crop.fill") }
 
     /// 􁄻
     /// Single Localization, 3 Layersets
@@ -6461,7 +6461,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareOnSquareIntersectionDashed = SFSymbol(rawValue: "square.on.square.intersection.dashed")
+    static var squareOnSquareIntersectionDashed: SFSymbol { .init(rawValue: "square.on.square.intersection.dashed") }
 
     /// 􁒣
     /// Single Localization, 2 Layersets
@@ -6474,7 +6474,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledRightthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledRightthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRightthirdSquare")
-    static let squareRightthirdInsetFilled = SFSymbol(rawValue: "square.rightthird.inset.filled")
+    static var squareRightthirdInsetFilled: SFSymbol { .init(rawValue: "square.rightthird.inset.filled") }
 
     /// 􁒠
     /// Single Localization, 2 Layersets
@@ -6487,7 +6487,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledTopthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledTopthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTopthirdSquare")
-    static let squareTopthirdInsetFilled = SFSymbol(rawValue: "square.topthird.inset.filled")
+    static var squareTopthirdInsetFilled: SFSymbol { .init(rawValue: "square.topthird.inset.filled") }
 
     /// 􁒥
     /// Single Localization, 2 Layersets
@@ -6500,7 +6500,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "insetFilledTrailingthirdSquare")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "insetFilledTrailingthirdSquare")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledTrailingthirdSquare")
-    static let squareTrailingthirdInsetFilled = SFSymbol(rawValue: "square.trailingthird.inset.filled")
+    static var squareTrailingthirdInsetFilled: SFSymbol { .init(rawValue: "square.trailingthird.inset.filled") }
 
     /// 􁚬
     /// Single Localization, 2 Layersets
@@ -6508,7 +6508,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squaresLeadingRectangle = SFSymbol(rawValue: "squares.leading.rectangle")
+    static var squaresLeadingRectangle: SFSymbol { .init(rawValue: "squares.leading.rectangle") }
 
     /// 􁓓
     /// Single Localization, Single Layerset
@@ -6520,14 +6520,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.4, renamed: "squareshapeSplit2x2DottedInsideAndOutside")
     @available(watchOS, introduced: 9.0, deprecated: 11.4, renamed: "squareshapeSplit2x2DottedInsideAndOutside")
     @available(visionOS, introduced: 1.0, deprecated: 2.4, renamed: "squareshapeSplit2x2DottedInsideAndOutside")
-    static let squareshapeDottedSplit2x2 = SFSymbol(rawValue: "squareshape.dotted.split.2x2")
+    static var squareshapeDottedSplit2x2: SFSymbol { .init(rawValue: "squareshape.dotted.split.2x2") }
 
     /// 􁕋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stairs = SFSymbol(rawValue: "stairs")
+    static var stairs: SFSymbol { .init(rawValue: "stairs") }
 
     /// 􁚍
     /// Single Localization, 3 Layersets
@@ -6536,7 +6536,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let starSquareOnSquare = SFSymbol(rawValue: "star.square.on.square")
+    static var starSquareOnSquare: SFSymbol { .init(rawValue: "star.square.on.square") }
 
     /// 􁚎
     /// Single Localization, 3 Layersets
@@ -6545,28 +6545,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let starSquareOnSquareFill = SFSymbol(rawValue: "star.square.on.square.fill")
+    static var starSquareOnSquareFill: SFSymbol { .init(rawValue: "star.square.on.square.fill") }
 
     /// 􁑂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sterlingsign = SFSymbol(rawValue: "sterlingsign")
+    static var sterlingsign: SFSymbol { .init(rawValue: "sterlingsign") }
 
     /// 􁐦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stove = SFSymbol(rawValue: "stove")
+    static var stove: SFSymbol { .init(rawValue: "stove") }
 
     /// 􁐧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stoveFill = SFSymbol(rawValue: "stove.fill")
+    static var stoveFill: SFSymbol { .init(rawValue: "stove.fill") }
 
     /// 􁛅
     /// Single Localization, 2 Layersets
@@ -6579,7 +6579,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "sunHorizonCircle")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "sunHorizonCircle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sunHorizonCircle")
-    static let sunAndHorizonCircle = SFSymbol(rawValue: "sun.and.horizon.circle")
+    static var sunAndHorizonCircle: SFSymbol { .init(rawValue: "sun.and.horizon.circle") }
 
     /// 􁛆
     /// Single Localization, 3 Layersets
@@ -6593,7 +6593,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 17.0, renamed: "sunHorizonCircleFill")
     @available(watchOS, introduced: 9.0, deprecated: 10.0, renamed: "sunHorizonCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "sunHorizonCircleFill")
-    static let sunAndHorizonCircleFill = SFSymbol(rawValue: "sun.and.horizon.circle.fill")
+    static var sunAndHorizonCircleFill: SFSymbol { .init(rawValue: "sun.and.horizon.circle.fill") }
 
     /// 􁛇
     /// Single Localization, 2 Layersets
@@ -6601,7 +6601,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunDustCircle = SFSymbol(rawValue: "sun.dust.circle")
+    static var sunDustCircle: SFSymbol { .init(rawValue: "sun.dust.circle") }
 
     /// 􁛈
     /// Single Localization, 3 Layersets
@@ -6610,7 +6610,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunDustCircleFill = SFSymbol(rawValue: "sun.dust.circle.fill")
+    static var sunDustCircleFill: SFSymbol { .init(rawValue: "sun.dust.circle.fill") }
 
     /// 􁛉
     /// Single Localization, 2 Layersets
@@ -6618,7 +6618,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunHazeCircle = SFSymbol(rawValue: "sun.haze.circle")
+    static var sunHazeCircle: SFSymbol { .init(rawValue: "sun.haze.circle") }
 
     /// 􁛊
     /// Single Localization, 3 Layersets
@@ -6627,7 +6627,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunHazeCircleFill = SFSymbol(rawValue: "sun.haze.circle.fill")
+    static var sunHazeCircleFill: SFSymbol { .init(rawValue: "sun.haze.circle.fill") }
 
     /// 􁜎
     /// Single Localization, 3 Layersets
@@ -6636,7 +6636,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunMaxTrianglebadgeExclamationmark = SFSymbol(rawValue: "sun.max.trianglebadge.exclamationmark")
+    static var sunMaxTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "sun.max.trianglebadge.exclamationmark") }
 
     /// 􁜏
     /// Single Localization, 3 Layersets
@@ -6645,7 +6645,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunMaxTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "sun.max.trianglebadge.exclamationmark.fill")
+    static var sunMaxTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "sun.max.trianglebadge.exclamationmark.fill") }
 
     /// 􁛁
     /// Single Localization, 2 Layersets
@@ -6653,7 +6653,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunriseCircle = SFSymbol(rawValue: "sunrise.circle")
+    static var sunriseCircle: SFSymbol { .init(rawValue: "sunrise.circle") }
 
     /// 􁛂
     /// Single Localization, 3 Layersets
@@ -6662,7 +6662,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunriseCircleFill = SFSymbol(rawValue: "sunrise.circle.fill")
+    static var sunriseCircleFill: SFSymbol { .init(rawValue: "sunrise.circle.fill") }
 
     /// 􁛃
     /// Single Localization, 2 Layersets
@@ -6670,7 +6670,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunsetCircle = SFSymbol(rawValue: "sunset.circle")
+    static var sunsetCircle: SFSymbol { .init(rawValue: "sunset.circle") }
 
     /// 􁛄
     /// Single Localization, 3 Layersets
@@ -6679,7 +6679,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunsetCircleFill = SFSymbol(rawValue: "sunset.circle.fill")
+    static var sunsetCircleFill: SFSymbol { .init(rawValue: "sunset.circle.fill") }
 
     /// 􁙧
     /// Single Localization, 2 Layersets
@@ -6687,7 +6687,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let swatchpalette = SFSymbol(rawValue: "swatchpalette")
+    static var swatchpalette: SFSymbol { .init(rawValue: "swatchpalette") }
 
     /// 􁙨
     /// Single Localization, 2 Layersets
@@ -6695,7 +6695,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let swatchpaletteFill = SFSymbol(rawValue: "swatchpalette.fill")
+    static var swatchpaletteFill: SFSymbol { .init(rawValue: "swatchpalette.fill") }
 
     /// 􁕳
     /// Single Localization, 2 Layersets
@@ -6703,7 +6703,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let switchProgrammable = SFSymbol(rawValue: "switch.programmable")
+    static var switchProgrammable: SFSymbol { .init(rawValue: "switch.programmable") }
 
     /// 􁘀
     /// Single Localization, 3 Layersets
@@ -6712,7 +6712,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let switchProgrammableFill = SFSymbol(rawValue: "switch.programmable.fill")
+    static var switchProgrammableFill: SFSymbol { .init(rawValue: "switch.programmable.fill") }
 
     /// 􁕴
     /// Single Localization, 2 Layersets
@@ -6720,7 +6720,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let switchProgrammableSquare = SFSymbol(rawValue: "switch.programmable.square")
+    static var switchProgrammableSquare: SFSymbol { .init(rawValue: "switch.programmable.square") }
 
     /// 􁕵
     /// Single Localization, 3 Layersets
@@ -6729,63 +6729,63 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let switchProgrammableSquareFill = SFSymbol(rawValue: "switch.programmable.square.fill")
+    static var switchProgrammableSquareFill: SFSymbol { .init(rawValue: "switch.programmable.square.fill") }
 
     /// 􀠷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let syringe = SFSymbol(rawValue: "syringe")
+    static var syringe: SFSymbol { .init(rawValue: "syringe") }
 
     /// 􀠸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let syringeFill = SFSymbol(rawValue: "syringe.fill")
+    static var syringeFill: SFSymbol { .init(rawValue: "syringe.fill") }
 
     /// 􁐰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tableFurniture = SFSymbol(rawValue: "table.furniture")
+    static var tableFurniture: SFSymbol { .init(rawValue: "table.furniture") }
 
     /// 􁐱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tableFurnitureFill = SFSymbol(rawValue: "table.furniture.fill")
+    static var tableFurnitureFill: SFSymbol { .init(rawValue: "table.furniture.fill") }
 
     /// 􀲬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let teddybear = SFSymbol(rawValue: "teddybear")
+    static var teddybear: SFSymbol { .init(rawValue: "teddybear") }
 
     /// 􀲭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let teddybearFill = SFSymbol(rawValue: "teddybear.fill")
+    static var teddybearFill: SFSymbol { .init(rawValue: "teddybear.fill") }
 
     /// 􁑊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tengesign = SFSymbol(rawValue: "tengesign")
+    static var tengesign: SFSymbol { .init(rawValue: "tengesign") }
 
     /// 􁗍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tennisRacket = SFSymbol(rawValue: "tennis.racket")
+    static var tennisRacket: SFSymbol { .init(rawValue: "tennis.racket") }
 
     /// 􁜤
     /// Single Localization, 2 Layersets
@@ -6793,7 +6793,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tennisRacketCircle = SFSymbol(rawValue: "tennis.racket.circle")
+    static var tennisRacketCircle: SFSymbol { .init(rawValue: "tennis.racket.circle") }
 
     /// 􁜥
     /// Single Localization, 3 Layersets
@@ -6802,14 +6802,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tennisRacketCircleFill = SFSymbol(rawValue: "tennis.racket.circle.fill")
+    static var tennisRacketCircleFill: SFSymbol { .init(rawValue: "tennis.racket.circle.fill") }
 
     /// 􁜦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tennisball = SFSymbol(rawValue: "tennisball")
+    static var tennisball: SFSymbol { .init(rawValue: "tennisball") }
 
     /// 􁜨
     /// Single Localization, 2 Layersets
@@ -6817,7 +6817,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tennisballCircle = SFSymbol(rawValue: "tennisball.circle")
+    static var tennisballCircle: SFSymbol { .init(rawValue: "tennisball.circle") }
 
     /// 􁜩
     /// Single Localization, 3 Layersets
@@ -6826,28 +6826,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tennisballCircleFill = SFSymbol(rawValue: "tennisball.circle.fill")
+    static var tennisballCircleFill: SFSymbol { .init(rawValue: "tennisball.circle.fill") }
 
     /// 􁜧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tennisballFill = SFSymbol(rawValue: "tennisball.fill")
+    static var tennisballFill: SFSymbol { .init(rawValue: "tennisball.fill") }
 
     /// 􁋨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tent = SFSymbol(rawValue: "tent")
+    static var tent: SFSymbol { .init(rawValue: "tent") }
 
     /// 􁋩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tentFill = SFSymbol(rawValue: "tent.fill")
+    static var tentFill: SFSymbol { .init(rawValue: "tent.fill") }
 
     /// 􁘿
     /// Single Localization, 2 Layersets
@@ -6855,7 +6855,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textLineFirstAndArrowtriangleForward = SFSymbol(rawValue: "text.line.first.and.arrowtriangle.forward")
+    static var textLineFirstAndArrowtriangleForward: SFSymbol { .init(rawValue: "text.line.first.and.arrowtriangle.forward") }
 
     /// 􁙀
     /// Single Localization, 2 Layersets
@@ -6863,14 +6863,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textLineLastAndArrowtriangleForward = SFSymbol(rawValue: "text.line.last.and.arrowtriangle.forward")
+    static var textLineLastAndArrowtriangleForward: SFSymbol { .init(rawValue: "text.line.last.and.arrowtriangle.forward") }
 
     /// 􀵫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textWordSpacing = SFSymbol(rawValue: "text.word.spacing")
+    static var textWordSpacing: SFSymbol { .init(rawValue: "text.word.spacing") }
 
     /// 􁖻
     /// 5 Localizations, Single Layerset
@@ -6889,7 +6889,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "textformatNumbers")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "textformatNumbers")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "textformatNumbers")
-    static let textformat12 = SymbolWith4Localizations<Ar, Hi, Km_v5, My_v5>(rawValue: "textformat.12")
+    static var textformat12: SymbolWith4Localizations<Ar, Hi, Km_v5, My_v5> { .init(rawValue: "textformat.12") }
 
     /// 􁔘
     /// Single Localization, 2 Layersets
@@ -6897,7 +6897,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let theatermaskAndPaintbrush = SFSymbol(rawValue: "theatermask.and.paintbrush")
+    static var theatermaskAndPaintbrush: SFSymbol { .init(rawValue: "theatermask.and.paintbrush") }
 
     /// 􁕒
     /// Single Localization, 2 Layersets
@@ -6905,7 +6905,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let theatermaskAndPaintbrushFill = SFSymbol(rawValue: "theatermask.and.paintbrush.fill")
+    static var theatermaskAndPaintbrushFill: SFSymbol { .init(rawValue: "theatermask.and.paintbrush.fill") }
 
     /// 􁀵
     /// Single Localization, 3 Layersets
@@ -6914,7 +6914,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let thermometerBrakesignal = SFSymbol(rawValue: "thermometer.brakesignal")
+    static var thermometerBrakesignal: SFSymbol { .init(rawValue: "thermometer.brakesignal") }
 
     /// 􁏄
     /// Single Localization, 3 Layersets
@@ -6923,7 +6923,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerHigh = SFSymbol(rawValue: "thermometer.high")
+    static var thermometerHigh: SFSymbol { .init(rawValue: "thermometer.high") }
 
     /// 􁏃
     /// Single Localization, 3 Layersets
@@ -6932,7 +6932,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerLow = SFSymbol(rawValue: "thermometer.low")
+    static var thermometerLow: SFSymbol { .init(rawValue: "thermometer.low") }
 
     /// 􀇬
     /// Single Localization, 3 Layersets
@@ -6941,7 +6941,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let thermometerMedium = SFSymbol(rawValue: "thermometer.medium")
+    static var thermometerMedium: SFSymbol { .init(rawValue: "thermometer.medium") }
 
     /// 􁗄
     /// Single Localization, 2 Layersets
@@ -6949,7 +6949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerMediumSlash = SFSymbol(rawValue: "thermometer.medium.slash")
+    static var thermometerMediumSlash: SFSymbol { .init(rawValue: "thermometer.medium.slash") }
 
     /// 􁛻
     /// Single Localization, 2 Layersets
@@ -6957,7 +6957,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerSnowflakeCircle = SFSymbol(rawValue: "thermometer.snowflake.circle")
+    static var thermometerSnowflakeCircle: SFSymbol { .init(rawValue: "thermometer.snowflake.circle") }
 
     /// 􁛼
     /// Single Localization, 3 Layersets
@@ -6966,7 +6966,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerSnowflakeCircleFill = SFSymbol(rawValue: "thermometer.snowflake.circle.fill")
+    static var thermometerSnowflakeCircleFill: SFSymbol { .init(rawValue: "thermometer.snowflake.circle.fill") }
 
     /// 􁛹
     /// Single Localization, 2 Layersets
@@ -6974,7 +6974,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerSunCircle = SFSymbol(rawValue: "thermometer.sun.circle")
+    static var thermometerSunCircle: SFSymbol { .init(rawValue: "thermometer.sun.circle") }
 
     /// 􁛺
     /// Single Localization, 3 Layersets
@@ -6983,7 +6983,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerSunCircleFill = SFSymbol(rawValue: "thermometer.sun.circle.fill")
+    static var thermometerSunCircleFill: SFSymbol { .init(rawValue: "thermometer.sun.circle.fill") }
 
     /// 􁙅
     /// Single Localization, 2 Layersets
@@ -6991,7 +6991,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let timerCircle = SFSymbol(rawValue: "timer.circle")
+    static var timerCircle: SFSymbol { .init(rawValue: "timer.circle") }
 
     /// 􁙆
     /// Single Localization, 3 Layersets
@@ -7000,21 +7000,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let timerCircleFill = SFSymbol(rawValue: "timer.circle.fill")
+    static var timerCircleFill: SFSymbol { .init(rawValue: "timer.circle.fill") }
 
     /// 􁐾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let toilet = SFSymbol(rawValue: "toilet")
+    static var toilet: SFSymbol { .init(rawValue: "toilet") }
 
     /// 􁐿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let toiletFill = SFSymbol(rawValue: "toilet.fill")
+    static var toiletFill: SFSymbol { .init(rawValue: "toilet.fill") }
 
     /// 􁛳
     /// Single Localization, 2 Layersets
@@ -7022,7 +7022,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tornadoCircle = SFSymbol(rawValue: "tornado.circle")
+    static var tornadoCircle: SFSymbol { .init(rawValue: "tornado.circle") }
 
     /// 􁛴
     /// Single Localization, 3 Layersets
@@ -7031,14 +7031,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tornadoCircleFill = SFSymbol(rawValue: "tornado.circle.fill")
+    static var tornadoCircleFill: SFSymbol { .init(rawValue: "tornado.circle.fill") }
 
     /// 􀠏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trophy = SFSymbol(rawValue: "trophy")
+    static var trophy: SFSymbol { .init(rawValue: "trophy") }
 
     /// 􁒔
     /// Single Localization, 2 Layersets
@@ -7046,7 +7046,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let trophyCircle = SFSymbol(rawValue: "trophy.circle")
+    static var trophyCircle: SFSymbol { .init(rawValue: "trophy.circle") }
 
     /// 􁒕
     /// Single Localization, 3 Layersets
@@ -7055,14 +7055,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trophyCircleFill = SFSymbol(rawValue: "trophy.circle.fill")
+    static var trophyCircleFill: SFSymbol { .init(rawValue: "trophy.circle.fill") }
 
     /// 􀠐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let trophyFill = SFSymbol(rawValue: "trophy.fill")
+    static var trophyFill: SFSymbol { .init(rawValue: "trophy.fill") }
 
     /// 􁛵
     /// Single Localization, 2 Layersets
@@ -7070,7 +7070,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tropicalstormCircle = SFSymbol(rawValue: "tropicalstorm.circle")
+    static var tropicalstormCircle: SFSymbol { .init(rawValue: "tropicalstorm.circle") }
 
     /// 􁛶
     /// Single Localization, 3 Layersets
@@ -7079,21 +7079,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tropicalstormCircleFill = SFSymbol(rawValue: "tropicalstorm.circle.fill")
+    static var tropicalstormCircleFill: SFSymbol { .init(rawValue: "tropicalstorm.circle.fill") }
 
     /// 􁑗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tugriksign = SFSymbol(rawValue: "tugriksign")
+    static var tugriksign: SFSymbol { .init(rawValue: "tugriksign") }
 
     /// 􁑅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let turkishlirasign = SFSymbol(rawValue: "turkishlirasign")
+    static var turkishlirasign: SFSymbol { .init(rawValue: "turkishlirasign") }
 
     /// 􁝡
     /// Single Localization, 2 Layersets
@@ -7101,7 +7101,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tvAndMediaboxFill = SFSymbol(rawValue: "tv.and.mediabox.fill")
+    static var tvAndMediaboxFill: SFSymbol { .init(rawValue: "tv.and.mediabox.fill") }
 
     /// 􀸰
     /// 2 Localizations, 2 Layersets
@@ -7113,7 +7113,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let umbrellaPercent = SymbolWith1Localization<Ar>(rawValue: "umbrella.percent")
+    static var umbrellaPercent: SymbolWith1Localization<Ar> { .init(rawValue: "umbrella.percent") }
 
     /// 􀸱
     /// 2 Localizations, 2 Layersets
@@ -7125,7 +7125,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let umbrellaPercentFill = SymbolWith1Localization<Ar>(rawValue: "umbrella.percent.fill")
+    static var umbrellaPercentFill: SymbolWith1Localization<Ar> { .init(rawValue: "umbrella.percent.fill") }
 
     /// 􁙮
     /// Single Localization, 2 Layersets
@@ -7133,7 +7133,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let vialViewfinder = SFSymbol(rawValue: "vial.viewfinder")
+    static var vialViewfinder: SFSymbol { .init(rawValue: "vial.viewfinder") }
 
     /// 􁓟
     /// Single Localization, 2 Layersets
@@ -7141,7 +7141,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let videoDoorbell = SFSymbol(rawValue: "video.doorbell")
+    static var videoDoorbell: SFSymbol { .init(rawValue: "video.doorbell") }
 
     /// 􁓠
     /// Single Localization, 3 Layersets
@@ -7150,28 +7150,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let videoDoorbellFill = SFSymbol(rawValue: "video.doorbell.fill")
+    static var videoDoorbellFill: SFSymbol { .init(rawValue: "video.doorbell.fill") }
 
     /// 􁒮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let videoprojector = SFSymbol(rawValue: "videoprojector")
+    static var videoprojector: SFSymbol { .init(rawValue: "videoprojector") }
 
     /// 􁒯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let videoprojectorFill = SFSymbol(rawValue: "videoprojector.fill")
+    static var videoprojectorFill: SFSymbol { .init(rawValue: "videoprojector.fill") }
 
     /// 􁜪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let volleyball = SFSymbol(rawValue: "volleyball")
+    static var volleyball: SFSymbol { .init(rawValue: "volleyball") }
 
     /// 􁜬
     /// Single Localization, 2 Layersets
@@ -7179,7 +7179,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let volleyballCircle = SFSymbol(rawValue: "volleyball.circle")
+    static var volleyballCircle: SFSymbol { .init(rawValue: "volleyball.circle") }
 
     /// 􁜭
     /// Single Localization, 3 Layersets
@@ -7188,14 +7188,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let volleyballCircleFill = SFSymbol(rawValue: "volleyball.circle.fill")
+    static var volleyballCircleFill: SFSymbol { .init(rawValue: "volleyball.circle.fill") }
 
     /// 􁜫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let volleyballFill = SFSymbol(rawValue: "volleyball.fill")
+    static var volleyballFill: SFSymbol { .init(rawValue: "volleyball.fill") }
 
     /// 􁐠
     /// Single Localization, 2 Layersets
@@ -7203,7 +7203,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let washer = SFSymbol(rawValue: "washer")
+    static var washer: SFSymbol { .init(rawValue: "washer") }
 
     /// 􁐡
     /// Single Localization, 2 Layersets
@@ -7211,7 +7211,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let washerFill = SFSymbol(rawValue: "washer.fill")
+    static var washerFill: SFSymbol { .init(rawValue: "washer.fill") }
 
     /// 􁎄
     /// Single Localization, 3 Layersets
@@ -7220,7 +7220,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waterWaves = SFSymbol(rawValue: "water.waves")
+    static var waterWaves: SFSymbol { .init(rawValue: "water.waves") }
 
     /// 􁎆
     /// Single Localization, 3 Layersets
@@ -7234,7 +7234,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "waterWavesAndArrowTriangleheadDown")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "waterWavesAndArrowTriangleheadDown")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "waterWavesAndArrowTriangleheadDown")
-    static let waterWavesAndArrowDown = SFSymbol(rawValue: "water.waves.and.arrow.down")
+    static var waterWavesAndArrowDown: SFSymbol { .init(rawValue: "water.waves.and.arrow.down") }
 
     /// 􁜰
     /// Single Localization, 3 Layersets
@@ -7248,7 +7248,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "waterWavesAndArrowTriangleheadDownTrianglebadgeExclamationmark")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "waterWavesAndArrowTriangleheadDownTrianglebadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "waterWavesAndArrowTriangleheadDownTrianglebadgeExclamationmark")
-    static let waterWavesAndArrowDownTrianglebadgeExclamationmark = SFSymbol(rawValue: "water.waves.and.arrow.down.trianglebadge.exclamationmark")
+    static var waterWavesAndArrowDownTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "water.waves.and.arrow.down.trianglebadge.exclamationmark") }
 
     /// 􁎅
     /// Single Localization, 3 Layersets
@@ -7262,7 +7262,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 18.0, renamed: "waterWavesAndArrowTriangleheadUp")
     @available(watchOS, introduced: 9.0, deprecated: 11.0, renamed: "waterWavesAndArrowTriangleheadUp")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "waterWavesAndArrowTriangleheadUp")
-    static let waterWavesAndArrowUp = SFSymbol(rawValue: "water.waves.and.arrow.up")
+    static var waterWavesAndArrowUp: SFSymbol { .init(rawValue: "water.waves.and.arrow.up") }
 
     /// 􁗃
     /// Single Localization, 2 Layersets
@@ -7270,7 +7270,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waterWavesSlash = SFSymbol(rawValue: "water.waves.slash")
+    static var waterWavesSlash: SFSymbol { .init(rawValue: "water.waves.slash") }
 
     /// 􁏏
     /// Single Localization, 2 Layersets
@@ -7278,7 +7278,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waveformSlash = SFSymbol(rawValue: "waveform.slash")
+    static var waveformSlash: SFSymbol { .init(rawValue: "waveform.slash") }
 
     /// 􁒲
     /// Single Localization, 2 Layersets
@@ -7286,7 +7286,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let webCamera = SFSymbol(rawValue: "web.camera")
+    static var webCamera: SFSymbol { .init(rawValue: "web.camera") }
 
     /// 􁒳
     /// Single Localization, 3 Layersets
@@ -7295,7 +7295,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let webCameraFill = SFSymbol(rawValue: "web.camera.fill")
+    static var webCameraFill: SFSymbol { .init(rawValue: "web.camera.fill") }
 
     /// 􁓣
     /// Single Localization, 3 Layersets
@@ -7304,7 +7304,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wifiRouter = SFSymbol(rawValue: "wifi.router")
+    static var wifiRouter: SFSymbol { .init(rawValue: "wifi.router") }
 
     /// 􁓤
     /// Single Localization, 3 Layersets
@@ -7313,7 +7313,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wifiRouterFill = SFSymbol(rawValue: "wifi.router.fill")
+    static var wifiRouterFill: SFSymbol { .init(rawValue: "wifi.router.fill") }
 
     /// 􁛯
     /// Single Localization, 2 Layersets
@@ -7321,7 +7321,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windCircle = SFSymbol(rawValue: "wind.circle")
+    static var windCircle: SFSymbol { .init(rawValue: "wind.circle") }
 
     /// 􁛰
     /// Single Localization, 3 Layersets
@@ -7330,7 +7330,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windCircleFill = SFSymbol(rawValue: "wind.circle.fill")
+    static var windCircleFill: SFSymbol { .init(rawValue: "wind.circle.fill") }
 
     /// 􁛱
     /// Single Localization, 2 Layersets
@@ -7338,7 +7338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windSnowCircle = SFSymbol(rawValue: "wind.snow.circle")
+    static var windSnowCircle: SFSymbol { .init(rawValue: "wind.snow.circle") }
 
     /// 􁛲
     /// Single Localization, 3 Layersets
@@ -7347,7 +7347,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windSnowCircleFill = SFSymbol(rawValue: "wind.snow.circle.fill")
+    static var windSnowCircleFill: SFSymbol { .init(rawValue: "wind.snow.circle.fill") }
 
     /// 􁑽
     /// Single Localization, 2 Layersets
@@ -7355,7 +7355,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowAwning = SFSymbol(rawValue: "window.awning")
+    static var windowAwning: SFSymbol { .init(rawValue: "window.awning") }
 
     /// 􁑾
     /// Single Localization, 2 Layersets
@@ -7363,7 +7363,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowAwningClosed = SFSymbol(rawValue: "window.awning.closed")
+    static var windowAwningClosed: SFSymbol { .init(rawValue: "window.awning.closed") }
 
     /// 􁑿
     /// Single Localization, 2 Layersets
@@ -7371,7 +7371,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowCasement = SFSymbol(rawValue: "window.casement")
+    static var windowCasement: SFSymbol { .init(rawValue: "window.casement") }
 
     /// 􁒀
     /// Single Localization, 2 Layersets
@@ -7379,7 +7379,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowCasementClosed = SFSymbol(rawValue: "window.casement.closed")
+    static var windowCasementClosed: SFSymbol { .init(rawValue: "window.casement.closed") }
 
     /// 􁒁
     /// Single Localization, 2 Layersets
@@ -7387,7 +7387,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowCeiling = SFSymbol(rawValue: "window.ceiling")
+    static var windowCeiling: SFSymbol { .init(rawValue: "window.ceiling") }
 
     /// 􁒂
     /// Single Localization, 2 Layersets
@@ -7395,7 +7395,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowCeilingClosed = SFSymbol(rawValue: "window.ceiling.closed")
+    static var windowCeilingClosed: SFSymbol { .init(rawValue: "window.ceiling.closed") }
 
     /// 􁑭
     /// Single Localization, 2 Layersets
@@ -7403,7 +7403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowHorizontal = SFSymbol(rawValue: "window.horizontal")
+    static var windowHorizontal: SFSymbol { .init(rawValue: "window.horizontal") }
 
     /// 􁑮
     /// Single Localization, 2 Layersets
@@ -7411,7 +7411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowHorizontalClosed = SFSymbol(rawValue: "window.horizontal.closed")
+    static var windowHorizontalClosed: SFSymbol { .init(rawValue: "window.horizontal.closed") }
 
     /// 􁏣
     /// Single Localization, 2 Layersets
@@ -7419,7 +7419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowShadeClosed = SFSymbol(rawValue: "window.shade.closed")
+    static var windowShadeClosed: SFSymbol { .init(rawValue: "window.shade.closed") }
 
     /// 􁏢
     /// Single Localization, 2 Layersets
@@ -7427,7 +7427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowShadeOpen = SFSymbol(rawValue: "window.shade.open")
+    static var windowShadeOpen: SFSymbol { .init(rawValue: "window.shade.open") }
 
     /// 􁑬
     /// Single Localization, 2 Layersets
@@ -7435,7 +7435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowVerticalClosed = SFSymbol(rawValue: "window.vertical.closed")
+    static var windowVerticalClosed: SFSymbol { .init(rawValue: "window.vertical.closed") }
 
     /// 􁑫
     /// Single Localization, 2 Layersets
@@ -7443,7 +7443,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windowVerticalOpen = SFSymbol(rawValue: "window.vertical.open")
+    static var windowVerticalOpen: SFSymbol { .init(rawValue: "window.vertical.open") }
 
     /// 􁀕
     /// Single Localization, 2 Layersets
@@ -7456,7 +7456,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 16.1, renamed: "windshieldFrontAndSpray")
     @available(watchOS, introduced: 9.0, deprecated: 9.1, renamed: "windshieldFrontAndSpray")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "windshieldFrontAndSpray")
-    static let windshieldFrontAndFluid = SFSymbol(rawValue: "windshield.front.and.fluid")
+    static var windshieldFrontAndFluid: SFSymbol { .init(rawValue: "windshield.front.and.fluid") }
 
     /// 􁀔
     /// Single Localization, 3 Layersets
@@ -7465,7 +7465,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndWiper = SFSymbol(rawValue: "windshield.front.and.wiper")
+    static var windshieldFrontAndWiper: SFSymbol { .init(rawValue: "windshield.front.and.wiper") }
 
     /// 􁀗
     /// Single Localization, 3 Layersets
@@ -7474,7 +7474,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndWiperAndDrop = SFSymbol(rawValue: "windshield.front.and.wiper.and.drop")
+    static var windshieldFrontAndWiperAndDrop: SFSymbol { .init(rawValue: "windshield.front.and.wiper.and.drop") }
 
     /// 􁀡
     /// Single Localization, 2 Layersets
@@ -7487,7 +7487,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.0, deprecated: 16.1, renamed: "windshieldRearAndSpray")
     @available(watchOS, introduced: 9.0, deprecated: 9.1, renamed: "windshieldRearAndSpray")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "windshieldRearAndSpray")
-    static let windshieldRearAndFluid = SFSymbol(rawValue: "windshield.rear.and.fluid")
+    static var windshieldRearAndFluid: SFSymbol { .init(rawValue: "windshield.rear.and.fluid") }
 
     /// 􁀠
     /// Single Localization, 3 Layersets
@@ -7496,42 +7496,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndWiper = SFSymbol(rawValue: "windshield.rear.and.wiper")
+    static var windshieldRearAndWiper: SFSymbol { .init(rawValue: "windshield.rear.and.wiper") }
 
     /// 􁎤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wineglass = SFSymbol(rawValue: "wineglass")
+    static var wineglass: SFSymbol { .init(rawValue: "wineglass") }
 
     /// 􁎥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wineglassFill = SFSymbol(rawValue: "wineglass.fill")
+    static var wineglassFill: SFSymbol { .init(rawValue: "wineglass.fill") }
 
     /// 􁑎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wonsign = SFSymbol(rawValue: "wonsign")
+    static var wonsign: SFSymbol { .init(rawValue: "wonsign") }
 
     /// 􀎕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wrenchAdjustable = SFSymbol(rawValue: "wrench.adjustable")
+    static var wrenchAdjustable: SFSymbol { .init(rawValue: "wrench.adjustable") }
 
     /// 􀎖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wrenchAdjustableFill = SFSymbol(rawValue: "wrench.adjustable.fill")
+    static var wrenchAdjustableFill: SFSymbol { .init(rawValue: "wrench.adjustable.fill") }
 
     /// 􀾉
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -7540,12 +7540,12 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Microsoft’s Xbox.
-    static let xboxLogo = SFSymbol(rawValue: "xbox.logo")
+    static var xboxLogo: SFSymbol { .init(rawValue: "xbox.logo") }
 
     /// 􁑁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let yensign = SFSymbol(rawValue: "yensign")
+    static var yensign: SFSymbol { .init(rawValue: "yensign") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+4.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+4.1.swift
@@ -9,7 +9,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _1Brakesignal = SFSymbol(rawValue: "1.brakesignal")
+    static var _1Brakesignal: SFSymbol { .init(rawValue: "1.brakesignal") }
 
     /// 􁟐
     /// 3 Localizations, 2 Layersets
@@ -22,7 +22,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _1Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "1.lane")
+    static var _1Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "1.lane") }
 
     /// 􁟅
     /// Single Localization, 2 Layersets
@@ -30,7 +30,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _2Brakesignal = SFSymbol(rawValue: "2.brakesignal")
+    static var _2Brakesignal: SFSymbol { .init(rawValue: "2.brakesignal") }
 
     /// 􁟑
     /// 3 Localizations, 2 Layersets
@@ -43,7 +43,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _2Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "2.lane")
+    static var _2Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "2.lane") }
 
     /// 􁟒
     /// 3 Localizations, 2 Layersets
@@ -56,7 +56,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _3Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "3.lane")
+    static var _3Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "3.lane") }
 
     /// 􁟓
     /// 3 Localizations, 2 Layersets
@@ -69,7 +69,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _4Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "4.lane")
+    static var _4Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "4.lane") }
 
     /// 􁟔
     /// 3 Localizations, 2 Layersets
@@ -82,7 +82,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _5Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "5.lane")
+    static var _5Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "5.lane") }
 
     /// 􁟕
     /// 3 Localizations, 2 Layersets
@@ -95,7 +95,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _6Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "6.lane")
+    static var _6Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "6.lane") }
 
     /// 􁟖
     /// 3 Localizations, 2 Layersets
@@ -108,7 +108,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _7Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "7.lane")
+    static var _7Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "7.lane") }
 
     /// 􁟗
     /// 3 Localizations, 2 Layersets
@@ -121,7 +121,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _8Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "8.lane")
+    static var _8Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "8.lane") }
 
     /// 􁟘
     /// 3 Localizations, 2 Layersets
@@ -134,7 +134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _9Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "9.lane")
+    static var _9Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "9.lane") }
 
     /// 􁟙
     /// 3 Localizations, 2 Layersets
@@ -147,7 +147,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _10Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "10.lane")
+    static var _10Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "10.lane") }
 
     /// 􁟚
     /// 3 Localizations, 2 Layersets
@@ -160,7 +160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _11Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "11.lane")
+    static var _11Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "11.lane") }
 
     /// 􁟛
     /// 3 Localizations, 2 Layersets
@@ -173,7 +173,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _12Lane = SymbolWith2Localizations<Ar_v4_2, Hi_v4_2>(rawValue: "12.lane")
+    static var _12Lane: SymbolWith2Localizations<Ar_v4_2, Hi_v4_2> { .init(rawValue: "12.lane") }
 
     /// 􁢷
     /// Single Localization, 2 Layersets
@@ -181,7 +181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let abs = SFSymbol(rawValue: "abs")
+    static var abs: SFSymbol { .init(rawValue: "abs") }
 
     /// 􁟆
     /// Single Localization, 3 Layersets
@@ -190,7 +190,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let absBrakesignalSlash = SFSymbol(rawValue: "abs.brakesignal.slash")
+    static var absBrakesignalSlash: SFSymbol { .init(rawValue: "abs.brakesignal.slash") }
 
     /// 􁢸
     /// Single Localization, 3 Layersets
@@ -199,7 +199,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let absCircle = SFSymbol(rawValue: "abs.circle")
+    static var absCircle: SFSymbol { .init(rawValue: "abs.circle") }
 
     /// 􁢹
     /// Single Localization, 3 Layersets
@@ -208,7 +208,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let absCircleFill = SFSymbol(rawValue: "abs.circle.fill")
+    static var absCircleFill: SFSymbol { .init(rawValue: "abs.circle.fill") }
 
     /// 􁟁
     /// Single Localization, 2 Layersets
@@ -221,7 +221,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "automaticBrakesignal")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "automaticBrakesignal")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "automaticBrakesignal")
-    static let autoBrakesignal = SFSymbol(rawValue: "auto.brakesignal")
+    static var autoBrakesignal: SFSymbol { .init(rawValue: "auto.brakesignal") }
 
     /// 􁢧
     /// Single Localization, 3 Layersets
@@ -235,7 +235,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "automaticHeadlightHighBeam")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "automaticHeadlightHighBeam")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "automaticHeadlightHighBeam")
-    static let autoHeadlightHighBeam = SFSymbol(rawValue: "auto.headlight.high.beam")
+    static var autoHeadlightHighBeam: SFSymbol { .init(rawValue: "auto.headlight.high.beam") }
 
     /// 􁢨
     /// Single Localization, 3 Layersets
@@ -249,7 +249,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "automaticHeadlightHighBeamFill")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "automaticHeadlightHighBeamFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "automaticHeadlightHighBeamFill")
-    static let autoHeadlightHighBeamFill = SFSymbol(rawValue: "auto.headlight.high.beam.fill")
+    static var autoHeadlightHighBeamFill: SFSymbol { .init(rawValue: "auto.headlight.high.beam.fill") }
 
     /// 􁢩
     /// Single Localization, 3 Layersets
@@ -263,7 +263,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "automaticHeadlightLowBeam")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "automaticHeadlightLowBeam")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "automaticHeadlightLowBeam")
-    static let autoHeadlightLowBeam = SFSymbol(rawValue: "auto.headlight.low.beam")
+    static var autoHeadlightLowBeam: SFSymbol { .init(rawValue: "auto.headlight.low.beam") }
 
     /// 􁢪
     /// Single Localization, 3 Layersets
@@ -277,7 +277,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "automaticHeadlightLowBeamFill")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "automaticHeadlightLowBeamFill")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "automaticHeadlightLowBeamFill")
-    static let autoHeadlightLowBeamFill = SFSymbol(rawValue: "auto.headlight.low.beam.fill")
+    static var autoHeadlightLowBeamFill: SFSymbol { .init(rawValue: "auto.headlight.low.beam.fill") }
 
     /// 􁉢
     /// Single Localization, 3 Layersets
@@ -286,7 +286,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let autostartstop = SFSymbol(rawValue: "autostartstop")
+    static var autostartstop: SFSymbol { .init(rawValue: "autostartstop") }
 
     /// 􁉣
     /// Single Localization, 3 Layersets
@@ -295,7 +295,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let autostartstopSlash = SFSymbol(rawValue: "autostartstop.slash")
+    static var autostartstopSlash: SFSymbol { .init(rawValue: "autostartstop.slash") }
 
     /// 􁊀
     /// Single Localization, 3 Layersets
@@ -304,7 +304,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let autostartstopTrianglebadgeExclamationmark = SFSymbol(rawValue: "autostartstop.trianglebadge.exclamationmark")
+    static var autostartstopTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "autostartstop.trianglebadge.exclamationmark") }
 
     /// 􁢚
     /// Single Localization, Single Layerset
@@ -316,7 +316,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 16.4, renamed: "axle2")
     @available(watchOS, introduced: 9.1, deprecated: 9.4, renamed: "axle2")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "axle2")
-    static let axel2 = SFSymbol(rawValue: "axel.2")
+    static var axel2: SFSymbol { .init(rawValue: "axel.2") }
 
     /// 􁠡
     /// Single Localization, 2 Layersets
@@ -329,7 +329,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 16.4, renamed: "axle2FrontAndRearEngaged")
     @available(watchOS, introduced: 9.1, deprecated: 9.4, renamed: "axle2FrontAndRearEngaged")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "axle2FrontAndRearEngaged")
-    static let axel2FrontAndRearEngaged = SFSymbol(rawValue: "axel.2.front.and.rear.engaged")
+    static var axel2FrontAndRearEngaged: SFSymbol { .init(rawValue: "axel.2.front.and.rear.engaged") }
 
     /// 􁠟
     /// Single Localization, 2 Layersets
@@ -342,7 +342,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 16.4, renamed: "axle2FrontEngaged")
     @available(watchOS, introduced: 9.1, deprecated: 9.4, renamed: "axle2FrontEngaged")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "axle2FrontEngaged")
-    static let axel2FrontEngaged = SFSymbol(rawValue: "axel.2.front.engaged")
+    static var axel2FrontEngaged: SFSymbol { .init(rawValue: "axel.2.front.engaged") }
 
     /// 􁠠
     /// Single Localization, 2 Layersets
@@ -355,7 +355,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 16.4, renamed: "axle2RearEngaged")
     @available(watchOS, introduced: 9.1, deprecated: 9.4, renamed: "axle2RearEngaged")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "axle2RearEngaged")
-    static let axel2RearEngaged = SFSymbol(rawValue: "axel.2.rear.engaged")
+    static var axel2RearEngaged: SFSymbol { .init(rawValue: "axel.2.rear.engaged") }
 
     /// 􁝺
     /// Single Localization, 2 Layersets
@@ -363,7 +363,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let backpackCircle = SFSymbol(rawValue: "backpack.circle")
+    static var backpackCircle: SFSymbol { .init(rawValue: "backpack.circle") }
 
     /// 􁝻
     /// Single Localization, 3 Layersets
@@ -372,21 +372,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let backpackCircleFill = SFSymbol(rawValue: "backpack.circle.fill")
+    static var backpackCircleFill: SFSymbol { .init(rawValue: "backpack.circle.fill") }
 
     /// 􁠷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let batteryblock = SFSymbol(rawValue: "batteryblock")
+    static var batteryblock: SFSymbol { .init(rawValue: "batteryblock") }
 
     /// 􁠸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let batteryblockFill = SFSymbol(rawValue: "batteryblock.fill")
+    static var batteryblockFill: SFSymbol { .init(rawValue: "batteryblock.fill") }
 
     /// 􁠵
     /// Single Localization, 2 Layersets
@@ -394,7 +394,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let batteryblockSlash = SFSymbol(rawValue: "batteryblock.slash")
+    static var batteryblockSlash: SFSymbol { .init(rawValue: "batteryblock.slash") }
 
     /// 􁠶
     /// Single Localization, 2 Layersets
@@ -402,7 +402,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let batteryblockSlashFill = SFSymbol(rawValue: "batteryblock.slash.fill")
+    static var batteryblockSlashFill: SFSymbol { .init(rawValue: "batteryblock.slash.fill") }
 
     /// 􁝱
     /// Single Localization, 3 Layersets
@@ -411,7 +411,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltTrianglebadgeExclamationmark = SFSymbol(rawValue: "bolt.trianglebadge.exclamationmark")
+    static var boltTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "bolt.trianglebadge.exclamationmark") }
 
     /// 􁝲
     /// Single Localization, 3 Layersets
@@ -420,7 +420,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "bolt.trianglebadge.exclamationmark.fill")
+    static var boltTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "bolt.trianglebadge.exclamationmark.fill") }
 
     /// 􁢱
     /// Single Localization, 3 Layersets
@@ -429,7 +429,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carFrontWavesUp = SFSymbol(rawValue: "car.front.waves.up")
+    static var carFrontWavesUp: SFSymbol { .init(rawValue: "car.front.waves.up") }
 
     /// 􁢲
     /// Single Localization, 3 Layersets
@@ -438,14 +438,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carFrontWavesUpFill = SFSymbol(rawValue: "car.front.waves.up.fill")
+    static var carFrontWavesUpFill: SFSymbol { .init(rawValue: "car.front.waves.up.fill") }
 
     /// 􀽛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carRear = SFSymbol(rawValue: "car.rear")
+    static var carRear: SFSymbol { .init(rawValue: "car.rear") }
 
     /// 􀿈
     /// Single Localization, 2 Layersets
@@ -453,7 +453,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carRearAndTireMarks = SFSymbol(rawValue: "car.rear.and.tire.marks")
+    static var carRearAndTireMarks: SFSymbol { .init(rawValue: "car.rear.and.tire.marks") }
 
     /// 􁢦
     /// Single Localization, 3 Layersets
@@ -462,14 +462,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carRearAndTireMarksSlash = SFSymbol(rawValue: "car.rear.and.tire.marks.slash")
+    static var carRearAndTireMarksSlash: SFSymbol { .init(rawValue: "car.rear.and.tire.marks.slash") }
 
     /// 􀽜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carRearFill = SFSymbol(rawValue: "car.rear.fill")
+    static var carRearFill: SFSymbol { .init(rawValue: "car.rear.fill") }
 
     /// 􁕿
     /// Single Localization, 2 Layersets
@@ -477,7 +477,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLane = SFSymbol(rawValue: "car.rear.road.lane")
+    static var carRearRoadLane: SFSymbol { .init(rawValue: "car.rear.road.lane") }
 
     /// 􁕸
     /// Single Localization, 2 Layersets
@@ -485,7 +485,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDashed = SFSymbol(rawValue: "car.rear.road.lane.dashed")
+    static var carRearRoadLaneDashed: SFSymbol { .init(rawValue: "car.rear.road.lane.dashed") }
 
     /// 􁖝
     /// Single Localization, 3 Layersets
@@ -494,7 +494,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carRearWavesUp = SFSymbol(rawValue: "car.rear.waves.up")
+    static var carRearWavesUp: SFSymbol { .init(rawValue: "car.rear.waves.up") }
 
     /// 􁖞
     /// Single Localization, 3 Layersets
@@ -503,14 +503,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carRearWavesUpFill = SFSymbol(rawValue: "car.rear.waves.up.fill")
+    static var carRearWavesUpFill: SFSymbol { .init(rawValue: "car.rear.waves.up.fill") }
 
     /// 􁎷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSide = SFSymbol(rawValue: "car.side")
+    static var carSide: SFSymbol { .init(rawValue: "car.side") }
 
     /// 􁉬
     /// Single Localization, 2 Layersets
@@ -518,7 +518,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideAirCirculate = SFSymbol(rawValue: "car.side.air.circulate")
+    static var carSideAirCirculate: SFSymbol { .init(rawValue: "car.side.air.circulate") }
 
     /// 􁉭
     /// Single Localization, 3 Layersets
@@ -527,7 +527,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carSideAirCirculateFill = SFSymbol(rawValue: "car.side.air.circulate.fill")
+    static var carSideAirCirculateFill: SFSymbol { .init(rawValue: "car.side.air.circulate.fill") }
 
     /// 􁉮
     /// Single Localization, 2 Layersets
@@ -535,7 +535,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideAirFresh = SFSymbol(rawValue: "car.side.air.fresh")
+    static var carSideAirFresh: SFSymbol { .init(rawValue: "car.side.air.fresh") }
 
     /// 􁉯
     /// Single Localization, 2 Layersets
@@ -543,7 +543,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideAirFreshFill = SFSymbol(rawValue: "car.side.air.fresh.fill")
+    static var carSideAirFreshFill: SFSymbol { .init(rawValue: "car.side.air.fresh.fill") }
 
     /// 􁉪
     /// Single Localization, 3 Layersets
@@ -552,7 +552,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideAndExclamationmark = SFSymbol(rawValue: "car.side.and.exclamationmark")
+    static var carSideAndExclamationmark: SFSymbol { .init(rawValue: "car.side.and.exclamationmark") }
 
     /// 􁠅
     /// Single Localization, 3 Layersets
@@ -561,7 +561,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideAndExclamationmarkFill = SFSymbol(rawValue: "car.side.and.exclamationmark.fill")
+    static var carSideAndExclamationmarkFill: SFSymbol { .init(rawValue: "car.side.and.exclamationmark.fill") }
 
     /// 􁠋
     /// Single Localization, 2 Layersets
@@ -569,7 +569,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowtriangleDown = SFSymbol(rawValue: "car.side.arrowtriangle.down")
+    static var carSideArrowtriangleDown: SFSymbol { .init(rawValue: "car.side.arrowtriangle.down") }
 
     /// 􁠌
     /// Single Localization, 2 Layersets
@@ -577,7 +577,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowtriangleDownFill = SFSymbol(rawValue: "car.side.arrowtriangle.down.fill")
+    static var carSideArrowtriangleDownFill: SFSymbol { .init(rawValue: "car.side.arrowtriangle.down.fill") }
 
     /// 􁠉
     /// Single Localization, 2 Layersets
@@ -585,7 +585,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowtriangleUp = SFSymbol(rawValue: "car.side.arrowtriangle.up")
+    static var carSideArrowtriangleUp: SFSymbol { .init(rawValue: "car.side.arrowtriangle.up") }
 
     /// 􁠇
     /// Single Localization, 2 Layersets
@@ -593,7 +593,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowtriangleUpArrowtriangleDown = SFSymbol(rawValue: "car.side.arrowtriangle.up.arrowtriangle.down")
+    static var carSideArrowtriangleUpArrowtriangleDown: SFSymbol { .init(rawValue: "car.side.arrowtriangle.up.arrowtriangle.down") }
 
     /// 􁠈
     /// Single Localization, 3 Layersets
@@ -602,7 +602,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carSideArrowtriangleUpArrowtriangleDownFill = SFSymbol(rawValue: "car.side.arrowtriangle.up.arrowtriangle.down.fill")
+    static var carSideArrowtriangleUpArrowtriangleDownFill: SFSymbol { .init(rawValue: "car.side.arrowtriangle.up.arrowtriangle.down.fill") }
 
     /// 􁠊
     /// Single Localization, 3 Layersets
@@ -611,14 +611,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carSideArrowtriangleUpFill = SFSymbol(rawValue: "car.side.arrowtriangle.up.fill")
+    static var carSideArrowtriangleUpFill: SFSymbol { .init(rawValue: "car.side.arrowtriangle.up.fill") }
 
     /// 􁎸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideFill = SFSymbol(rawValue: "car.side.fill")
+    static var carSideFill: SFSymbol { .init(rawValue: "car.side.fill") }
 
     /// 􁉤
     /// Single Localization, 2 Layersets
@@ -626,7 +626,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideFrontOpen = SFSymbol(rawValue: "car.side.front.open")
+    static var carSideFrontOpen: SFSymbol { .init(rawValue: "car.side.front.open") }
 
     /// 􁉥
     /// Single Localization, 2 Layersets
@@ -634,7 +634,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideFrontOpenFill = SFSymbol(rawValue: "car.side.front.open.fill")
+    static var carSideFrontOpenFill: SFSymbol { .init(rawValue: "car.side.front.open.fill") }
 
     /// 􁉦
     /// Single Localization, 2 Layersets
@@ -642,7 +642,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideRearOpen = SFSymbol(rawValue: "car.side.rear.open")
+    static var carSideRearOpen: SFSymbol { .init(rawValue: "car.side.rear.open") }
 
     /// 􁉧
     /// Single Localization, 2 Layersets
@@ -650,7 +650,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carSideRearOpenFill = SFSymbol(rawValue: "car.side.rear.open.fill")
+    static var carSideRearOpenFill: SFSymbol { .init(rawValue: "car.side.rear.open.fill") }
 
     /// 􁀐
     /// Single Localization, 2 Layersets
@@ -658,7 +658,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearLeftAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.and.rear.right.open")
+    static var carTopDoorFrontLeftAndFrontRightAndRearLeftAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.and.rear.right.open") }
 
     /// 􁀑
     /// Single Localization, 2 Layersets
@@ -666,7 +666,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearLeftAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.and.rear.right.open.fill")
+    static var carTopDoorFrontLeftAndFrontRightAndRearLeftAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.and.rear.right.open.fill") }
 
     /// 􁡜
     /// Single Localization, 2 Layersets
@@ -674,7 +674,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearLeftOpen = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.open")
+    static var carTopDoorFrontLeftAndFrontRightAndRearLeftOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.open") }
 
     /// 􁡝
     /// Single Localization, 2 Layersets
@@ -682,7 +682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearLeftOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.open.fill")
+    static var carTopDoorFrontLeftAndFrontRightAndRearLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.left.open.fill") }
 
     /// 􁡞
     /// Single Localization, 2 Layersets
@@ -690,7 +690,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.right.open")
+    static var carTopDoorFrontLeftAndFrontRightAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.right.open") }
 
     /// 􁡟
     /// Single Localization, 2 Layersets
@@ -698,7 +698,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.and.rear.right.open.fill")
+    static var carTopDoorFrontLeftAndFrontRightAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.and.rear.right.open.fill") }
 
     /// 􁡐
     /// Single Localization, 2 Layersets
@@ -706,7 +706,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightOpen = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.open")
+    static var carTopDoorFrontLeftAndFrontRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.open") }
 
     /// 􁡑
     /// Single Localization, 2 Layersets
@@ -714,7 +714,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndFrontRightOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.front.right.open.fill")
+    static var carTopDoorFrontLeftAndFrontRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.front.right.open.fill") }
 
     /// 􁡠
     /// Single Localization, 2 Layersets
@@ -722,7 +722,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearLeftAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.left.and.rear.left.and.rear.right.open")
+    static var carTopDoorFrontLeftAndRearLeftAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.left.and.rear.right.open") }
 
     /// 􁡡
     /// Single Localization, 2 Layersets
@@ -730,7 +730,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearLeftAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.rear.left.and.rear.right.open.fill")
+    static var carTopDoorFrontLeftAndRearLeftAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.left.and.rear.right.open.fill") }
 
     /// 􁡔
     /// Single Localization, 2 Layersets
@@ -738,7 +738,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearLeftOpen = SFSymbol(rawValue: "car.top.door.front.left.and.rear.left.open")
+    static var carTopDoorFrontLeftAndRearLeftOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.left.open") }
 
     /// 􁡕
     /// Single Localization, 2 Layersets
@@ -746,7 +746,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearLeftOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.rear.left.open.fill")
+    static var carTopDoorFrontLeftAndRearLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.left.open.fill") }
 
     /// 􁡘
     /// Single Localization, 2 Layersets
@@ -754,7 +754,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.left.and.rear.right.open")
+    static var carTopDoorFrontLeftAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.right.open") }
 
     /// 􁡙
     /// Single Localization, 2 Layersets
@@ -762,7 +762,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.left.and.rear.right.open.fill")
+    static var carTopDoorFrontLeftAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.and.rear.right.open.fill") }
 
     /// 􀿂
     /// Single Localization, 2 Layersets
@@ -770,7 +770,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftOpen = SFSymbol(rawValue: "car.top.door.front.left.open")
+    static var carTopDoorFrontLeftOpen: SFSymbol { .init(rawValue: "car.top.door.front.left.open") }
 
     /// 􀿃
     /// Single Localization, 2 Layersets
@@ -778,7 +778,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontLeftOpenFill = SFSymbol(rawValue: "car.top.door.front.left.open.fill")
+    static var carTopDoorFrontLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.left.open.fill") }
 
     /// 􁡢
     /// Single Localization, 2 Layersets
@@ -786,7 +786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearLeftAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.right.and.rear.left.and.rear.right.open")
+    static var carTopDoorFrontRightAndRearLeftAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.left.and.rear.right.open") }
 
     /// 􁡣
     /// Single Localization, 2 Layersets
@@ -794,7 +794,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearLeftAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.right.and.rear.left.and.rear.right.open.fill")
+    static var carTopDoorFrontRightAndRearLeftAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.left.and.rear.right.open.fill") }
 
     /// 􁡚
     /// Single Localization, 2 Layersets
@@ -802,7 +802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearLeftOpen = SFSymbol(rawValue: "car.top.door.front.right.and.rear.left.open")
+    static var carTopDoorFrontRightAndRearLeftOpen: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.left.open") }
 
     /// 􁡛
     /// Single Localization, 2 Layersets
@@ -810,7 +810,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearLeftOpenFill = SFSymbol(rawValue: "car.top.door.front.right.and.rear.left.open.fill")
+    static var carTopDoorFrontRightAndRearLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.left.open.fill") }
 
     /// 􁡖
     /// Single Localization, 2 Layersets
@@ -818,7 +818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearRightOpen = SFSymbol(rawValue: "car.top.door.front.right.and.rear.right.open")
+    static var carTopDoorFrontRightAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.right.open") }
 
     /// 􁡗
     /// Single Localization, 2 Layersets
@@ -826,7 +826,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.front.right.and.rear.right.open.fill")
+    static var carTopDoorFrontRightAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.right.and.rear.right.open.fill") }
 
     /// 􁡊
     /// Single Localization, 2 Layersets
@@ -834,7 +834,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightOpen = SFSymbol(rawValue: "car.top.door.front.right.open")
+    static var carTopDoorFrontRightOpen: SFSymbol { .init(rawValue: "car.top.door.front.right.open") }
 
     /// 􁡋
     /// Single Localization, 2 Layersets
@@ -842,7 +842,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorFrontRightOpenFill = SFSymbol(rawValue: "car.top.door.front.right.open.fill")
+    static var carTopDoorFrontRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.front.right.open.fill") }
 
     /// 􁡒
     /// Single Localization, 2 Layersets
@@ -850,7 +850,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearLeftAndRearRightOpen = SFSymbol(rawValue: "car.top.door.rear.left.and.rear.right.open")
+    static var carTopDoorRearLeftAndRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.rear.left.and.rear.right.open") }
 
     /// 􁡓
     /// Single Localization, 2 Layersets
@@ -858,7 +858,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearLeftAndRearRightOpenFill = SFSymbol(rawValue: "car.top.door.rear.left.and.rear.right.open.fill")
+    static var carTopDoorRearLeftAndRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.rear.left.and.rear.right.open.fill") }
 
     /// 􁡌
     /// Single Localization, 2 Layersets
@@ -866,7 +866,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearLeftOpen = SFSymbol(rawValue: "car.top.door.rear.left.open")
+    static var carTopDoorRearLeftOpen: SFSymbol { .init(rawValue: "car.top.door.rear.left.open") }
 
     /// 􁡍
     /// Single Localization, 2 Layersets
@@ -874,7 +874,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearLeftOpenFill = SFSymbol(rawValue: "car.top.door.rear.left.open.fill")
+    static var carTopDoorRearLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.rear.left.open.fill") }
 
     /// 􁡎
     /// Single Localization, 2 Layersets
@@ -882,7 +882,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearRightOpen = SFSymbol(rawValue: "car.top.door.rear.right.open")
+    static var carTopDoorRearRightOpen: SFSymbol { .init(rawValue: "car.top.door.rear.right.open") }
 
     /// 􁡏
     /// Single Localization, 2 Layersets
@@ -890,7 +890,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let carTopDoorRearRightOpenFill = SFSymbol(rawValue: "car.top.door.rear.right.open.fill")
+    static var carTopDoorRearRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.rear.right.open.fill") }
 
     /// 􁕾
     /// Single Localization, 2 Layersets
@@ -898,7 +898,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedArrowtriangleInward = SFSymbol(rawValue: "car.top.lane.dashed.arrowtriangle.inward")
+    static var carTopLaneDashedArrowtriangleInward: SFSymbol { .init(rawValue: "car.top.lane.dashed.arrowtriangle.inward") }
 
     /// 􁖃
     /// Single Localization, 2 Layersets
@@ -906,7 +906,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedArrowtriangleInwardFill = SFSymbol(rawValue: "car.top.lane.dashed.arrowtriangle.inward.fill")
+    static var carTopLaneDashedArrowtriangleInwardFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.arrowtriangle.inward.fill") }
 
     /// 􁖄
     /// Single Localization, 2 Layersets
@@ -914,7 +914,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedBadgeSteeringwheel = SFSymbol(rawValue: "car.top.lane.dashed.badge.steeringwheel")
+    static var carTopLaneDashedBadgeSteeringwheel: SFSymbol { .init(rawValue: "car.top.lane.dashed.badge.steeringwheel") }
 
     /// 􁖅
     /// Single Localization, 2 Layersets
@@ -922,7 +922,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedBadgeSteeringwheelFill = SFSymbol(rawValue: "car.top.lane.dashed.badge.steeringwheel.fill")
+    static var carTopLaneDashedBadgeSteeringwheelFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.badge.steeringwheel.fill") }
 
     /// 􁢯
     /// Single Localization, 3 Layersets
@@ -931,7 +931,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopLaneDashedDepartureLeft = SFSymbol(rawValue: "car.top.lane.dashed.departure.left")
+    static var carTopLaneDashedDepartureLeft: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.left") }
 
     /// 􁢰
     /// Single Localization, 3 Layersets
@@ -940,7 +940,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopLaneDashedDepartureLeftFill = SFSymbol(rawValue: "car.top.lane.dashed.departure.left.fill")
+    static var carTopLaneDashedDepartureLeftFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.left.fill") }
 
     /// 􁕼
     /// Single Localization, 3 Layersets
@@ -949,7 +949,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopLaneDashedDepartureRight = SFSymbol(rawValue: "car.top.lane.dashed.departure.right")
+    static var carTopLaneDashedDepartureRight: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.right") }
 
     /// 􁕽
     /// Single Localization, 3 Layersets
@@ -958,7 +958,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopLaneDashedDepartureRightFill = SFSymbol(rawValue: "car.top.lane.dashed.departure.right.fill")
+    static var carTopLaneDashedDepartureRightFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.right.fill") }
 
     /// 􁖵
     /// Single Localization, 3 Layersets
@@ -967,7 +967,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesFront = SFSymbol(rawValue: "car.top.radiowaves.front")
+    static var carTopRadiowavesFront: SFSymbol { .init(rawValue: "car.top.radiowaves.front") }
 
     /// 􁖹
     /// Single Localization, 3 Layersets
@@ -976,7 +976,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesFrontFill = SFSymbol(rawValue: "car.top.radiowaves.front.fill")
+    static var carTopRadiowavesFrontFill: SFSymbol { .init(rawValue: "car.top.radiowaves.front.fill") }
 
     /// 􁖶
     /// Single Localization, 3 Layersets
@@ -985,7 +985,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRear = SFSymbol(rawValue: "car.top.radiowaves.rear")
+    static var carTopRadiowavesRear: SFSymbol { .init(rawValue: "car.top.radiowaves.rear") }
 
     /// 􁖺
     /// Single Localization, 3 Layersets
@@ -994,7 +994,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearFill = SFSymbol(rawValue: "car.top.radiowaves.rear.fill")
+    static var carTopRadiowavesRearFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.fill") }
 
     /// 􁖴
     /// Single Localization, 3 Layersets
@@ -1003,7 +1003,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearLeft = SFSymbol(rawValue: "car.top.radiowaves.rear.left")
+    static var carTopRadiowavesRearLeft: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left") }
 
     /// 􁢠
     /// Single Localization, 3 Layersets
@@ -1012,7 +1012,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearLeftAndRearRight = SFSymbol(rawValue: "car.top.radiowaves.rear.left.and.rear.right")
+    static var carTopRadiowavesRearLeftAndRearRight: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left.and.rear.right") }
 
     /// 􁢡
     /// Single Localization, 3 Layersets
@@ -1021,7 +1021,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearLeftAndRearRightFill = SFSymbol(rawValue: "car.top.radiowaves.rear.left.and.rear.right.fill")
+    static var carTopRadiowavesRearLeftAndRearRightFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left.and.rear.right.fill") }
 
     /// 􁖸
     /// Single Localization, 3 Layersets
@@ -1030,7 +1030,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearLeftFill = SFSymbol(rawValue: "car.top.radiowaves.rear.left.fill")
+    static var carTopRadiowavesRearLeftFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left.fill") }
 
     /// 􁖳
     /// Single Localization, 3 Layersets
@@ -1039,7 +1039,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRight = SFSymbol(rawValue: "car.top.radiowaves.rear.right")
+    static var carTopRadiowavesRearRight: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right") }
 
     /// 􁖷
     /// Single Localization, 3 Layersets
@@ -1048,7 +1048,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRightFill = SFSymbol(rawValue: "car.top.radiowaves.rear.right.fill")
+    static var carTopRadiowavesRearRightFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.fill") }
 
     /// 􁣃
     /// Single Localization, 3 Layersets
@@ -1057,7 +1057,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartDotsScatter = SFSymbol(rawValue: "chart.dots.scatter")
+    static var chartDotsScatter: SFSymbol { .init(rawValue: "chart.dots.scatter") }
 
     /// 􁝾
     /// Single Localization, 2 Layersets
@@ -1065,7 +1065,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let crossCaseCircle = SFSymbol(rawValue: "cross.case.circle")
+    static var crossCaseCircle: SFSymbol { .init(rawValue: "cross.case.circle") }
 
     /// 􁝿
     /// Single Localization, 3 Layersets
@@ -1074,7 +1074,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let crossCaseCircleFill = SFSymbol(rawValue: "cross.case.circle.fill")
+    static var crossCaseCircleFill: SFSymbol { .init(rawValue: "cross.case.circle.fill") }
 
     /// 􁢏
     /// Single Localization, 3 Layersets
@@ -1083,21 +1083,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ellipsisViewfinder = SFSymbol(rawValue: "ellipsis.viewfinder")
+    static var ellipsisViewfinder: SFSymbol { .init(rawValue: "ellipsis.viewfinder") }
 
     /// 􀾰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let engineCombustion = SFSymbol(rawValue: "engine.combustion")
+    static var engineCombustion: SFSymbol { .init(rawValue: "engine.combustion") }
 
     /// 􀾱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let engineCombustionFill = SFSymbol(rawValue: "engine.combustion.fill")
+    static var engineCombustionFill: SFSymbol { .init(rawValue: "engine.combustion.fill") }
 
     /// 􀿁
     /// Single Localization, 2 Layersets
@@ -1105,7 +1105,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let exclamationmarkTransmission = SFSymbol(rawValue: "exclamationmark.transmission")
+    static var exclamationmarkTransmission: SFSymbol { .init(rawValue: "exclamationmark.transmission") }
 
     /// 􁟺
     /// Single Localization, 2 Layersets
@@ -1113,7 +1113,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRunSquareStack = SFSymbol(rawValue: "figure.run.square.stack")
+    static var figureRunSquareStack: SFSymbol { .init(rawValue: "figure.run.square.stack") }
 
     /// 􁟻
     /// Single Localization, 3 Layersets
@@ -1122,7 +1122,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRunSquareStackFill = SFSymbol(rawValue: "figure.run.square.stack.fill")
+    static var figureRunSquareStackFill: SFSymbol { .init(rawValue: "figure.run.square.stack.fill") }
 
     /// 􀿦
     /// Single Localization, 2 Layersets
@@ -1130,7 +1130,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let figureSeatedSeatbelt = SFSymbol(rawValue: "figure.seated.seatbelt")
+    static var figureSeatedSeatbelt: SFSymbol { .init(rawValue: "figure.seated.seatbelt") }
 
     /// 􁊂
     /// Single Localization, 3 Layersets
@@ -1139,7 +1139,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let figureSeatedSeatbeltAndAirbagOff = SFSymbol(rawValue: "figure.seated.seatbelt.and.airbag.off")
+    static var figureSeatedSeatbeltAndAirbagOff: SFSymbol { .init(rawValue: "figure.seated.seatbelt.and.airbag.off") }
 
     /// 􁞛
     /// Single Localization, 3 Layersets
@@ -1148,7 +1148,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let figureSeatedSeatbeltAndAirbagOn = SFSymbol(rawValue: "figure.seated.seatbelt.and.airbag.on")
+    static var figureSeatedSeatbeltAndAirbagOn: SFSymbol { .init(rawValue: "figure.seated.seatbelt.and.airbag.on") }
 
     /// 􁁶
     /// Single Localization, Single Layerset
@@ -1160,7 +1160,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "figureSeatedSideAirDistributionLower")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "figureSeatedSideAirDistributionLower")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "figureSeatedSideAirDistributionLower")
-    static let figureSeatedSideAirLower = SFSymbol(rawValue: "figure.seated.side.air.lower")
+    static var figureSeatedSideAirLower: SFSymbol { .init(rawValue: "figure.seated.side.air.lower") }
 
     /// 􁁵
     /// Single Localization, Single Layerset
@@ -1172,7 +1172,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "figureSeatedSideAirDistributionMiddle")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "figureSeatedSideAirDistributionMiddle")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "figureSeatedSideAirDistributionMiddle")
-    static let figureSeatedSideAirUpper = SFSymbol(rawValue: "figure.seated.side.air.upper")
+    static var figureSeatedSideAirUpper: SFSymbol { .init(rawValue: "figure.seated.side.air.upper") }
 
     /// 􁁸
     /// Single Localization, Single Layerset
@@ -1184,7 +1184,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "figureSeatedSideAirDistributionMiddleAndLower")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "figureSeatedSideAirDistributionMiddleAndLower")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "figureSeatedSideAirDistributionMiddleAndLower")
-    static let figureSeatedSideAirUpperAndLower = SFSymbol(rawValue: "figure.seated.side.air.upper.and.lower")
+    static var figureSeatedSideAirUpperAndLower: SFSymbol { .init(rawValue: "figure.seated.side.air.upper.and.lower") }
 
     /// 􁁷
     /// Single Localization, Single Layerset
@@ -1196,7 +1196,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 17.0, renamed: "figureSeatedSideAirDistributionUpper")
     @available(watchOS, introduced: 9.1, deprecated: 10.0, renamed: "figureSeatedSideAirDistributionUpper")
     @available(visionOS, introduced: 1.0, deprecated: 1.0, renamed: "figureSeatedSideAirDistributionUpper")
-    static let figureSeatedSideAirWindshield = SFSymbol(rawValue: "figure.seated.side.air.windshield")
+    static var figureSeatedSideAirWindshield: SFSymbol { .init(rawValue: "figure.seated.side.air.windshield") }
 
     /// 􁊍
     /// Single Localization, 3 Layersets
@@ -1210,7 +1210,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "figureSeatedSideLeftAirbagOff")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "figureSeatedSideLeftAirbagOff")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirbagOff")
-    static let figureSeatedSideAirbagOff = SFSymbol(rawValue: "figure.seated.side.airbag.off")
+    static var figureSeatedSideAirbagOff: SFSymbol { .init(rawValue: "figure.seated.side.airbag.off") }
 
     /// 􁉻
     /// Single Localization, 3 Layersets
@@ -1224,7 +1224,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "figureSeatedSideLeftAirbagOff2")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "figureSeatedSideLeftAirbagOff2")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirbagOff2")
-    static let figureSeatedSideAirbagOff2 = SFSymbol(rawValue: "figure.seated.side.airbag.off.2")
+    static var figureSeatedSideAirbagOff2: SFSymbol { .init(rawValue: "figure.seated.side.airbag.off.2") }
 
     /// 􀿧
     /// Single Localization, 3 Layersets
@@ -1238,7 +1238,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "figureSeatedSideLeftAirbagOn")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "figureSeatedSideLeftAirbagOn")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirbagOn")
-    static let figureSeatedSideAirbagOn = SFSymbol(rawValue: "figure.seated.side.airbag.on")
+    static var figureSeatedSideAirbagOn: SFSymbol { .init(rawValue: "figure.seated.side.airbag.on") }
 
     /// 􁞚
     /// Single Localization, 3 Layersets
@@ -1252,7 +1252,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "figureSeatedSideLeftAirbagOn2")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "figureSeatedSideLeftAirbagOn2")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirbagOn2")
-    static let figureSeatedSideAirbagOn2 = SFSymbol(rawValue: "figure.seated.side.airbag.on.2")
+    static var figureSeatedSideAirbagOn2: SFSymbol { .init(rawValue: "figure.seated.side.airbag.on.2") }
 
     /// 􁁹
     /// Single Localization, 2 Layersets
@@ -1265,7 +1265,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWaves")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWaves")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWaves")
-    static let figureSeatedSideWindshieldFrontAndHeatWaves = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves")
+    static var figureSeatedSideWindshieldFrontAndHeatWaves: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves") }
 
     /// 􁞱
     /// Single Localization, 2 Layersets
@@ -1273,7 +1273,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fishCircle = SFSymbol(rawValue: "fish.circle")
+    static var fishCircle: SFSymbol { .init(rawValue: "fish.circle") }
 
     /// 􁞲
     /// Single Localization, 3 Layersets
@@ -1282,7 +1282,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fishCircleFill = SFSymbol(rawValue: "fish.circle.fill")
+    static var fishCircleFill: SFSymbol { .init(rawValue: "fish.circle.fill") }
 
     /// 􁝼
     /// Single Localization, 2 Layersets
@@ -1295,7 +1295,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "flagPatternCheckeredCircle")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "flagPatternCheckeredCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "flagPatternCheckeredCircle")
-    static let flagCheckeredCircle = SFSymbol(rawValue: "flag.checkered.circle")
+    static var flagCheckeredCircle: SFSymbol { .init(rawValue: "flag.checkered.circle") }
 
     /// 􁝽
     /// Single Localization, 3 Layersets
@@ -1309,21 +1309,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "flagPatternCheckeredCircleFill")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "flagPatternCheckeredCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "flagPatternCheckeredCircleFill")
-    static let flagCheckeredCircleFill = SFSymbol(rawValue: "flag.checkered.circle.fill")
+    static var flagCheckeredCircleFill: SFSymbol { .init(rawValue: "flag.checkered.circle.fill") }
 
     /// 􁠴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fluidTransmission = SFSymbol(rawValue: "fluid.transmission")
+    static var fluidTransmission: SFSymbol { .init(rawValue: "fluid.transmission") }
 
     /// 􁀱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let glowplug = SFSymbol(rawValue: "glowplug")
+    static var glowplug: SFSymbol { .init(rawValue: "glowplug") }
 
     /// 􁝌
     /// Single Localization, 3 Layersets
@@ -1332,7 +1332,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedApp = SFSymbol(rawValue: "hand.raised.app")
+    static var handRaisedApp: SFSymbol { .init(rawValue: "hand.raised.app") }
 
     /// 􁝍
     /// Single Localization, 3 Layersets
@@ -1341,7 +1341,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handRaisedAppFill = SFSymbol(rawValue: "hand.raised.app.fill")
+    static var handRaisedAppFill: SFSymbol { .init(rawValue: "hand.raised.app.fill") }
 
     /// 􁟂
     /// Single Localization, 2 Layersets
@@ -1349,7 +1349,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handRaisedBrakesignal = SFSymbol(rawValue: "hand.raised.brakesignal")
+    static var handRaisedBrakesignal: SFSymbol { .init(rawValue: "hand.raised.brakesignal") }
 
     /// 􁟃
     /// Single Localization, 2 Layersets
@@ -1357,21 +1357,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handRaisedBrakesignalSlash = SFSymbol(rawValue: "hand.raised.brakesignal.slash")
+    static var handRaisedBrakesignalSlash: SFSymbol { .init(rawValue: "hand.raised.brakesignal.slash") }
 
     /// 􁞸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handbag = SFSymbol(rawValue: "handbag")
+    static var handbag: SFSymbol { .init(rawValue: "handbag") }
 
     /// 􁞹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handbagFill = SFSymbol(rawValue: "handbag.fill")
+    static var handbagFill: SFSymbol { .init(rawValue: "handbag.fill") }
 
     /// 􁀰
     /// Single Localization, 3 Layersets
@@ -1380,7 +1380,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hazardsign = SFSymbol(rawValue: "hazardsign")
+    static var hazardsign: SFSymbol { .init(rawValue: "hazardsign") }
 
     /// 􁕣
     /// Single Localization, 3 Layersets
@@ -1389,7 +1389,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hazardsignFill = SFSymbol(rawValue: "hazardsign.fill")
+    static var hazardsignFill: SFSymbol { .init(rawValue: "hazardsign.fill") }
 
     /// 􀾺
     /// Single Localization, 2 Layersets
@@ -1397,7 +1397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightDaytime = SFSymbol(rawValue: "headlight.daytime")
+    static var headlightDaytime: SFSymbol { .init(rawValue: "headlight.daytime") }
 
     /// 􀾻
     /// Single Localization, 2 Layersets
@@ -1405,7 +1405,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightDaytimeFill = SFSymbol(rawValue: "headlight.daytime.fill")
+    static var headlightDaytimeFill: SFSymbol { .init(rawValue: "headlight.daytime.fill") }
 
     /// 􀾶
     /// Single Localization, 3 Layersets
@@ -1414,7 +1414,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightFog = SFSymbol(rawValue: "headlight.fog")
+    static var headlightFog: SFSymbol { .init(rawValue: "headlight.fog") }
 
     /// 􀾷
     /// Single Localization, 3 Layersets
@@ -1423,7 +1423,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let headlightFogFill = SFSymbol(rawValue: "headlight.fog.fill")
+    static var headlightFogFill: SFSymbol { .init(rawValue: "headlight.fog.fill") }
 
     /// 􁟉
     /// Single Localization, 3 Layersets
@@ -1432,14 +1432,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heatElementWindshield = SFSymbol(rawValue: "heat.element.windshield")
+    static var heatElementWindshield: SFSymbol { .init(rawValue: "heat.element.windshield") }
 
     /// 􁘱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let houseAndFlag = SFSymbol(rawValue: "house.and.flag")
+    static var houseAndFlag: SFSymbol { .init(rawValue: "house.and.flag") }
 
     /// 􁞈
     /// Single Localization, 2 Layersets
@@ -1447,7 +1447,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let houseAndFlagCircle = SFSymbol(rawValue: "house.and.flag.circle")
+    static var houseAndFlagCircle: SFSymbol { .init(rawValue: "house.and.flag.circle") }
 
     /// 􁞉
     /// Single Localization, 3 Layersets
@@ -1456,21 +1456,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseAndFlagCircleFill = SFSymbol(rawValue: "house.and.flag.circle.fill")
+    static var houseAndFlagCircleFill: SFSymbol { .init(rawValue: "house.and.flag.circle.fill") }
 
     /// 􁘲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let houseAndFlagFill = SFSymbol(rawValue: "house.and.flag.fill")
+    static var houseAndFlagFill: SFSymbol { .init(rawValue: "house.and.flag.fill") }
 
     /// 􁘭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let houseLodge = SFSymbol(rawValue: "house.lodge")
+    static var houseLodge: SFSymbol { .init(rawValue: "house.lodge") }
 
     /// 􁞆
     /// Single Localization, 2 Layersets
@@ -1478,7 +1478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let houseLodgeCircle = SFSymbol(rawValue: "house.lodge.circle")
+    static var houseLodgeCircle: SFSymbol { .init(rawValue: "house.lodge.circle") }
 
     /// 􁞇
     /// Single Localization, 3 Layersets
@@ -1487,14 +1487,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseLodgeCircleFill = SFSymbol(rawValue: "house.lodge.circle.fill")
+    static var houseLodgeCircleFill: SFSymbol { .init(rawValue: "house.lodge.circle.fill") }
 
     /// 􁘮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let houseLodgeFill = SFSymbol(rawValue: "house.lodge.fill")
+    static var houseLodgeFill: SFSymbol { .init(rawValue: "house.lodge.fill") }
 
     /// 􁟊
     /// Single Localization, 2 Layersets
@@ -1502,7 +1502,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let infoWindshield = SFSymbol(rawValue: "info.windshield")
+    static var infoWindshield: SFSymbol { .init(rawValue: "info.windshield") }
 
     /// 􁋟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1517,7 +1517,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 18.0, renamed: "ipadLandscapeAndIphoneSlash")
     @available(watchOS, introduced: 9.1, deprecated: 11.0, renamed: "ipadLandscapeAndIphoneSlash")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "ipadLandscapeAndIphoneSlash")
-    static let ipadAndIphoneSlash = SFSymbol(rawValue: "ipad.and.iphone.slash")
+    static var ipadAndIphoneSlash: SFSymbol { .init(rawValue: "ipad.and.iphone.slash") }
 
     /// 􀟟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1527,7 +1527,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1 = SFSymbol(rawValue: "ipad.gen1")
+    static var ipadGen1: SFSymbol { .init(rawValue: "ipad.gen1") }
 
     /// 􀴒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1538,7 +1538,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1BadgePlay = SFSymbol(rawValue: "ipad.gen1.badge.play")
+    static var ipadGen1BadgePlay: SFSymbol { .init(rawValue: "ipad.gen1.badge.play") }
 
     /// 􀥓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1548,7 +1548,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1Landscape = SFSymbol(rawValue: "ipad.gen1.landscape")
+    static var ipadGen1Landscape: SFSymbol { .init(rawValue: "ipad.gen1.landscape") }
 
     /// 􀵑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1559,7 +1559,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1LandscapeBadgePlay = SFSymbol(rawValue: "ipad.gen1.landscape.badge.play")
+    static var ipadGen1LandscapeBadgePlay: SFSymbol { .init(rawValue: "ipad.gen1.landscape.badge.play") }
 
     /// 􁟧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1569,7 +1569,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2 = SFSymbol(rawValue: "ipad.gen2")
+    static var ipadGen2: SFSymbol { .init(rawValue: "ipad.gen2") }
 
     /// 􁟨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1580,7 +1580,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2BadgePlay = SFSymbol(rawValue: "ipad.gen2.badge.play")
+    static var ipadGen2BadgePlay: SFSymbol { .init(rawValue: "ipad.gen2.badge.play") }
 
     /// 􁟩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1590,7 +1590,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2Landscape = SFSymbol(rawValue: "ipad.gen2.landscape")
+    static var ipadGen2Landscape: SFSymbol { .init(rawValue: "ipad.gen2.landscape") }
 
     /// 􁟪
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1601,7 +1601,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2LandscapeBadgePlay = SFSymbol(rawValue: "ipad.gen2.landscape.badge.play")
+    static var ipadGen2LandscapeBadgePlay: SFSymbol { .init(rawValue: "ipad.gen2.landscape.badge.play") }
 
     /// 􀟝
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1611,7 +1611,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1 = SFSymbol(rawValue: "iphone.gen1")
+    static var iphoneGen1: SFSymbol { .init(rawValue: "iphone.gen1") }
 
     /// 􀐶
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1622,7 +1622,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1BadgePlay = SFSymbol(rawValue: "iphone.gen1.badge.play")
+    static var iphoneGen1BadgePlay: SFSymbol { .init(rawValue: "iphone.gen1.badge.play") }
 
     /// 􁄥
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1632,7 +1632,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1Circle = SFSymbol(rawValue: "iphone.gen1.circle")
+    static var iphoneGen1Circle: SFSymbol { .init(rawValue: "iphone.gen1.circle") }
 
     /// 􁄦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1643,7 +1643,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1CircleFill = SFSymbol(rawValue: "iphone.gen1.circle.fill")
+    static var iphoneGen1CircleFill: SFSymbol { .init(rawValue: "iphone.gen1.circle.fill") }
 
     /// 􀴎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1653,7 +1653,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1Landscape = SFSymbol(rawValue: "iphone.gen1.landscape")
+    static var iphoneGen1Landscape: SFSymbol { .init(rawValue: "iphone.gen1.landscape") }
 
     /// 􀡆
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1664,7 +1664,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1RadiowavesLeftAndRight = SFSymbol(rawValue: "iphone.gen1.radiowaves.left.and.right")
+    static var iphoneGen1RadiowavesLeftAndRight: SFSymbol { .init(rawValue: "iphone.gen1.radiowaves.left.and.right") }
 
     /// 􁅚
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1675,7 +1675,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1RadiowavesLeftAndRightCircle = SFSymbol(rawValue: "iphone.gen1.radiowaves.left.and.right.circle")
+    static var iphoneGen1RadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "iphone.gen1.radiowaves.left.and.right.circle") }
 
     /// 􁅛
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1686,7 +1686,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1RadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "iphone.gen1.radiowaves.left.and.right.circle.fill")
+    static var iphoneGen1RadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "iphone.gen1.radiowaves.left.and.right.circle.fill") }
 
     /// 􀨴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1696,7 +1696,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1Slash = SFSymbol(rawValue: "iphone.gen1.slash")
+    static var iphoneGen1Slash: SFSymbol { .init(rawValue: "iphone.gen1.slash") }
 
     /// 􁄧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1706,7 +1706,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1SlashCircle = SFSymbol(rawValue: "iphone.gen1.slash.circle")
+    static var iphoneGen1SlashCircle: SFSymbol { .init(rawValue: "iphone.gen1.slash.circle") }
 
     /// 􁄨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1717,7 +1717,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1SlashCircleFill = SFSymbol(rawValue: "iphone.gen1.slash.circle.fill")
+    static var iphoneGen1SlashCircleFill: SFSymbol { .init(rawValue: "iphone.gen1.slash.circle.fill") }
 
     /// 􁟜
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1727,7 +1727,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2 = SFSymbol(rawValue: "iphone.gen2")
+    static var iphoneGen2: SFSymbol { .init(rawValue: "iphone.gen2") }
 
     /// 􁟦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1738,7 +1738,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2BadgePlay = SFSymbol(rawValue: "iphone.gen2.badge.play")
+    static var iphoneGen2BadgePlay: SFSymbol { .init(rawValue: "iphone.gen2.badge.play") }
 
     /// 􁟝
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1748,7 +1748,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2Circle = SFSymbol(rawValue: "iphone.gen2.circle")
+    static var iphoneGen2Circle: SFSymbol { .init(rawValue: "iphone.gen2.circle") }
 
     /// 􁟞
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1759,7 +1759,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2CircleFill = SFSymbol(rawValue: "iphone.gen2.circle.fill")
+    static var iphoneGen2CircleFill: SFSymbol { .init(rawValue: "iphone.gen2.circle.fill") }
 
     /// 􁟟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1769,7 +1769,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2Landscape = SFSymbol(rawValue: "iphone.gen2.landscape")
+    static var iphoneGen2Landscape: SFSymbol { .init(rawValue: "iphone.gen2.landscape") }
 
     /// 􁟠
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1780,7 +1780,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2RadiowavesLeftAndRight = SFSymbol(rawValue: "iphone.gen2.radiowaves.left.and.right")
+    static var iphoneGen2RadiowavesLeftAndRight: SFSymbol { .init(rawValue: "iphone.gen2.radiowaves.left.and.right") }
 
     /// 􁟡
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1791,7 +1791,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2RadiowavesLeftAndRightCircle = SFSymbol(rawValue: "iphone.gen2.radiowaves.left.and.right.circle")
+    static var iphoneGen2RadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "iphone.gen2.radiowaves.left.and.right.circle") }
 
     /// 􁟢
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1802,7 +1802,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2RadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "iphone.gen2.radiowaves.left.and.right.circle.fill")
+    static var iphoneGen2RadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "iphone.gen2.radiowaves.left.and.right.circle.fill") }
 
     /// 􁟣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1812,7 +1812,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2Slash = SFSymbol(rawValue: "iphone.gen2.slash")
+    static var iphoneGen2Slash: SFSymbol { .init(rawValue: "iphone.gen2.slash") }
 
     /// 􁟤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1822,7 +1822,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2SlashCircle = SFSymbol(rawValue: "iphone.gen2.slash.circle")
+    static var iphoneGen2SlashCircle: SFSymbol { .init(rawValue: "iphone.gen2.slash.circle") }
 
     /// 􁟥
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1833,7 +1833,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2SlashCircleFill = SFSymbol(rawValue: "iphone.gen2.slash.circle.fill")
+    static var iphoneGen2SlashCircleFill: SFSymbol { .init(rawValue: "iphone.gen2.slash.circle.fill") }
 
     /// 􁊮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1843,7 +1843,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3 = SFSymbol(rawValue: "iphone.gen3")
+    static var iphoneGen3: SFSymbol { .init(rawValue: "iphone.gen3") }
 
     /// 􁊸
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1854,7 +1854,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3BadgePlay = SFSymbol(rawValue: "iphone.gen3.badge.play")
+    static var iphoneGen3BadgePlay: SFSymbol { .init(rawValue: "iphone.gen3.badge.play") }
 
     /// 􁊯
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1864,7 +1864,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3Circle = SFSymbol(rawValue: "iphone.gen3.circle")
+    static var iphoneGen3Circle: SFSymbol { .init(rawValue: "iphone.gen3.circle") }
 
     /// 􁊰
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1875,7 +1875,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3CircleFill = SFSymbol(rawValue: "iphone.gen3.circle.fill")
+    static var iphoneGen3CircleFill: SFSymbol { .init(rawValue: "iphone.gen3.circle.fill") }
 
     /// 􁊱
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1885,7 +1885,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3Landscape = SFSymbol(rawValue: "iphone.gen3.landscape")
+    static var iphoneGen3Landscape: SFSymbol { .init(rawValue: "iphone.gen3.landscape") }
 
     /// 􁊲
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1896,7 +1896,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3RadiowavesLeftAndRight = SFSymbol(rawValue: "iphone.gen3.radiowaves.left.and.right")
+    static var iphoneGen3RadiowavesLeftAndRight: SFSymbol { .init(rawValue: "iphone.gen3.radiowaves.left.and.right") }
 
     /// 􁊳
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1907,7 +1907,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3RadiowavesLeftAndRightCircle = SFSymbol(rawValue: "iphone.gen3.radiowaves.left.and.right.circle")
+    static var iphoneGen3RadiowavesLeftAndRightCircle: SFSymbol { .init(rawValue: "iphone.gen3.radiowaves.left.and.right.circle") }
 
     /// 􁊴
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1918,7 +1918,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3RadiowavesLeftAndRightCircleFill = SFSymbol(rawValue: "iphone.gen3.radiowaves.left.and.right.circle.fill")
+    static var iphoneGen3RadiowavesLeftAndRightCircleFill: SFSymbol { .init(rawValue: "iphone.gen3.radiowaves.left.and.right.circle.fill") }
 
     /// 􁊵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1928,7 +1928,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3Slash = SFSymbol(rawValue: "iphone.gen3.slash")
+    static var iphoneGen3Slash: SFSymbol { .init(rawValue: "iphone.gen3.slash") }
 
     /// 􁊶
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1938,7 +1938,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3SlashCircle = SFSymbol(rawValue: "iphone.gen3.slash.circle")
+    static var iphoneGen3SlashCircle: SFSymbol { .init(rawValue: "iphone.gen3.slash.circle") }
 
     /// 􁊷
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1949,21 +1949,21 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3SlashCircleFill = SFSymbol(rawValue: "iphone.gen3.slash.circle.fill")
+    static var iphoneGen3SlashCircleFill: SFSymbol { .init(rawValue: "iphone.gen3.slash.circle.fill") }
 
     /// 􁠱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyHorizontal = SFSymbol(rawValue: "key.horizontal")
+    static var keyHorizontal: SFSymbol { .init(rawValue: "key.horizontal") }
 
     /// 􁠲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let keyHorizontalFill = SFSymbol(rawValue: "key.horizontal.fill")
+    static var keyHorizontalFill: SFSymbol { .init(rawValue: "key.horizontal.fill") }
 
     /// 􁠯
     /// Single Localization, 3 Layersets
@@ -1972,7 +1972,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyRadiowavesForward = SFSymbol(rawValue: "key.radiowaves.forward")
+    static var keyRadiowavesForward: SFSymbol { .init(rawValue: "key.radiowaves.forward") }
 
     /// 􁠰
     /// Single Localization, 3 Layersets
@@ -1981,14 +1981,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyRadiowavesForwardFill = SFSymbol(rawValue: "key.radiowaves.forward.fill")
+    static var keyRadiowavesForwardFill: SFSymbol { .init(rawValue: "key.radiowaves.forward.fill") }
 
     /// 􁢽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let kph = SFSymbol(rawValue: "kph")
+    static var kph: SFSymbol { .init(rawValue: "kph") }
 
     /// 􁢾
     /// Single Localization, 2 Layersets
@@ -1996,7 +1996,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kphCircle = SFSymbol(rawValue: "kph.circle")
+    static var kphCircle: SFSymbol { .init(rawValue: "kph.circle") }
 
     /// 􁢿
     /// Single Localization, 3 Layersets
@@ -2005,14 +2005,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let kphCircleFill = SFSymbol(rawValue: "kph.circle.fill")
+    static var kphCircleFill: SFSymbol { .init(rawValue: "kph.circle.fill") }
 
     /// 􁟏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lane = SFSymbol(rawValue: "lane")
+    static var lane: SFSymbol { .init(rawValue: "lane") }
 
     /// 􁊭
     /// Single Localization, 2 Layersets
@@ -2020,7 +2020,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let laptopcomputerSlash = SFSymbol(rawValue: "laptopcomputer.slash")
+    static var laptopcomputerSlash: SFSymbol { .init(rawValue: "laptopcomputer.slash") }
 
     /// 􁋋
     /// Single Localization, 2 Layersets
@@ -2028,7 +2028,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let lightOverheadLeft = SFSymbol(rawValue: "light.overhead.left")
+    static var lightOverheadLeft: SFSymbol { .init(rawValue: "light.overhead.left") }
 
     /// 􁣇
     /// Single Localization, 2 Layersets
@@ -2036,7 +2036,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let lightOverheadLeftFill = SFSymbol(rawValue: "light.overhead.left.fill")
+    static var lightOverheadLeftFill: SFSymbol { .init(rawValue: "light.overhead.left.fill") }
 
     /// 􁋊
     /// Single Localization, 2 Layersets
@@ -2044,7 +2044,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let lightOverheadRight = SFSymbol(rawValue: "light.overhead.right")
+    static var lightOverheadRight: SFSymbol { .init(rawValue: "light.overhead.right") }
 
     /// 􁣆
     /// Single Localization, 2 Layersets
@@ -2052,7 +2052,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let lightOverheadRightFill = SFSymbol(rawValue: "light.overhead.right.fill")
+    static var lightOverheadRightFill: SFSymbol { .init(rawValue: "light.overhead.right.fill") }
 
     /// 􀑚
     /// Single Localization, 2 Layersets
@@ -2060,7 +2060,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockOpenRotation = SFSymbol(rawValue: "lock.open.rotation")
+    static var lockOpenRotation: SFSymbol { .init(rawValue: "lock.open.rotation") }
 
     /// 􁘞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2070,7 +2070,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook and iPad.
-    static let macbookAndIpad = SFSymbol(rawValue: "macbook.and.ipad")
+    static var macbookAndIpad: SFSymbol { .init(rawValue: "macbook.and.ipad") }
 
     /// 􀬩
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2081,7 +2081,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook and iPhone.
-    static let macbookAndIphone = SFSymbol(rawValue: "macbook.and.iphone")
+    static var macbookAndIphone: SFSymbol { .init(rawValue: "macbook.and.iphone") }
 
     /// 􁠄
     /// Single Localization, 3 Layersets
@@ -2090,7 +2090,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let minusPlusAndFluidBatteryblock = SFSymbol(rawValue: "minus.plus.and.fluid.batteryblock")
+    static var minusPlusAndFluidBatteryblock: SFSymbol { .init(rawValue: "minus.plus.and.fluid.batteryblock") }
 
     /// 􁠿
     /// Single Localization, 3 Layersets
@@ -2099,7 +2099,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockExclamationmark = SFSymbol(rawValue: "minus.plus.batteryblock.exclamationmark")
+    static var minusPlusBatteryblockExclamationmark: SFSymbol { .init(rawValue: "minus.plus.batteryblock.exclamationmark") }
 
     /// 􁡀
     /// Single Localization, 3 Layersets
@@ -2108,7 +2108,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockExclamationmarkFill = SFSymbol(rawValue: "minus.plus.batteryblock.exclamationmark.fill")
+    static var minusPlusBatteryblockExclamationmarkFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.exclamationmark.fill") }
 
     /// 􁠹
     /// Single Localization, 3 Layersets
@@ -2117,7 +2117,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockSlash = SFSymbol(rawValue: "minus.plus.batteryblock.slash")
+    static var minusPlusBatteryblockSlash: SFSymbol { .init(rawValue: "minus.plus.batteryblock.slash") }
 
     /// 􁠺
     /// Single Localization, 3 Layersets
@@ -2126,7 +2126,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockSlashFill = SFSymbol(rawValue: "minus.plus.batteryblock.slash.fill")
+    static var minusPlusBatteryblockSlashFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.slash.fill") }
 
     /// 􁡁
     /// Single Localization, 3 Layersets
@@ -2135,7 +2135,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let minusPlusBatteryblockStack = SFSymbol(rawValue: "minus.plus.batteryblock.stack")
+    static var minusPlusBatteryblockStack: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack") }
 
     /// 􁡃
     /// Single Localization, 3 Layersets
@@ -2144,7 +2144,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockStackExclamationmark = SFSymbol(rawValue: "minus.plus.batteryblock.stack.exclamationmark")
+    static var minusPlusBatteryblockStackExclamationmark: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.exclamationmark") }
 
     /// 􁡄
     /// Single Localization, 3 Layersets
@@ -2153,7 +2153,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let minusPlusBatteryblockStackExclamationmarkFill = SFSymbol(rawValue: "minus.plus.batteryblock.stack.exclamationmark.fill")
+    static var minusPlusBatteryblockStackExclamationmarkFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.exclamationmark.fill") }
 
     /// 􁡂
     /// Single Localization, 3 Layersets
@@ -2162,7 +2162,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let minusPlusBatteryblockStackFill = SFSymbol(rawValue: "minus.plus.batteryblock.stack.fill")
+    static var minusPlusBatteryblockStackFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.fill") }
 
     /// 􁉵
     /// Single Localization, 2 Layersets
@@ -2170,7 +2170,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mirrorSideLeftAndArrowTurnDownRight = SFSymbol(rawValue: "mirror.side.left.and.arrow.turn.down.right")
+    static var mirrorSideLeftAndArrowTurnDownRight: SFSymbol { .init(rawValue: "mirror.side.left.and.arrow.turn.down.right") }
 
     /// 􁉳
     /// Single Localization, 3 Layersets
@@ -2179,7 +2179,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mirrorSideLeftAndHeatWaves = SFSymbol(rawValue: "mirror.side.left.and.heat.waves")
+    static var mirrorSideLeftAndHeatWaves: SFSymbol { .init(rawValue: "mirror.side.left.and.heat.waves") }
 
     /// 􁉶
     /// Single Localization, 2 Layersets
@@ -2187,7 +2187,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mirrorSideRightAndArrowTurnDownLeft = SFSymbol(rawValue: "mirror.side.right.and.arrow.turn.down.left")
+    static var mirrorSideRightAndArrowTurnDownLeft: SFSymbol { .init(rawValue: "mirror.side.right.and.arrow.turn.down.left") }
 
     /// 􁉴
     /// Single Localization, 3 Layersets
@@ -2196,7 +2196,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mirrorSideRightAndHeatWaves = SFSymbol(rawValue: "mirror.side.right.and.heat.waves")
+    static var mirrorSideRightAndHeatWaves: SFSymbol { .init(rawValue: "mirror.side.right.and.heat.waves") }
 
     /// 􁗝
     /// Single Localization, 3 Layersets
@@ -2205,7 +2205,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mountain2 = SFSymbol(rawValue: "mountain.2")
+    static var mountain2: SFSymbol { .init(rawValue: "mountain.2") }
 
     /// 􁞒
     /// Single Localization, 2 Layersets
@@ -2213,7 +2213,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mountain2Circle = SFSymbol(rawValue: "mountain.2.circle")
+    static var mountain2Circle: SFSymbol { .init(rawValue: "mountain.2.circle") }
 
     /// 􁞓
     /// Single Localization, 3 Layersets
@@ -2222,7 +2222,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mountain2CircleFill = SFSymbol(rawValue: "mountain.2.circle.fill")
+    static var mountain2CircleFill: SFSymbol { .init(rawValue: "mountain.2.circle.fill") }
 
     /// 􁗞
     /// Single Localization, 2 Layersets
@@ -2230,14 +2230,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mountain2Fill = SFSymbol(rawValue: "mountain.2.fill")
+    static var mountain2Fill: SFSymbol { .init(rawValue: "mountain.2.fill") }
 
     /// 􁢺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mph = SFSymbol(rawValue: "mph")
+    static var mph: SFSymbol { .init(rawValue: "mph") }
 
     /// 􁢻
     /// Single Localization, 2 Layersets
@@ -2245,7 +2245,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let mphCircle = SFSymbol(rawValue: "mph.circle")
+    static var mphCircle: SFSymbol { .init(rawValue: "mph.circle") }
 
     /// 􁢼
     /// Single Localization, 3 Layersets
@@ -2254,21 +2254,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mphCircleFill = SFSymbol(rawValue: "mph.circle.fill")
+    static var mphCircleFill: SFSymbol { .init(rawValue: "mph.circle.fill") }
 
     /// 􁞴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mug = SFSymbol(rawValue: "mug")
+    static var mug: SFSymbol { .init(rawValue: "mug") }
 
     /// 􁞵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mugFill = SFSymbol(rawValue: "mug.fill")
+    static var mugFill: SFSymbol { .init(rawValue: "mug.fill") }
 
     /// 􀿄
     /// Single Localization, 2 Layersets
@@ -2276,7 +2276,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let oilcan = SFSymbol(rawValue: "oilcan")
+    static var oilcan: SFSymbol { .init(rawValue: "oilcan") }
 
     /// 􀿅
     /// Single Localization, 2 Layersets
@@ -2284,14 +2284,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let oilcanFill = SFSymbol(rawValue: "oilcan.fill")
+    static var oilcanFill: SFSymbol { .init(rawValue: "oilcan.fill") }
 
     /// 􁞮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let personCropCircleDashed = SFSymbol(rawValue: "person.crop.circle.dashed")
+    static var personCropCircleDashed: SFSymbol { .init(rawValue: "person.crop.circle.dashed") }
 
     /// 􁟼
     /// Single Localization, 2 Layersets
@@ -2299,7 +2299,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playSquareStack = SFSymbol(rawValue: "play.square.stack")
+    static var playSquareStack: SFSymbol { .init(rawValue: "play.square.stack") }
 
     /// 􁟽
     /// Single Localization, 3 Layersets
@@ -2308,14 +2308,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let playSquareStackFill = SFSymbol(rawValue: "play.square.stack.fill")
+    static var playSquareStackFill: SFSymbol { .init(rawValue: "play.square.stack.fill") }
 
     /// 􁠳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let questionmarkKeyFilled = SFSymbol(rawValue: "questionmark.key.filled")
+    static var questionmarkKeyFilled: SFSymbol { .init(rawValue: "questionmark.key.filled") }
 
     /// 􁟇
     /// Single Localization, 2 Layersets
@@ -2323,7 +2323,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let retarderBrakesignal = SFSymbol(rawValue: "retarder.brakesignal")
+    static var retarderBrakesignal: SFSymbol { .init(rawValue: "retarder.brakesignal") }
 
     /// 􁕶
     /// Single Localization, 2 Layersets
@@ -2331,7 +2331,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let roadLaneArrowtriangle2Inward = SFSymbol(rawValue: "road.lane.arrowtriangle.2.inward")
+    static var roadLaneArrowtriangle2Inward: SFSymbol { .init(rawValue: "road.lane.arrowtriangle.2.inward") }
 
     /// 􁞘
     /// Single Localization, 2 Layersets
@@ -2339,7 +2339,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sailboatCircle = SFSymbol(rawValue: "sailboat.circle")
+    static var sailboatCircle: SFSymbol { .init(rawValue: "sailboat.circle") }
 
     /// 􁞙
     /// Single Localization, 3 Layersets
@@ -2348,7 +2348,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sailboatCircleFill = SFSymbol(rawValue: "sailboat.circle.fill")
+    static var sailboatCircleFill: SFSymbol { .init(rawValue: "sailboat.circle.fill") }
 
     /// 􁝳
     /// Single Localization, 2 Layersets
@@ -2356,7 +2356,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let signpostAndArrowtriangleUp = SFSymbol(rawValue: "signpost.and.arrowtriangle.up")
+    static var signpostAndArrowtriangleUp: SFSymbol { .init(rawValue: "signpost.and.arrowtriangle.up") }
 
     /// 􁞐
     /// Single Localization, 2 Layersets
@@ -2364,7 +2364,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let signpostAndArrowtriangleUpCircle = SFSymbol(rawValue: "signpost.and.arrowtriangle.up.circle")
+    static var signpostAndArrowtriangleUpCircle: SFSymbol { .init(rawValue: "signpost.and.arrowtriangle.up.circle") }
 
     /// 􁞑
     /// Single Localization, 3 Layersets
@@ -2373,7 +2373,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let signpostAndArrowtriangleUpCircleFill = SFSymbol(rawValue: "signpost.and.arrowtriangle.up.circle.fill")
+    static var signpostAndArrowtriangleUpCircleFill: SFSymbol { .init(rawValue: "signpost.and.arrowtriangle.up.circle.fill") }
 
     /// 􁝴
     /// Single Localization, 3 Layersets
@@ -2382,7 +2382,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let signpostAndArrowtriangleUpFill = SFSymbol(rawValue: "signpost.and.arrowtriangle.up.fill")
+    static var signpostAndArrowtriangleUpFill: SFSymbol { .init(rawValue: "signpost.and.arrowtriangle.up.fill") }
 
     /// 􁞊
     /// Single Localization, 2 Layersets
@@ -2390,7 +2390,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let signpostLeftCircle = SFSymbol(rawValue: "signpost.left.circle")
+    static var signpostLeftCircle: SFSymbol { .init(rawValue: "signpost.left.circle") }
 
     /// 􁞋
     /// Single Localization, 3 Layersets
@@ -2399,14 +2399,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let signpostLeftCircleFill = SFSymbol(rawValue: "signpost.left.circle.fill")
+    static var signpostLeftCircleFill: SFSymbol { .init(rawValue: "signpost.left.circle.fill") }
 
     /// 􁝮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostRightAndLeft = SFSymbol(rawValue: "signpost.right.and.left")
+    static var signpostRightAndLeft: SFSymbol { .init(rawValue: "signpost.right.and.left") }
 
     /// 􁞎
     /// Single Localization, 2 Layersets
@@ -2414,7 +2414,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let signpostRightAndLeftCircle = SFSymbol(rawValue: "signpost.right.and.left.circle")
+    static var signpostRightAndLeftCircle: SFSymbol { .init(rawValue: "signpost.right.and.left.circle") }
 
     /// 􁞏
     /// Single Localization, 3 Layersets
@@ -2423,14 +2423,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let signpostRightAndLeftCircleFill = SFSymbol(rawValue: "signpost.right.and.left.circle.fill")
+    static var signpostRightAndLeftCircleFill: SFSymbol { .init(rawValue: "signpost.right.and.left.circle.fill") }
 
     /// 􁝭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let signpostRightAndLeftFill = SFSymbol(rawValue: "signpost.right.and.left.fill")
+    static var signpostRightAndLeftFill: SFSymbol { .init(rawValue: "signpost.right.and.left.fill") }
 
     /// 􁞌
     /// Single Localization, 2 Layersets
@@ -2438,7 +2438,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let signpostRightCircle = SFSymbol(rawValue: "signpost.right.circle")
+    static var signpostRightCircle: SFSymbol { .init(rawValue: "signpost.right.circle") }
 
     /// 􁞍
     /// Single Localization, 3 Layersets
@@ -2447,7 +2447,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let signpostRightCircleFill = SFSymbol(rawValue: "signpost.right.circle.fill")
+    static var signpostRightCircleFill: SFSymbol { .init(rawValue: "signpost.right.circle.fill") }
 
     /// 􁕹
     /// Single Localization, 2 Layersets
@@ -2455,7 +2455,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let snowflakeRoadLane = SFSymbol(rawValue: "snowflake.road.lane")
+    static var snowflakeRoadLane: SFSymbol { .init(rawValue: "snowflake.road.lane") }
 
     /// 􁖀
     /// Single Localization, 2 Layersets
@@ -2463,7 +2463,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let snowflakeRoadLaneDashed = SFSymbol(rawValue: "snowflake.road.lane.dashed")
+    static var snowflakeRoadLaneDashed: SFSymbol { .init(rawValue: "snowflake.road.lane.dashed") }
 
     /// 􁠂
     /// Single Localization, 3 Layersets
@@ -2472,14 +2472,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let snowflakeSlash = SFSymbol(rawValue: "snowflake.slash")
+    static var snowflakeSlash: SFSymbol { .init(rawValue: "snowflake.slash") }
 
     /// 􀜥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sos = SFSymbol(rawValue: "sos")
+    static var sos: SFSymbol { .init(rawValue: "sos") }
 
     /// 􁞪
     /// Single Localization, 2 Layersets
@@ -2487,7 +2487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sosCircle = SFSymbol(rawValue: "sos.circle")
+    static var sosCircle: SFSymbol { .init(rawValue: "sos.circle") }
 
     /// 􁞫
     /// Single Localization, 3 Layersets
@@ -2496,14 +2496,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sosCircleFill = SFSymbol(rawValue: "sos.circle.fill")
+    static var sosCircleFill: SFSymbol { .init(rawValue: "sos.circle.fill") }
 
     /// 􁂩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let steeringwheel = SFSymbol(rawValue: "steeringwheel")
+    static var steeringwheel: SFSymbol { .init(rawValue: "steeringwheel") }
 
     /// 􁉙
     /// Single Localization, 2 Layersets
@@ -2511,7 +2511,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelAndHeatWaves = SFSymbol(rawValue: "steeringwheel.and.heat.waves")
+    static var steeringwheelAndHeatWaves: SFSymbol { .init(rawValue: "steeringwheel.and.heat.waves") }
 
     /// 􁞿
     /// Single Localization, 2 Layersets
@@ -2519,7 +2519,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelAndKey = SFSymbol(rawValue: "steeringwheel.and.key")
+    static var steeringwheelAndKey: SFSymbol { .init(rawValue: "steeringwheel.and.key") }
 
     /// 􁟀
     /// Single Localization, 2 Layersets
@@ -2532,7 +2532,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 16.1, deprecated: 26.0, renamed: "steeringwheelBadgeLock")
     @available(watchOS, introduced: 9.1, deprecated: 26.0, renamed: "steeringwheelBadgeLock")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "steeringwheelBadgeLock")
-    static let steeringwheelAndLock = SFSymbol(rawValue: "steeringwheel.and.lock")
+    static var steeringwheelAndLock: SFSymbol { .init(rawValue: "steeringwheel.and.lock") }
 
     /// 􁉚
     /// Single Localization, 3 Layersets
@@ -2541,7 +2541,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let steeringwheelExclamationmark = SFSymbol(rawValue: "steeringwheel.exclamationmark")
+    static var steeringwheelExclamationmark: SFSymbol { .init(rawValue: "steeringwheel.exclamationmark") }
 
     /// 􁖥
     /// Single Localization, 2 Layersets
@@ -2549,7 +2549,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelRoadLane = SFSymbol(rawValue: "steeringwheel.road.lane")
+    static var steeringwheelRoadLane: SFSymbol { .init(rawValue: "steeringwheel.road.lane") }
 
     /// 􁖦
     /// Single Localization, 2 Layersets
@@ -2557,7 +2557,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelRoadLaneDashed = SFSymbol(rawValue: "steeringwheel.road.lane.dashed")
+    static var steeringwheelRoadLaneDashed: SFSymbol { .init(rawValue: "steeringwheel.road.lane.dashed") }
 
     /// 􁡉
     /// Single Localization, 2 Layersets
@@ -2565,42 +2565,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelSlash = SFSymbol(rawValue: "steeringwheel.slash")
+    static var steeringwheelSlash: SFSymbol { .init(rawValue: "steeringwheel.slash") }
 
     /// 􁞖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let stroller = SFSymbol(rawValue: "stroller")
+    static var stroller: SFSymbol { .init(rawValue: "stroller") }
 
     /// 􁞗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let strollerFill = SFSymbol(rawValue: "stroller.fill")
+    static var strollerFill: SFSymbol { .init(rawValue: "stroller.fill") }
 
     /// 􁞯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suitcaseRolling = SFSymbol(rawValue: "suitcase.rolling")
+    static var suitcaseRolling: SFSymbol { .init(rawValue: "suitcase.rolling") }
 
     /// 􁞰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suitcaseRollingFill = SFSymbol(rawValue: "suitcase.rolling.fill")
+    static var suitcaseRollingFill: SFSymbol { .init(rawValue: "suitcase.rolling.fill") }
 
     /// 􁠀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSide = SFSymbol(rawValue: "suv.side")
+    static var suvSide: SFSymbol { .init(rawValue: "suv.side") }
 
     /// 􁠑
     /// Single Localization, 2 Layersets
@@ -2608,7 +2608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideAirCirculate = SFSymbol(rawValue: "suv.side.air.circulate")
+    static var suvSideAirCirculate: SFSymbol { .init(rawValue: "suv.side.air.circulate") }
 
     /// 􁠒
     /// Single Localization, 3 Layersets
@@ -2617,7 +2617,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suvSideAirCirculateFill = SFSymbol(rawValue: "suv.side.air.circulate.fill")
+    static var suvSideAirCirculateFill: SFSymbol { .init(rawValue: "suv.side.air.circulate.fill") }
 
     /// 􁠓
     /// Single Localization, 2 Layersets
@@ -2625,7 +2625,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideAirFresh = SFSymbol(rawValue: "suv.side.air.fresh")
+    static var suvSideAirFresh: SFSymbol { .init(rawValue: "suv.side.air.fresh") }
 
     /// 􁠔
     /// Single Localization, 2 Layersets
@@ -2633,7 +2633,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideAirFreshFill = SFSymbol(rawValue: "suv.side.air.fresh.fill")
+    static var suvSideAirFreshFill: SFSymbol { .init(rawValue: "suv.side.air.fresh.fill") }
 
     /// 􁠕
     /// Single Localization, 3 Layersets
@@ -2642,7 +2642,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideAndExclamationmark = SFSymbol(rawValue: "suv.side.and.exclamationmark")
+    static var suvSideAndExclamationmark: SFSymbol { .init(rawValue: "suv.side.and.exclamationmark") }
 
     /// 􁠖
     /// Single Localization, 3 Layersets
@@ -2651,7 +2651,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideAndExclamationmarkFill = SFSymbol(rawValue: "suv.side.and.exclamationmark.fill")
+    static var suvSideAndExclamationmarkFill: SFSymbol { .init(rawValue: "suv.side.and.exclamationmark.fill") }
 
     /// 􁠝
     /// Single Localization, 2 Layersets
@@ -2659,7 +2659,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowtriangleDown = SFSymbol(rawValue: "suv.side.arrowtriangle.down")
+    static var suvSideArrowtriangleDown: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.down") }
 
     /// 􁠞
     /// Single Localization, 2 Layersets
@@ -2667,7 +2667,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowtriangleDownFill = SFSymbol(rawValue: "suv.side.arrowtriangle.down.fill")
+    static var suvSideArrowtriangleDownFill: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.down.fill") }
 
     /// 􁠛
     /// Single Localization, 2 Layersets
@@ -2675,7 +2675,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowtriangleUp = SFSymbol(rawValue: "suv.side.arrowtriangle.up")
+    static var suvSideArrowtriangleUp: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.up") }
 
     /// 􁠙
     /// Single Localization, 2 Layersets
@@ -2683,7 +2683,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowtriangleUpArrowtriangleDown = SFSymbol(rawValue: "suv.side.arrowtriangle.up.arrowtriangle.down")
+    static var suvSideArrowtriangleUpArrowtriangleDown: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.up.arrowtriangle.down") }
 
     /// 􁠚
     /// Single Localization, 3 Layersets
@@ -2692,7 +2692,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suvSideArrowtriangleUpArrowtriangleDownFill = SFSymbol(rawValue: "suv.side.arrowtriangle.up.arrowtriangle.down.fill")
+    static var suvSideArrowtriangleUpArrowtriangleDownFill: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.up.arrowtriangle.down.fill") }
 
     /// 􁠜
     /// Single Localization, 3 Layersets
@@ -2701,14 +2701,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suvSideArrowtriangleUpFill = SFSymbol(rawValue: "suv.side.arrowtriangle.up.fill")
+    static var suvSideArrowtriangleUpFill: SFSymbol { .init(rawValue: "suv.side.arrowtriangle.up.fill") }
 
     /// 􁠁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSideFill = SFSymbol(rawValue: "suv.side.fill")
+    static var suvSideFill: SFSymbol { .init(rawValue: "suv.side.fill") }
 
     /// 􁠍
     /// Single Localization, 2 Layersets
@@ -2716,7 +2716,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideFrontOpen = SFSymbol(rawValue: "suv.side.front.open")
+    static var suvSideFrontOpen: SFSymbol { .init(rawValue: "suv.side.front.open") }
 
     /// 􁠎
     /// Single Localization, 2 Layersets
@@ -2724,7 +2724,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideFrontOpenFill = SFSymbol(rawValue: "suv.side.front.open.fill")
+    static var suvSideFrontOpenFill: SFSymbol { .init(rawValue: "suv.side.front.open.fill") }
 
     /// 􁠏
     /// Single Localization, 2 Layersets
@@ -2732,7 +2732,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideRearOpen = SFSymbol(rawValue: "suv.side.rear.open")
+    static var suvSideRearOpen: SFSymbol { .init(rawValue: "suv.side.rear.open") }
 
     /// 􁠐
     /// Single Localization, 2 Layersets
@@ -2740,7 +2740,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let suvSideRearOpenFill = SFSymbol(rawValue: "suv.side.rear.open.fill")
+    static var suvSideRearOpenFill: SFSymbol { .init(rawValue: "suv.side.rear.open.fill") }
 
     /// 􀾸
     /// Single Localization, 3 Layersets
@@ -2749,7 +2749,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let taillightFog = SFSymbol(rawValue: "taillight.fog")
+    static var taillightFog: SFSymbol { .init(rawValue: "taillight.fog") }
 
     /// 􀾹
     /// Single Localization, 3 Layersets
@@ -2758,7 +2758,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let taillightFogFill = SFSymbol(rawValue: "taillight.fog.fill")
+    static var taillightFogFill: SFSymbol { .init(rawValue: "taillight.fog.fill") }
 
     /// 􁔐
     /// Single Localization, 3 Layersets
@@ -2767,7 +2767,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tent2 = SFSymbol(rawValue: "tent.2")
+    static var tent2: SFSymbol { .init(rawValue: "tent.2") }
 
     /// 􁞄
     /// Single Localization, 2 Layersets
@@ -2775,7 +2775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tent2Circle = SFSymbol(rawValue: "tent.2.circle")
+    static var tent2Circle: SFSymbol { .init(rawValue: "tent.2.circle") }
 
     /// 􁞅
     /// Single Localization, 3 Layersets
@@ -2784,7 +2784,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tent2CircleFill = SFSymbol(rawValue: "tent.2.circle.fill")
+    static var tent2CircleFill: SFSymbol { .init(rawValue: "tent.2.circle.fill") }
 
     /// 􁔑
     /// Single Localization, 3 Layersets
@@ -2793,7 +2793,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tent2Fill = SFSymbol(rawValue: "tent.2.fill")
+    static var tent2Fill: SFSymbol { .init(rawValue: "tent.2.fill") }
 
     /// 􁞂
     /// Single Localization, 2 Layersets
@@ -2801,7 +2801,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tentCircle = SFSymbol(rawValue: "tent.circle")
+    static var tentCircle: SFSymbol { .init(rawValue: "tent.circle") }
 
     /// 􁞃
     /// Single Localization, 3 Layersets
@@ -2810,7 +2810,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tentCircleFill = SFSymbol(rawValue: "tent.circle.fill")
+    static var tentCircleFill: SFSymbol { .init(rawValue: "tent.circle.fill") }
 
     /// 􁀳
     /// Single Localization, 2 Layersets
@@ -2818,7 +2818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerAndLiquidWaves = SFSymbol(rawValue: "thermometer.and.liquid.waves")
+    static var thermometerAndLiquidWaves: SFSymbol { .init(rawValue: "thermometer.and.liquid.waves") }
 
     /// 􁊁
     /// Single Localization, 2 Layersets
@@ -2826,7 +2826,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerTransmission = SFSymbol(rawValue: "thermometer.transmission")
+    static var thermometerTransmission: SFSymbol { .init(rawValue: "thermometer.transmission") }
 
     /// 􁞀
     /// Single Localization, 2 Layersets
@@ -2834,7 +2834,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let toiletCircle = SFSymbol(rawValue: "toilet.circle")
+    static var toiletCircle: SFSymbol { .init(rawValue: "toilet.circle") }
 
     /// 􁞁
     /// Single Localization, 3 Layersets
@@ -2843,7 +2843,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let toiletCircleFill = SFSymbol(rawValue: "toilet.circle.fill")
+    static var toiletCircleFill: SFSymbol { .init(rawValue: "toilet.circle.fill") }
 
     /// 􁟌
     /// Single Localization, 2 Layersets
@@ -2851,7 +2851,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let transmission = SFSymbol(rawValue: "transmission")
+    static var transmission: SFSymbol { .init(rawValue: "transmission") }
 
     /// 􁝯
     /// Single Localization, 2 Layersets
@@ -2859,7 +2859,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let tree = SFSymbol(rawValue: "tree")
+    static var tree: SFSymbol { .init(rawValue: "tree") }
 
     /// 􁞔
     /// Single Localization, 3 Layersets
@@ -2868,7 +2868,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let treeCircle = SFSymbol(rawValue: "tree.circle")
+    static var treeCircle: SFSymbol { .init(rawValue: "tree.circle") }
 
     /// 􁞕
     /// Single Localization, 3 Layersets
@@ -2877,7 +2877,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let treeCircleFill = SFSymbol(rawValue: "tree.circle.fill")
+    static var treeCircleFill: SFSymbol { .init(rawValue: "tree.circle.fill") }
 
     /// 􁝰
     /// Single Localization, 2 Layersets
@@ -2885,7 +2885,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let treeFill = SFSymbol(rawValue: "tree.fill")
+    static var treeFill: SFSymbol { .init(rawValue: "tree.fill") }
 
     /// 􁞼
     /// Single Localization, 3 Layersets
@@ -2894,7 +2894,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndFluidAndSpray = SFSymbol(rawValue: "windshield.front.and.fluid.and.spray")
+    static var windshieldFrontAndFluidAndSpray: SFSymbol { .init(rawValue: "windshield.front.and.fluid.and.spray") }
 
     /// 􁀟
     /// Single Localization, 3 Layersets
@@ -2903,7 +2903,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndHeatWaves = SFSymbol(rawValue: "windshield.front.and.heat.waves")
+    static var windshieldFrontAndHeatWaves: SFSymbol { .init(rawValue: "windshield.front.and.heat.waves") }
 
     /// 􁀕
     /// Single Localization, 2 Layersets
@@ -2911,7 +2911,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windshieldFrontAndSpray = SFSymbol(rawValue: "windshield.front.and.spray")
+    static var windshieldFrontAndSpray: SFSymbol { .init(rawValue: "windshield.front.and.spray") }
 
     /// 􁞻
     /// Single Localization, 3 Layersets
@@ -2920,7 +2920,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndWiperAndSpray = SFSymbol(rawValue: "windshield.front.and.wiper.and.spray")
+    static var windshieldFrontAndWiperAndSpray: SFSymbol { .init(rawValue: "windshield.front.and.wiper.and.spray") }
 
     /// 􁉍
     /// Single Localization, 3 Layersets
@@ -2929,7 +2929,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndWiperExclamationmark = SFSymbol(rawValue: "windshield.front.and.wiper.exclamationmark")
+    static var windshieldFrontAndWiperExclamationmark: SFSymbol { .init(rawValue: "windshield.front.and.wiper.exclamationmark") }
 
     /// 􁀖
     /// Single Localization, 3 Layersets
@@ -2938,7 +2938,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldFrontAndWiperIntermittent = SFSymbol(rawValue: "windshield.front.and.wiper.intermittent")
+    static var windshieldFrontAndWiperIntermittent: SFSymbol { .init(rawValue: "windshield.front.and.wiper.intermittent") }
 
     /// 􁞾
     /// Single Localization, 3 Layersets
@@ -2947,7 +2947,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndFluidAndSpray = SFSymbol(rawValue: "windshield.rear.and.fluid.and.spray")
+    static var windshieldRearAndFluidAndSpray: SFSymbol { .init(rawValue: "windshield.rear.and.fluid.and.spray") }
 
     /// 􁀤
     /// Single Localization, 3 Layersets
@@ -2956,7 +2956,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndHeatWaves = SFSymbol(rawValue: "windshield.rear.and.heat.waves")
+    static var windshieldRearAndHeatWaves: SFSymbol { .init(rawValue: "windshield.rear.and.heat.waves") }
 
     /// 􁀡
     /// Single Localization, 2 Layersets
@@ -2964,7 +2964,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windshieldRearAndSpray = SFSymbol(rawValue: "windshield.rear.and.spray")
+    static var windshieldRearAndSpray: SFSymbol { .init(rawValue: "windshield.rear.and.spray") }
 
     /// 􁀣
     /// Single Localization, 2 Layersets
@@ -2972,7 +2972,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let windshieldRearAndWiperAndDrop = SFSymbol(rawValue: "windshield.rear.and.wiper.and.drop")
+    static var windshieldRearAndWiperAndDrop: SFSymbol { .init(rawValue: "windshield.rear.and.wiper.and.drop") }
 
     /// 􁞽
     /// Single Localization, 3 Layersets
@@ -2981,7 +2981,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndWiperAndSpray = SFSymbol(rawValue: "windshield.rear.and.wiper.and.spray")
+    static var windshieldRearAndWiperAndSpray: SFSymbol { .init(rawValue: "windshield.rear.and.wiper.and.spray") }
 
     /// 􁉑
     /// Single Localization, 3 Layersets
@@ -2990,7 +2990,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndWiperExclamationmark = SFSymbol(rawValue: "windshield.rear.and.wiper.exclamationmark")
+    static var windshieldRearAndWiperExclamationmark: SFSymbol { .init(rawValue: "windshield.rear.and.wiper.exclamationmark") }
 
     /// 􁀢
     /// Single Localization, 3 Layersets
@@ -2999,7 +2999,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let windshieldRearAndWiperIntermittent = SFSymbol(rawValue: "windshield.rear.and.wiper.intermittent")
+    static var windshieldRearAndWiperIntermittent: SFSymbol { .init(rawValue: "windshield.rear.and.wiper.intermittent") }
 
     /// 􁕦
     /// Single Localization, 3 Layersets
@@ -3008,7 +3008,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wrongwaysign = SFSymbol(rawValue: "wrongwaysign")
+    static var wrongwaysign: SFSymbol { .init(rawValue: "wrongwaysign") }
 
     /// 􁕧
     /// Single Localization, 3 Layersets
@@ -3017,5 +3017,5 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wrongwaysignFill = SFSymbol(rawValue: "wrongwaysign.fill")
+    static var wrongwaysignFill: SFSymbol { .init(rawValue: "wrongwaysign.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+4.2.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+4.2.swift
@@ -8,7 +8,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let axle2 = SFSymbol(rawValue: "axle.2")
+    static var axle2: SFSymbol { .init(rawValue: "axle.2") }
 
     /// 􁠡
     /// Single Localization, 2 Layersets
@@ -16,7 +16,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let axle2FrontAndRearEngaged = SFSymbol(rawValue: "axle.2.front.and.rear.engaged")
+    static var axle2FrontAndRearEngaged: SFSymbol { .init(rawValue: "axle.2.front.and.rear.engaged") }
 
     /// 􁠟
     /// Single Localization, 2 Layersets
@@ -24,7 +24,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let axle2FrontEngaged = SFSymbol(rawValue: "axle.2.front.engaged")
+    static var axle2FrontEngaged: SFSymbol { .init(rawValue: "axle.2.front.engaged") }
 
     /// 􁠠
     /// Single Localization, 2 Layersets
@@ -32,7 +32,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0)
-    static let axle2RearEngaged = SFSymbol(rawValue: "axle.2.rear.engaged")
+    static var axle2RearEngaged: SFSymbol { .init(rawValue: "axle.2.rear.engaged") }
 
     /// 􁰼
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -42,7 +42,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats.
-    static let beatsPowerbeatsLeft = SFSymbol(rawValue: "beats.powerbeats.left")
+    static var beatsPowerbeatsLeft: SFSymbol { .init(rawValue: "beats.powerbeats.left") }
 
     /// 􀻕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -52,7 +52,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats.
-    static let beatsPowerbeatsRight = SFSymbol(rawValue: "beats.powerbeats.right")
+    static var beatsPowerbeatsRight: SFSymbol { .init(rawValue: "beats.powerbeats.right") }
 
     /// 􁰾
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -62,7 +62,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats3.
-    static let beatsPowerbeats3Left = SFSymbol(rawValue: "beats.powerbeats3.left")
+    static var beatsPowerbeats3Left: SFSymbol { .init(rawValue: "beats.powerbeats3.left") }
 
     /// 􁰽
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -72,5 +72,5 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats3.
-    static let beatsPowerbeats3Right = SFSymbol(rawValue: "beats.powerbeats3.right")
+    static var beatsPowerbeats3Right: SFSymbol { .init(rawValue: "beats.powerbeats3.right") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+5.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+5.0.swift
@@ -8,7 +8,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let _2h = SFSymbol(rawValue: "2h")
+    static var _2h: SFSymbol { .init(rawValue: "2h") }
 
     /// 􁥞
     /// Single Localization, 2 Layersets
@@ -16,7 +16,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _2hCircle = SFSymbol(rawValue: "2h.circle")
+    static var _2hCircle: SFSymbol { .init(rawValue: "2h.circle") }
 
     /// 􁥟
     /// Single Localization, 3 Layersets
@@ -25,14 +25,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _2hCircleFill = SFSymbol(rawValue: "2h.circle.fill")
+    static var _2hCircleFill: SFSymbol { .init(rawValue: "2h.circle.fill") }
 
     /// 􁥝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let _4a = SFSymbol(rawValue: "4a")
+    static var _4a: SFSymbol { .init(rawValue: "4a") }
 
     /// 􁥤
     /// Single Localization, 2 Layersets
@@ -40,7 +40,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _4aCircle = SFSymbol(rawValue: "4a.circle")
+    static var _4aCircle: SFSymbol { .init(rawValue: "4a.circle") }
 
     /// 􁥥
     /// Single Localization, 3 Layersets
@@ -49,14 +49,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _4aCircleFill = SFSymbol(rawValue: "4a.circle.fill")
+    static var _4aCircleFill: SFSymbol { .init(rawValue: "4a.circle.fill") }
 
     /// 􁥛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let _4h = SFSymbol(rawValue: "4h")
+    static var _4h: SFSymbol { .init(rawValue: "4h") }
 
     /// 􁥠
     /// Single Localization, 2 Layersets
@@ -64,7 +64,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _4hCircle = SFSymbol(rawValue: "4h.circle")
+    static var _4hCircle: SFSymbol { .init(rawValue: "4h.circle") }
 
     /// 􁥡
     /// Single Localization, 3 Layersets
@@ -73,14 +73,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _4hCircleFill = SFSymbol(rawValue: "4h.circle.fill")
+    static var _4hCircleFill: SFSymbol { .init(rawValue: "4h.circle.fill") }
 
     /// 􁥜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let _4l = SFSymbol(rawValue: "4l")
+    static var _4l: SFSymbol { .init(rawValue: "4l") }
 
     /// 􁥢
     /// Single Localization, 2 Layersets
@@ -88,7 +88,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _4lCircle = SFSymbol(rawValue: "4l.circle")
+    static var _4lCircle: SFSymbol { .init(rawValue: "4l.circle") }
 
     /// 􁥣
     /// Single Localization, 3 Layersets
@@ -97,7 +97,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _4lCircleFill = SFSymbol(rawValue: "4l.circle.fill")
+    static var _4lCircleFill: SFSymbol { .init(rawValue: "4l.circle.fill") }
 
     /// 􀕾
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -108,7 +108,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Accessibility features.
-    static let accessibility = SFSymbol(rawValue: "accessibility")
+    static var accessibility: SFSymbol { .init(rawValue: "accessibility") }
 
     /// 􀮓
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -119,7 +119,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Accessibility features.
-    static let accessibilityBadgeArrowUpRight = SFSymbol(rawValue: "accessibility.badge.arrow.up.right")
+    static var accessibilityBadgeArrowUpRight: SFSymbol { .init(rawValue: "accessibility.badge.arrow.up.right") }
 
     /// 􀕿
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -130,7 +130,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Accessibility features.
-    static let accessibilityFill = SFSymbol(rawValue: "accessibility.fill")
+    static var accessibilityFill: SFSymbol { .init(rawValue: "accessibility.fill") }
 
     /// 􁔂
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -145,7 +145,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRight")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRight")
-    static let airpodsproChargingcaseWirelessRadiowavesLeftAndRight = SFSymbol(rawValue: "airpodspro.chargingcase.wireless.radiowaves.left.and.right")
+    static var airpodsproChargingcaseWirelessRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "airpodspro.chargingcase.wireless.radiowaves.left.and.right") }
 
     /// 􁔃
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -160,7 +160,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill")
-    static let airpodsproChargingcaseWirelessRadiowavesLeftAndRightFill = SFSymbol(rawValue: "airpodspro.chargingcase.wireless.radiowaves.left.and.right.fill")
+    static var airpodsproChargingcaseWirelessRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "airpodspro.chargingcase.wireless.radiowaves.left.and.right.fill") }
 
     /// 􀩼
     /// Single Localization, 2 Layersets
@@ -168,7 +168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let appleTerminal = SFSymbol(rawValue: "apple.terminal")
+    static var appleTerminal: SFSymbol { .init(rawValue: "apple.terminal") }
 
     /// 􀪏
     /// Single Localization, 2 Layersets
@@ -176,7 +176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let appleTerminalFill = SFSymbol(rawValue: "apple.terminal.fill")
+    static var appleTerminalFill: SFSymbol { .init(rawValue: "apple.terminal.fill") }
 
     /// 􁹛
     /// Single Localization, 3 Layersets
@@ -185,7 +185,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appleTerminalOnRectangle = SFSymbol(rawValue: "apple.terminal.on.rectangle")
+    static var appleTerminalOnRectangle: SFSymbol { .init(rawValue: "apple.terminal.on.rectangle") }
 
     /// 􁹜
     /// Single Localization, 3 Layersets
@@ -194,7 +194,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appleTerminalOnRectangleFill = SFSymbol(rawValue: "apple.terminal.on.rectangle.fill")
+    static var appleTerminalOnRectangleFill: SFSymbol { .init(rawValue: "apple.terminal.on.rectangle.fill") }
 
     /// 􁰒
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -203,7 +203,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilAdapterUsbC = SFSymbol(rawValue: "applepencil.adapter.usb.c")
+    static var applepencilAdapterUsbC: SFSymbol { .init(rawValue: "applepencil.adapter.usb.c") }
 
     /// 􁰓
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -212,7 +212,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilAdapterUsbCFill = SFSymbol(rawValue: "applepencil.adapter.usb.c.fill")
+    static var applepencilAdapterUsbCFill: SFSymbol { .init(rawValue: "applepencil.adapter.usb.c.fill") }
 
     /// 􁤑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -222,7 +222,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilAndScribble = SFSymbol(rawValue: "applepencil.and.scribble")
+    static var applepencilAndScribble: SFSymbol { .init(rawValue: "applepencil.and.scribble") }
 
     /// 􁰤
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -231,7 +231,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilGen1 = SFSymbol(rawValue: "applepencil.gen1")
+    static var applepencilGen1: SFSymbol { .init(rawValue: "applepencil.gen1") }
 
     /// 􁰥
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -240,7 +240,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilGen2 = SFSymbol(rawValue: "applepencil.gen2")
+    static var applepencilGen2: SFSymbol { .init(rawValue: "applepencil.gen2") }
 
     /// 􁤓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -250,7 +250,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilTip = SFSymbol(rawValue: "applepencil.tip")
+    static var applepencilTip: SFSymbol { .init(rawValue: "applepencil.tip") }
 
     /// 􂄅
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -264,14 +264,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchAndArrowForward = SymbolWith1Localization<Rtl>(rawValue: "applewatch.and.arrow.forward")
+    static var applewatchAndArrowForward: SymbolWith1Localization<Rtl> { .init(rawValue: "applewatch.and.arrow.forward") }
 
     /// 􁻻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appwindowSwipeRectangle = SFSymbol(rawValue: "appwindow.swipe.rectangle")
+    static var appwindowSwipeRectangle: SFSymbol { .init(rawValue: "appwindow.swipe.rectangle") }
 
     /// 􂁢
     /// Single Localization, 2 Layersets
@@ -279,7 +279,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStick = SFSymbol(rawValue: "arcade.stick")
+    static var arcadeStick: SFSymbol { .init(rawValue: "arcade.stick") }
 
     /// 􂁨
     /// Single Localization, 2 Layersets
@@ -287,7 +287,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowDown = SFSymbol(rawValue: "arcade.stick.and.arrow.down")
+    static var arcadeStickAndArrowDown: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.down") }
 
     /// 􂁤
     /// Single Localization, 2 Layersets
@@ -295,7 +295,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowLeft = SFSymbol(rawValue: "arcade.stick.and.arrow.left")
+    static var arcadeStickAndArrowLeft: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.left") }
 
     /// 􂁣
     /// Single Localization, 2 Layersets
@@ -308,7 +308,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "arcadeStickAndArrowLeftAndArrowRightOutward")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "arcadeStickAndArrowLeftAndArrowRightOutward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arcadeStickAndArrowLeftAndArrowRightOutward")
-    static let arcadeStickAndArrowLeftAndArrowRight = SFSymbol(rawValue: "arcade.stick.and.arrow.left.and.arrow.right")
+    static var arcadeStickAndArrowLeftAndArrowRight: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.left.and.arrow.right") }
 
     /// 􂁥
     /// Single Localization, 2 Layersets
@@ -316,7 +316,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowRight = SFSymbol(rawValue: "arcade.stick.and.arrow.right")
+    static var arcadeStickAndArrowRight: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.right") }
 
     /// 􂁧
     /// Single Localization, 2 Layersets
@@ -324,7 +324,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowUp = SFSymbol(rawValue: "arcade.stick.and.arrow.up")
+    static var arcadeStickAndArrowUp: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.up") }
 
     /// 􂁦
     /// Single Localization, 2 Layersets
@@ -332,7 +332,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowUpAndArrowDown = SFSymbol(rawValue: "arcade.stick.and.arrow.up.and.arrow.down")
+    static var arcadeStickAndArrowUpAndArrowDown: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.up.and.arrow.down") }
 
     /// 􂁠
     /// Single Localization, 2 Layersets
@@ -340,14 +340,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickConsole = SFSymbol(rawValue: "arcade.stick.console")
+    static var arcadeStickConsole: SFSymbol { .init(rawValue: "arcade.stick.console") }
 
     /// 􂁡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arcadeStickConsoleFill = SFSymbol(rawValue: "arcade.stick.console.fill")
+    static var arcadeStickConsoleFill: SFSymbol { .init(rawValue: "arcade.stick.console.fill") }
 
     /// 􂅕
     /// Single Localization, 2 Layersets
@@ -355,7 +355,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowBackwardToLineSquare = SFSymbol(rawValue: "arrow.backward.to.line.square")
+    static var arrowBackwardToLineSquare: SFSymbol { .init(rawValue: "arrow.backward.to.line.square") }
 
     /// 􂅖
     /// Single Localization, 3 Layersets
@@ -364,7 +364,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowBackwardToLineSquareFill = SFSymbol(rawValue: "arrow.backward.to.line.square.fill")
+    static var arrowBackwardToLineSquareFill: SFSymbol { .init(rawValue: "arrow.backward.to.line.square.fill") }
 
     /// 􁹠
     /// Single Localization, Single Layerset
@@ -376,7 +376,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "arrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "arrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTriangleheadCounterclockwiseRotate90")
-    static let arrowCirclepath = SFSymbol(rawValue: "arrow.circlepath")
+    static var arrowCirclepath: SFSymbol { .init(rawValue: "arrow.circlepath") }
 
     /// 􂅛
     /// Single Localization, 2 Layersets
@@ -384,7 +384,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowClockwiseSquare = SFSymbol(rawValue: "arrow.clockwise.square")
+    static var arrowClockwiseSquare: SFSymbol { .init(rawValue: "arrow.clockwise.square") }
 
     /// 􂅜
     /// Single Localization, 3 Layersets
@@ -393,7 +393,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowClockwiseSquareFill = SFSymbol(rawValue: "arrow.clockwise.square.fill")
+    static var arrowClockwiseSquareFill: SFSymbol { .init(rawValue: "arrow.clockwise.square.fill") }
 
     /// 􂅟
     /// Single Localization, 2 Layersets
@@ -401,7 +401,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowCounterclockwiseSquare = SFSymbol(rawValue: "arrow.counterclockwise.square")
+    static var arrowCounterclockwiseSquare: SFSymbol { .init(rawValue: "arrow.counterclockwise.square") }
 
     /// 􂅠
     /// Single Localization, 3 Layersets
@@ -410,7 +410,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowCounterclockwiseSquareFill = SFSymbol(rawValue: "arrow.counterclockwise.square.fill")
+    static var arrowCounterclockwiseSquareFill: SFSymbol { .init(rawValue: "arrow.counterclockwise.square.fill") }
 
     /// 􂄘
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -420,14 +420,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let arrowDownApplewatch = SFSymbol(rawValue: "arrow.down.applewatch")
+    static var arrowDownApplewatch: SFSymbol { .init(rawValue: "arrow.down.applewatch") }
 
     /// 􂄢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownBackwardAndArrowUpForward = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward")
+    static var arrowDownBackwardAndArrowUpForward: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward") }
 
     /// 􂄣
     /// Single Localization, 2 Layersets
@@ -435,7 +435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownBackwardAndArrowUpForwardCircle = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.circle")
+    static var arrowDownBackwardAndArrowUpForwardCircle: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.circle") }
 
     /// 􂄤
     /// Single Localization, 3 Layersets
@@ -444,7 +444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownBackwardAndArrowUpForwardCircleFill = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.circle.fill")
+    static var arrowDownBackwardAndArrowUpForwardCircleFill: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.circle.fill") }
 
     /// 􂅅
     /// Single Localization, 2 Layersets
@@ -452,7 +452,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownBackwardAndArrowUpForwardSquare = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.square")
+    static var arrowDownBackwardAndArrowUpForwardSquare: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.square") }
 
     /// 􂅆
     /// Single Localization, 3 Layersets
@@ -461,7 +461,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownBackwardAndArrowUpForwardSquareFill = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.square.fill")
+    static var arrowDownBackwardAndArrowUpForwardSquareFill: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.square.fill") }
 
     /// 􁻿
     /// Single Localization, 2 Layersets
@@ -469,7 +469,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownBackwardToptrailingRectangle = SFSymbol(rawValue: "arrow.down.backward.toptrailing.rectangle")
+    static var arrowDownBackwardToptrailingRectangle: SFSymbol { .init(rawValue: "arrow.down.backward.toptrailing.rectangle") }
 
     /// 􁼀
     /// Single Localization, 3 Layersets
@@ -478,7 +478,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownBackwardToptrailingRectangleFill = SFSymbol(rawValue: "arrow.down.backward.toptrailing.rectangle.fill")
+    static var arrowDownBackwardToptrailingRectangleFill: SFSymbol { .init(rawValue: "arrow.down.backward.toptrailing.rectangle.fill") }
 
     /// 􁹟
     /// Single Localization, 2 Layersets
@@ -486,7 +486,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownCircleDotted = SFSymbol(rawValue: "arrow.down.circle.dotted")
+    static var arrowDownCircleDotted: SFSymbol { .init(rawValue: "arrow.down.circle.dotted") }
 
     /// 􂅉
     /// Single Localization, 2 Layersets
@@ -494,7 +494,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownForwardAndArrowUpBackwardSquare = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.square")
+    static var arrowDownForwardAndArrowUpBackwardSquare: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.square") }
 
     /// 􂅊
     /// Single Localization, 3 Layersets
@@ -503,7 +503,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownForwardAndArrowUpBackwardSquareFill = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.square.fill")
+    static var arrowDownForwardAndArrowUpBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.square.fill") }
 
     /// 􁼋
     /// Single Localization, 2 Layersets
@@ -511,7 +511,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownForwardTopleadingRectangle = SFSymbol(rawValue: "arrow.down.forward.topleading.rectangle")
+    static var arrowDownForwardTopleadingRectangle: SFSymbol { .init(rawValue: "arrow.down.forward.topleading.rectangle") }
 
     /// 􁼌
     /// Single Localization, 3 Layersets
@@ -520,14 +520,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownForwardTopleadingRectangleFill = SFSymbol(rawValue: "arrow.down.forward.topleading.rectangle.fill")
+    static var arrowDownForwardTopleadingRectangleFill: SFSymbol { .init(rawValue: "arrow.down.forward.topleading.rectangle.fill") }
 
     /// 􂄝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowDownLeftAndArrowUpRight = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right")
+    static var arrowDownLeftAndArrowUpRight: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right") }
 
     /// 􂄞
     /// Single Localization, 2 Layersets
@@ -535,7 +535,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftAndArrowUpRightCircle = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.circle")
+    static var arrowDownLeftAndArrowUpRightCircle: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.circle") }
 
     /// 􂄟
     /// Single Localization, 3 Layersets
@@ -544,7 +544,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftAndArrowUpRightCircleFill = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.circle.fill")
+    static var arrowDownLeftAndArrowUpRightCircleFill: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.circle.fill") }
 
     /// 􂅃
     /// Single Localization, 2 Layersets
@@ -552,7 +552,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftAndArrowUpRightSquare = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.square")
+    static var arrowDownLeftAndArrowUpRightSquare: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.square") }
 
     /// 􂅄
     /// Single Localization, 3 Layersets
@@ -561,7 +561,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftAndArrowUpRightSquareFill = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.square.fill")
+    static var arrowDownLeftAndArrowUpRightSquareFill: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.square.fill") }
 
     /// 􁽧
     /// Single Localization, 2 Layersets
@@ -569,7 +569,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftArrowUpRight = SFSymbol(rawValue: "arrow.down.left.arrow.up.right")
+    static var arrowDownLeftArrowUpRight: SFSymbol { .init(rawValue: "arrow.down.left.arrow.up.right") }
 
     /// 􁽨
     /// Single Localization, 2 Layersets
@@ -577,7 +577,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftArrowUpRightCircle = SFSymbol(rawValue: "arrow.down.left.arrow.up.right.circle")
+    static var arrowDownLeftArrowUpRightCircle: SFSymbol { .init(rawValue: "arrow.down.left.arrow.up.right.circle") }
 
     /// 􁽩
     /// Single Localization, 3 Layersets
@@ -586,7 +586,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftArrowUpRightCircleFill = SFSymbol(rawValue: "arrow.down.left.arrow.up.right.circle.fill")
+    static var arrowDownLeftArrowUpRightCircleFill: SFSymbol { .init(rawValue: "arrow.down.left.arrow.up.right.circle.fill") }
 
     /// 􁽪
     /// Single Localization, 2 Layersets
@@ -594,7 +594,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftArrowUpRightSquare = SFSymbol(rawValue: "arrow.down.left.arrow.up.right.square")
+    static var arrowDownLeftArrowUpRightSquare: SFSymbol { .init(rawValue: "arrow.down.left.arrow.up.right.square") }
 
     /// 􁽫
     /// Single Localization, 3 Layersets
@@ -603,7 +603,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftArrowUpRightSquareFill = SFSymbol(rawValue: "arrow.down.left.arrow.up.right.square.fill")
+    static var arrowDownLeftArrowUpRightSquareFill: SFSymbol { .init(rawValue: "arrow.down.left.arrow.up.right.square.fill") }
 
     /// 􁻽
     /// Single Localization, 2 Layersets
@@ -611,7 +611,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftToprightRectangle = SFSymbol(rawValue: "arrow.down.left.topright.rectangle")
+    static var arrowDownLeftToprightRectangle: SFSymbol { .init(rawValue: "arrow.down.left.topright.rectangle") }
 
     /// 􁻾
     /// Single Localization, 3 Layersets
@@ -620,7 +620,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftToprightRectangleFill = SFSymbol(rawValue: "arrow.down.left.topright.rectangle.fill")
+    static var arrowDownLeftToprightRectangleFill: SFSymbol { .init(rawValue: "arrow.down.left.topright.rectangle.fill") }
 
     /// 􂅇
     /// Single Localization, 2 Layersets
@@ -628,7 +628,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownRightAndArrowUpLeftSquare = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.square")
+    static var arrowDownRightAndArrowUpLeftSquare: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.square") }
 
     /// 􂅈
     /// Single Localization, 3 Layersets
@@ -637,7 +637,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownRightAndArrowUpLeftSquareFill = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.square.fill")
+    static var arrowDownRightAndArrowUpLeftSquareFill: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.square.fill") }
 
     /// 􁼉
     /// Single Localization, 2 Layersets
@@ -645,7 +645,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownRightTopleftRectangle = SFSymbol(rawValue: "arrow.down.right.topleft.rectangle")
+    static var arrowDownRightTopleftRectangle: SFSymbol { .init(rawValue: "arrow.down.right.topleft.rectangle") }
 
     /// 􁼊
     /// Single Localization, 3 Layersets
@@ -654,7 +654,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownRightTopleftRectangleFill = SFSymbol(rawValue: "arrow.down.right.topleft.rectangle.fill")
+    static var arrowDownRightTopleftRectangleFill: SFSymbol { .init(rawValue: "arrow.down.right.topleft.rectangle.fill") }
 
     /// 􂅑
     /// Single Localization, 2 Layersets
@@ -662,7 +662,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownToLineSquare = SFSymbol(rawValue: "arrow.down.to.line.square")
+    static var arrowDownToLineSquare: SFSymbol { .init(rawValue: "arrow.down.to.line.square") }
 
     /// 􂅒
     /// Single Localization, 3 Layersets
@@ -671,7 +671,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownToLineSquareFill = SFSymbol(rawValue: "arrow.down.to.line.square.fill")
+    static var arrowDownToLineSquareFill: SFSymbol { .init(rawValue: "arrow.down.to.line.square.fill") }
 
     /// 􂅙
     /// Single Localization, 2 Layersets
@@ -679,7 +679,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowForwardToLineSquare = SFSymbol(rawValue: "arrow.forward.to.line.square")
+    static var arrowForwardToLineSquare: SFSymbol { .init(rawValue: "arrow.forward.to.line.square") }
 
     /// 􂅚
     /// Single Localization, 3 Layersets
@@ -688,7 +688,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowForwardToLineSquareFill = SFSymbol(rawValue: "arrow.forward.to.line.square.fill")
+    static var arrowForwardToLineSquareFill: SFSymbol { .init(rawValue: "arrow.forward.to.line.square.fill") }
 
     /// 􂅓
     /// Single Localization, 2 Layersets
@@ -696,7 +696,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowLeftToLineSquare = SFSymbol(rawValue: "arrow.left.to.line.square")
+    static var arrowLeftToLineSquare: SFSymbol { .init(rawValue: "arrow.left.to.line.square") }
 
     /// 􂅔
     /// Single Localization, 3 Layersets
@@ -705,7 +705,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowLeftToLineSquareFill = SFSymbol(rawValue: "arrow.left.to.line.square.fill")
+    static var arrowLeftToLineSquareFill: SFSymbol { .init(rawValue: "arrow.left.to.line.square.fill") }
 
     /// 􂅗
     /// Single Localization, 2 Layersets
@@ -713,7 +713,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowRightToLineSquare = SFSymbol(rawValue: "arrow.right.to.line.square")
+    static var arrowRightToLineSquare: SFSymbol { .init(rawValue: "arrow.right.to.line.square") }
 
     /// 􂅘
     /// Single Localization, 3 Layersets
@@ -722,7 +722,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowRightToLineSquareFill = SFSymbol(rawValue: "arrow.right.to.line.square.fill")
+    static var arrowRightToLineSquareFill: SFSymbol { .init(rawValue: "arrow.right.to.line.square.fill") }
 
     /// 􂆍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -737,7 +737,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90Icloud")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90Icloud")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90Icloud")
-    static let arrowTriangle2CirclepathIcloud = SFSymbol(rawValue: "arrow.triangle.2.circlepath.icloud")
+    static var arrowTriangle2CirclepathIcloud: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.icloud") }
 
     /// 􂆎
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -753,7 +753,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "arrowTrianglehead2ClockwiseRotate90IcloudFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "arrowTrianglehead2ClockwiseRotate90IcloudFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "arrowTrianglehead2ClockwiseRotate90IcloudFill")
-    static let arrowTriangle2CirclepathIcloudFill = SFSymbol(rawValue: "arrow.triangle.2.circlepath.icloud.fill")
+    static var arrowTriangle2CirclepathIcloudFill: SFSymbol { .init(rawValue: "arrow.triangle.2.circlepath.icloud.fill") }
 
     /// 􂅁
     /// Single Localization, 2 Layersets
@@ -761,7 +761,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpBackwardAndArrowDownForwardSquare = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.square")
+    static var arrowUpBackwardAndArrowDownForwardSquare: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.square") }
 
     /// 􂅂
     /// Single Localization, 3 Layersets
@@ -770,7 +770,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpBackwardAndArrowDownForwardSquareFill = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.square.fill")
+    static var arrowUpBackwardAndArrowDownForwardSquareFill: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.square.fill") }
 
     /// 􁼃
     /// Single Localization, 2 Layersets
@@ -778,7 +778,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpBackwardBottomtrailingRectangle = SFSymbol(rawValue: "arrow.up.backward.bottomtrailing.rectangle")
+    static var arrowUpBackwardBottomtrailingRectangle: SFSymbol { .init(rawValue: "arrow.up.backward.bottomtrailing.rectangle") }
 
     /// 􁼄
     /// Single Localization, 3 Layersets
@@ -787,14 +787,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpBackwardBottomtrailingRectangleFill = SFSymbol(rawValue: "arrow.up.backward.bottomtrailing.rectangle.fill")
+    static var arrowUpBackwardBottomtrailingRectangleFill: SFSymbol { .init(rawValue: "arrow.up.backward.bottomtrailing.rectangle.fill") }
 
     /// 􂄬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpForwardAndArrowDownBackward = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward")
+    static var arrowUpForwardAndArrowDownBackward: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward") }
 
     /// 􂄭
     /// Single Localization, 2 Layersets
@@ -802,7 +802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpForwardAndArrowDownBackwardCircle = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.circle")
+    static var arrowUpForwardAndArrowDownBackwardCircle: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.circle") }
 
     /// 􂄮
     /// Single Localization, 3 Layersets
@@ -811,7 +811,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpForwardAndArrowDownBackwardCircleFill = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.circle.fill")
+    static var arrowUpForwardAndArrowDownBackwardCircleFill: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.circle.fill") }
 
     /// 􂅍
     /// Single Localization, 2 Layersets
@@ -819,7 +819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpForwardAndArrowDownBackwardSquare = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.square")
+    static var arrowUpForwardAndArrowDownBackwardSquare: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.square") }
 
     /// 􂅎
     /// Single Localization, 3 Layersets
@@ -828,7 +828,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpForwardAndArrowDownBackwardSquareFill = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.square.fill")
+    static var arrowUpForwardAndArrowDownBackwardSquareFill: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.square.fill") }
 
     /// 􁼇
     /// Single Localization, 2 Layersets
@@ -836,7 +836,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpForwardBottomleadingRectangle = SFSymbol(rawValue: "arrow.up.forward.bottomleading.rectangle")
+    static var arrowUpForwardBottomleadingRectangle: SFSymbol { .init(rawValue: "arrow.up.forward.bottomleading.rectangle") }
 
     /// 􁼈
     /// Single Localization, 3 Layersets
@@ -845,7 +845,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpForwardBottomleadingRectangleFill = SFSymbol(rawValue: "arrow.up.forward.bottomleading.rectangle.fill")
+    static var arrowUpForwardBottomleadingRectangleFill: SFSymbol { .init(rawValue: "arrow.up.forward.bottomleading.rectangle.fill") }
 
     /// 􂄿
     /// Single Localization, 2 Layersets
@@ -853,7 +853,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftAndArrowDownRightSquare = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.square")
+    static var arrowUpLeftAndArrowDownRightSquare: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.square") }
 
     /// 􂅀
     /// Single Localization, 3 Layersets
@@ -862,7 +862,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpLeftAndArrowDownRightSquareFill = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.square.fill")
+    static var arrowUpLeftAndArrowDownRightSquareFill: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.square.fill") }
 
     /// 􁾒
     /// Single Localization, 2 Layersets
@@ -870,7 +870,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftArrowDownRight = SFSymbol(rawValue: "arrow.up.left.arrow.down.right")
+    static var arrowUpLeftArrowDownRight: SFSymbol { .init(rawValue: "arrow.up.left.arrow.down.right") }
 
     /// 􁾓
     /// Single Localization, 2 Layersets
@@ -878,7 +878,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftArrowDownRightCircle = SFSymbol(rawValue: "arrow.up.left.arrow.down.right.circle")
+    static var arrowUpLeftArrowDownRightCircle: SFSymbol { .init(rawValue: "arrow.up.left.arrow.down.right.circle") }
 
     /// 􁾔
     /// Single Localization, 3 Layersets
@@ -887,7 +887,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpLeftArrowDownRightCircleFill = SFSymbol(rawValue: "arrow.up.left.arrow.down.right.circle.fill")
+    static var arrowUpLeftArrowDownRightCircleFill: SFSymbol { .init(rawValue: "arrow.up.left.arrow.down.right.circle.fill") }
 
     /// 􁾕
     /// Single Localization, 2 Layersets
@@ -895,7 +895,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftArrowDownRightSquare = SFSymbol(rawValue: "arrow.up.left.arrow.down.right.square")
+    static var arrowUpLeftArrowDownRightSquare: SFSymbol { .init(rawValue: "arrow.up.left.arrow.down.right.square") }
 
     /// 􁾖
     /// Single Localization, 3 Layersets
@@ -904,7 +904,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpLeftArrowDownRightSquareFill = SFSymbol(rawValue: "arrow.up.left.arrow.down.right.square.fill")
+    static var arrowUpLeftArrowDownRightSquareFill: SFSymbol { .init(rawValue: "arrow.up.left.arrow.down.right.square.fill") }
 
     /// 􁼁
     /// Single Localization, 2 Layersets
@@ -912,7 +912,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftBottomrightRectangle = SFSymbol(rawValue: "arrow.up.left.bottomright.rectangle")
+    static var arrowUpLeftBottomrightRectangle: SFSymbol { .init(rawValue: "arrow.up.left.bottomright.rectangle") }
 
     /// 􁼂
     /// Single Localization, 3 Layersets
@@ -921,14 +921,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpLeftBottomrightRectangleFill = SFSymbol(rawValue: "arrow.up.left.bottomright.rectangle.fill")
+    static var arrowUpLeftBottomrightRectangleFill: SFSymbol { .init(rawValue: "arrow.up.left.bottomright.rectangle.fill") }
 
     /// 􂄧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowUpRightAndArrowDownLeft = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left")
+    static var arrowUpRightAndArrowDownLeft: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left") }
 
     /// 􂄨
     /// Single Localization, 2 Layersets
@@ -936,7 +936,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpRightAndArrowDownLeftCircle = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.circle")
+    static var arrowUpRightAndArrowDownLeftCircle: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.circle") }
 
     /// 􂄩
     /// Single Localization, 3 Layersets
@@ -945,7 +945,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpRightAndArrowDownLeftCircleFill = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.circle.fill")
+    static var arrowUpRightAndArrowDownLeftCircleFill: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.circle.fill") }
 
     /// 􂅋
     /// Single Localization, 2 Layersets
@@ -953,7 +953,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpRightAndArrowDownLeftSquare = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.square")
+    static var arrowUpRightAndArrowDownLeftSquare: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.square") }
 
     /// 􂅌
     /// Single Localization, 3 Layersets
@@ -962,7 +962,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpRightAndArrowDownLeftSquareFill = SFSymbol(rawValue: "arrow.up.right.and.arrow.down.left.square.fill")
+    static var arrowUpRightAndArrowDownLeftSquareFill: SFSymbol { .init(rawValue: "arrow.up.right.and.arrow.down.left.square.fill") }
 
     /// 􁼅
     /// Single Localization, 2 Layersets
@@ -970,7 +970,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpRightBottomleftRectangle = SFSymbol(rawValue: "arrow.up.right.bottomleft.rectangle")
+    static var arrowUpRightBottomleftRectangle: SFSymbol { .init(rawValue: "arrow.up.right.bottomleft.rectangle") }
 
     /// 􁼆
     /// Single Localization, 3 Layersets
@@ -979,7 +979,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpRightBottomleftRectangleFill = SFSymbol(rawValue: "arrow.up.right.bottomleft.rectangle.fill")
+    static var arrowUpRightBottomleftRectangleFill: SFSymbol { .init(rawValue: "arrow.up.right.bottomleft.rectangle.fill") }
 
     /// 􂅏
     /// Single Localization, 2 Layersets
@@ -987,7 +987,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpToLineSquare = SFSymbol(rawValue: "arrow.up.to.line.square")
+    static var arrowUpToLineSquare: SFSymbol { .init(rawValue: "arrow.up.to.line.square") }
 
     /// 􂅐
     /// Single Localization, 3 Layersets
@@ -996,7 +996,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpToLineSquareFill = SFSymbol(rawValue: "arrow.up.to.line.square.fill")
+    static var arrowUpToLineSquareFill: SFSymbol { .init(rawValue: "arrow.up.to.line.square.fill") }
 
     /// 􁣈
     /// Single Localization, 3 Layersets
@@ -1005,7 +1005,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpTrash = SFSymbol(rawValue: "arrow.up.trash")
+    static var arrowUpTrash: SFSymbol { .init(rawValue: "arrow.up.trash") }
 
     /// 􁣉
     /// Single Localization, 3 Layersets
@@ -1014,7 +1014,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpTrashFill = SFSymbol(rawValue: "arrow.up.trash.fill")
+    static var arrowUpTrashFill: SFSymbol { .init(rawValue: "arrow.up.trash.fill") }
 
     /// 􁾰
     /// Single Localization, 2 Layersets
@@ -1022,7 +1022,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeys = SFSymbol(rawValue: "arrowkeys")
+    static var arrowkeys: SFSymbol { .init(rawValue: "arrowkeys") }
 
     /// 􁾳
     /// Single Localization, 2 Layersets
@@ -1030,7 +1030,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeysDownFilled = SFSymbol(rawValue: "arrowkeys.down.filled")
+    static var arrowkeysDownFilled: SFSymbol { .init(rawValue: "arrowkeys.down.filled") }
 
     /// 􁾱
     /// Single Localization, 2 Layersets
@@ -1038,7 +1038,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeysFill = SFSymbol(rawValue: "arrowkeys.fill")
+    static var arrowkeysFill: SFSymbol { .init(rawValue: "arrowkeys.fill") }
 
     /// 􁾴
     /// Single Localization, 2 Layersets
@@ -1046,7 +1046,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeysLeftFilled = SFSymbol(rawValue: "arrowkeys.left.filled")
+    static var arrowkeysLeftFilled: SFSymbol { .init(rawValue: "arrowkeys.left.filled") }
 
     /// 􁾵
     /// Single Localization, 2 Layersets
@@ -1054,7 +1054,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeysRightFilled = SFSymbol(rawValue: "arrowkeys.right.filled")
+    static var arrowkeysRightFilled: SFSymbol { .init(rawValue: "arrowkeys.right.filled") }
 
     /// 􁾲
     /// Single Localization, 2 Layersets
@@ -1062,7 +1062,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowkeysUpFilled = SFSymbol(rawValue: "arrowkeys.up.filled")
+    static var arrowkeysUpFilled: SFSymbol { .init(rawValue: "arrowkeys.up.filled") }
 
     /// 􁾢
     /// Single Localization, 2 Layersets
@@ -1070,7 +1070,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeBackwardCircle = SFSymbol(rawValue: "arrowshape.backward.circle")
+    static var arrowshapeBackwardCircle: SFSymbol { .init(rawValue: "arrowshape.backward.circle") }
 
     /// 􁾣
     /// Single Localization, 3 Layersets
@@ -1079,14 +1079,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeBackwardCircleFill = SFSymbol(rawValue: "arrowshape.backward.circle.fill")
+    static var arrowshapeBackwardCircleFill: SFSymbol { .init(rawValue: "arrowshape.backward.circle.fill") }
 
     /// 􁾬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeDown = SFSymbol(rawValue: "arrowshape.down")
+    static var arrowshapeDown: SFSymbol { .init(rawValue: "arrowshape.down") }
 
     /// 􁾮
     /// Single Localization, 2 Layersets
@@ -1094,7 +1094,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeDownCircle = SFSymbol(rawValue: "arrowshape.down.circle")
+    static var arrowshapeDownCircle: SFSymbol { .init(rawValue: "arrowshape.down.circle") }
 
     /// 􁾯
     /// Single Localization, 3 Layersets
@@ -1103,14 +1103,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeDownCircleFill = SFSymbol(rawValue: "arrowshape.down.circle.fill")
+    static var arrowshapeDownCircleFill: SFSymbol { .init(rawValue: "arrowshape.down.circle.fill") }
 
     /// 􁾭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeDownFill = SFSymbol(rawValue: "arrowshape.down.fill")
+    static var arrowshapeDownFill: SFSymbol { .init(rawValue: "arrowshape.down.fill") }
 
     /// 􁾦
     /// Single Localization, 2 Layersets
@@ -1118,7 +1118,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeForwardCircle = SFSymbol(rawValue: "arrowshape.forward.circle")
+    static var arrowshapeForwardCircle: SFSymbol { .init(rawValue: "arrowshape.forward.circle") }
 
     /// 􁾧
     /// Single Localization, 3 Layersets
@@ -1127,21 +1127,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeForwardCircleFill = SFSymbol(rawValue: "arrowshape.forward.circle.fill")
+    static var arrowshapeForwardCircleFill: SFSymbol { .init(rawValue: "arrowshape.forward.circle.fill") }
 
     /// 􁉾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeLeftArrowshapeRight = SFSymbol(rawValue: "arrowshape.left.arrowshape.right")
+    static var arrowshapeLeftArrowshapeRight: SFSymbol { .init(rawValue: "arrowshape.left.arrowshape.right") }
 
     /// 􁉿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeLeftArrowshapeRightFill = SFSymbol(rawValue: "arrowshape.left.arrowshape.right.fill")
+    static var arrowshapeLeftArrowshapeRightFill: SFSymbol { .init(rawValue: "arrowshape.left.arrowshape.right.fill") }
 
     /// 􁾠
     /// Single Localization, 2 Layersets
@@ -1149,7 +1149,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeLeftCircle = SFSymbol(rawValue: "arrowshape.left.circle")
+    static var arrowshapeLeftCircle: SFSymbol { .init(rawValue: "arrowshape.left.circle") }
 
     /// 􁾡
     /// Single Localization, 3 Layersets
@@ -1158,7 +1158,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeLeftCircleFill = SFSymbol(rawValue: "arrowshape.left.circle.fill")
+    static var arrowshapeLeftCircleFill: SFSymbol { .init(rawValue: "arrowshape.left.circle.fill") }
 
     /// 􁾤
     /// Single Localization, 2 Layersets
@@ -1166,7 +1166,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeRightCircle = SFSymbol(rawValue: "arrowshape.right.circle")
+    static var arrowshapeRightCircle: SFSymbol { .init(rawValue: "arrowshape.right.circle") }
 
     /// 􁾥
     /// Single Localization, 3 Layersets
@@ -1175,14 +1175,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeRightCircleFill = SFSymbol(rawValue: "arrowshape.right.circle.fill")
+    static var arrowshapeRightCircleFill: SFSymbol { .init(rawValue: "arrowshape.right.circle.fill") }
 
     /// 􁾨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeUp = SFSymbol(rawValue: "arrowshape.up")
+    static var arrowshapeUp: SFSymbol { .init(rawValue: "arrowshape.up") }
 
     /// 􁾪
     /// Single Localization, 2 Layersets
@@ -1190,7 +1190,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowshapeUpCircle = SFSymbol(rawValue: "arrowshape.up.circle")
+    static var arrowshapeUpCircle: SFSymbol { .init(rawValue: "arrowshape.up.circle") }
 
     /// 􁾫
     /// Single Localization, 3 Layersets
@@ -1199,14 +1199,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowshapeUpCircleFill = SFSymbol(rawValue: "arrowshape.up.circle.fill")
+    static var arrowshapeUpCircleFill: SFSymbol { .init(rawValue: "arrowshape.up.circle.fill") }
 
     /// 􁾩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowshapeUpFill = SFSymbol(rawValue: "arrowshape.up.fill")
+    static var arrowshapeUpFill: SFSymbol { .init(rawValue: "arrowshape.up.fill") }
 
     /// 􁊝
     /// Single Localization, 2 Layersets
@@ -1214,7 +1214,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowtriangleUpArrowtriangleDownWindowLeft = SFSymbol(rawValue: "arrowtriangle.up.arrowtriangle.down.window.left")
+    static var arrowtriangleUpArrowtriangleDownWindowLeft: SFSymbol { .init(rawValue: "arrowtriangle.up.arrowtriangle.down.window.left") }
 
     /// 􁉝
     /// Single Localization, 2 Layersets
@@ -1222,14 +1222,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowtriangleUpArrowtriangleDownWindowRight = SFSymbol(rawValue: "arrowtriangle.up.arrowtriangle.down.window.right")
+    static var arrowtriangleUpArrowtriangleDownWindowRight: SFSymbol { .init(rawValue: "arrowtriangle.up.arrowtriangle.down.window.right") }
 
     /// 􁾍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let australiandollarsign = SFSymbol(rawValue: "australiandollarsign")
+    static var australiandollarsign: SFSymbol { .init(rawValue: "australiandollarsign") }
 
     /// 􂈹
     /// Single Localization, 2 Layersets
@@ -1242,7 +1242,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "australiandollarsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "australiandollarsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "australiandollarsignArrowTriangleheadCounterclockwiseRotate90")
-    static let australiandollarsignArrowCirclepath = SFSymbol(rawValue: "australiandollarsign.arrow.circlepath")
+    static var australiandollarsignArrowCirclepath: SFSymbol { .init(rawValue: "australiandollarsign.arrow.circlepath") }
 
     /// 􀮠
     /// Single Localization, 2 Layersets
@@ -1250,7 +1250,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignCircle = SFSymbol(rawValue: "australiandollarsign.circle")
+    static var australiandollarsignCircle: SFSymbol { .init(rawValue: "australiandollarsign.circle") }
 
     /// 􀮡
     /// Single Localization, 3 Layersets
@@ -1259,7 +1259,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let australiandollarsignCircleFill = SFSymbol(rawValue: "australiandollarsign.circle.fill")
+    static var australiandollarsignCircleFill: SFSymbol { .init(rawValue: "australiandollarsign.circle.fill") }
 
     /// 􀮢
     /// Single Localization, 2 Layersets
@@ -1267,7 +1267,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignSquare = SFSymbol(rawValue: "australiandollarsign.square")
+    static var australiandollarsignSquare: SFSymbol { .init(rawValue: "australiandollarsign.square") }
 
     /// 􀮣
     /// Single Localization, 3 Layersets
@@ -1276,7 +1276,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let australiandollarsignSquareFill = SFSymbol(rawValue: "australiandollarsign.square.fill")
+    static var australiandollarsignSquareFill: SFSymbol { .init(rawValue: "australiandollarsign.square.fill") }
 
     /// 􂈣
     /// Single Localization, 2 Layersets
@@ -1289,7 +1289,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "australsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "australsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "australsignArrowTriangleheadCounterclockwiseRotate90")
-    static let australsignArrowCirclepath = SFSymbol(rawValue: "australsign.arrow.circlepath")
+    static var australsignArrowCirclepath: SFSymbol { .init(rawValue: "australsign.arrow.circlepath") }
 
     /// 􁟁
     /// Single Localization, 2 Layersets
@@ -1297,7 +1297,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let automaticBrakesignal = SFSymbol(rawValue: "automatic.brakesignal")
+    static var automaticBrakesignal: SFSymbol { .init(rawValue: "automatic.brakesignal") }
 
     /// 􁢧
     /// Single Localization, 3 Layersets
@@ -1306,7 +1306,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let automaticHeadlightHighBeam = SFSymbol(rawValue: "automatic.headlight.high.beam")
+    static var automaticHeadlightHighBeam: SFSymbol { .init(rawValue: "automatic.headlight.high.beam") }
 
     /// 􁢨
     /// Single Localization, 3 Layersets
@@ -1315,7 +1315,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let automaticHeadlightHighBeamFill = SFSymbol(rawValue: "automatic.headlight.high.beam.fill")
+    static var automaticHeadlightHighBeamFill: SFSymbol { .init(rawValue: "automatic.headlight.high.beam.fill") }
 
     /// 􁢩
     /// Single Localization, 3 Layersets
@@ -1324,7 +1324,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let automaticHeadlightLowBeam = SFSymbol(rawValue: "automatic.headlight.low.beam")
+    static var automaticHeadlightLowBeam: SFSymbol { .init(rawValue: "automatic.headlight.low.beam") }
 
     /// 􁢪
     /// Single Localization, 3 Layersets
@@ -1333,7 +1333,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let automaticHeadlightLowBeamFill = SFSymbol(rawValue: "automatic.headlight.low.beam.fill")
+    static var automaticHeadlightLowBeamFill: SFSymbol { .init(rawValue: "automatic.headlight.low.beam.fill") }
 
     /// 􁠤
     /// Single Localization, 2 Layersets
@@ -1341,7 +1341,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let axle2DriveshaftDisengaged = SFSymbol(rawValue: "axle.2.driveshaft.disengaged")
+    static var axle2DriveshaftDisengaged: SFSymbol { .init(rawValue: "axle.2.driveshaft.disengaged") }
 
     /// 􁠢
     /// Single Localization, 2 Layersets
@@ -1349,7 +1349,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let axle2FrontDisengaged = SFSymbol(rawValue: "axle.2.front.disengaged")
+    static var axle2FrontDisengaged: SFSymbol { .init(rawValue: "axle.2.front.disengaged") }
 
     /// 􁠣
     /// Single Localization, 2 Layersets
@@ -1357,7 +1357,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let axle2RearDisengaged = SFSymbol(rawValue: "axle.2.rear.disengaged")
+    static var axle2RearDisengaged: SFSymbol { .init(rawValue: "axle.2.rear.disengaged") }
 
     /// 􁠨
     /// Single Localization, 2 Layersets
@@ -1365,7 +1365,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let axle2RearLock = SFSymbol(rawValue: "axle.2.rear.lock")
+    static var axle2RearLock: SFSymbol { .init(rawValue: "axle.2.rear.lock") }
 
     /// 􂈯
     /// Single Localization, 2 Layersets
@@ -1378,7 +1378,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "bahtsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "bahtsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "bahtsignArrowTriangleheadCounterclockwiseRotate90")
-    static let bahtsignArrowCirclepath = SFSymbol(rawValue: "bahtsign.arrow.circlepath")
+    static var bahtsignArrowCirclepath: SFSymbol { .init(rawValue: "bahtsign.arrow.circlepath") }
 
     /// 􀛪
     /// Single Localization, 2 Layersets
@@ -1386,7 +1386,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let battery0percent = SFSymbol(rawValue: "battery.0percent")
+    static var battery0percent: SFSymbol { .init(rawValue: "battery.0percent") }
 
     /// 􀛩
     /// Single Localization, 3 Layersets
@@ -1395,7 +1395,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery25percent = SFSymbol(rawValue: "battery.25percent")
+    static var battery25percent: SFSymbol { .init(rawValue: "battery.25percent") }
 
     /// 􀺶
     /// Single Localization, 3 Layersets
@@ -1404,7 +1404,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery50percent = SFSymbol(rawValue: "battery.50percent")
+    static var battery50percent: SFSymbol { .init(rawValue: "battery.50percent") }
 
     /// 􀺸
     /// Single Localization, 3 Layersets
@@ -1413,7 +1413,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery75percent = SFSymbol(rawValue: "battery.75percent")
+    static var battery75percent: SFSymbol { .init(rawValue: "battery.75percent") }
 
     /// 􀛨
     /// Single Localization, 3 Layersets
@@ -1422,7 +1422,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery100percent = SFSymbol(rawValue: "battery.100percent")
+    static var battery100percent: SFSymbol { .init(rawValue: "battery.100percent") }
 
     /// 􀢋
     /// 2 Localizations, 3 Layersets
@@ -1435,7 +1435,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery100percentBolt = SymbolWith1Localization<Rtl>(rawValue: "battery.100percent.bolt")
+    static var battery100percentBolt: SymbolWith1Localization<Rtl> { .init(rawValue: "battery.100percent.bolt") }
 
     /// 􁁔
     /// Single Localization, 3 Layersets
@@ -1444,7 +1444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery100percentCircle = SFSymbol(rawValue: "battery.100percent.circle")
+    static var battery100percentCircle: SFSymbol { .init(rawValue: "battery.100percent.circle") }
 
     /// 􁁕
     /// Single Localization, 3 Layersets
@@ -1453,7 +1453,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let battery100percentCircleFill = SFSymbol(rawValue: "battery.100percent.circle.fill")
+    static var battery100percentCircleFill: SFSymbol { .init(rawValue: "battery.100percent.circle.fill") }
 
     /// 􁅞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1463,7 +1463,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Fit Pro.
-    static let beatsFitpro = SFSymbol(rawValue: "beats.fitpro")
+    static var beatsFitpro: SFSymbol { .init(rawValue: "beats.fitpro") }
 
     /// 􁅡
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1472,7 +1472,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Fit Pro case.
-    static let beatsFitproChargingcase = SFSymbol(rawValue: "beats.fitpro.chargingcase")
+    static var beatsFitproChargingcase: SFSymbol { .init(rawValue: "beats.fitpro.chargingcase") }
 
     /// 􁅢
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1481,7 +1481,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Fit Pro case.
-    static let beatsFitproChargingcaseFill = SFSymbol(rawValue: "beats.fitpro.chargingcase.fill")
+    static var beatsFitproChargingcaseFill: SFSymbol { .init(rawValue: "beats.fitpro.chargingcase.fill") }
 
     /// 􁅟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1491,7 +1491,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Fit Pro.
-    static let beatsFitproLeft = SFSymbol(rawValue: "beats.fitpro.left")
+    static var beatsFitproLeft: SFSymbol { .init(rawValue: "beats.fitpro.left") }
 
     /// 􁅠
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1501,7 +1501,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Fit Pro.
-    static let beatsFitproRight = SFSymbol(rawValue: "beats.fitpro.right")
+    static var beatsFitproRight: SFSymbol { .init(rawValue: "beats.fitpro.right") }
 
     /// 􁹳
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1516,7 +1516,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "beatsStudiobudsPlus")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "beatsStudiobudsPlus")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsPlus")
-    static let beatsStudiobudsplus = SFSymbol(rawValue: "beats.studiobudsplus")
+    static var beatsStudiobudsplus: SFSymbol { .init(rawValue: "beats.studiobudsplus") }
 
     /// 􁹶
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1530,7 +1530,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "beatsStudiobudsPlusChargingcase")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "beatsStudiobudsPlusChargingcase")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsPlusChargingcase")
-    static let beatsStudiobudsplusChargingcase = SFSymbol(rawValue: "beats.studiobudsplus.chargingcase")
+    static var beatsStudiobudsplusChargingcase: SFSymbol { .init(rawValue: "beats.studiobudsplus.chargingcase") }
 
     /// 􁹷
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1544,7 +1544,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "beatsStudiobudsPlusChargingcaseFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "beatsStudiobudsPlusChargingcaseFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsPlusChargingcaseFill")
-    static let beatsStudiobudsplusChargingcaseFill = SFSymbol(rawValue: "beats.studiobudsplus.chargingcase.fill")
+    static var beatsStudiobudsplusChargingcaseFill: SFSymbol { .init(rawValue: "beats.studiobudsplus.chargingcase.fill") }
 
     /// 􁹴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1559,7 +1559,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "beatsStudiobudsPlusLeft")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "beatsStudiobudsPlusLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsPlusLeft")
-    static let beatsStudiobudsplusLeft = SFSymbol(rawValue: "beats.studiobudsplus.left")
+    static var beatsStudiobudsplusLeft: SFSymbol { .init(rawValue: "beats.studiobudsplus.left") }
 
     /// 􁹵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1574,7 +1574,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "beatsStudiobudsPlusRight")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "beatsStudiobudsPlusRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "beatsStudiobudsPlusRight")
-    static let beatsStudiobudsplusRight = SFSymbol(rawValue: "beats.studiobudsplus.right")
+    static var beatsStudiobudsplusRight: SFSymbol { .init(rawValue: "beats.studiobudsplus.right") }
 
     /// 􂄱
     /// 2 Localizations, 2 Layersets
@@ -1586,7 +1586,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bellBadgeSlash = SymbolWith1Localization<Rtl>(rawValue: "bell.badge.slash")
+    static var bellBadgeSlash: SymbolWith1Localization<Rtl> { .init(rawValue: "bell.badge.slash") }
 
     /// 􂄲
     /// 2 Localizations, 2 Layersets
@@ -1598,7 +1598,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bellBadgeSlashFill = SymbolWith1Localization<Rtl>(rawValue: "bell.badge.slash.fill")
+    static var bellBadgeSlashFill: SymbolWith1Localization<Rtl> { .init(rawValue: "bell.badge.slash.fill") }
 
     /// 􀻿
     /// Single Localization, 3 Layersets
@@ -1607,7 +1607,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellBadgeWaveform = SFSymbol(rawValue: "bell.badge.waveform")
+    static var bellBadgeWaveform: SFSymbol { .init(rawValue: "bell.badge.waveform") }
 
     /// 􀼀
     /// Single Localization, 3 Layersets
@@ -1616,7 +1616,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bellBadgeWaveformFill = SFSymbol(rawValue: "bell.badge.waveform.fill")
+    static var bellBadgeWaveformFill: SFSymbol { .init(rawValue: "bell.badge.waveform.fill") }
 
     /// 􁣙
     /// Single Localization, 2 Layersets
@@ -1624,7 +1624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let binocularsCircle = SFSymbol(rawValue: "binoculars.circle")
+    static var binocularsCircle: SFSymbol { .init(rawValue: "binoculars.circle") }
 
     /// 􁣚
     /// Single Localization, 3 Layersets
@@ -1633,7 +1633,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let binocularsCircleFill = SFSymbol(rawValue: "binoculars.circle.fill")
+    static var binocularsCircleFill: SFSymbol { .init(rawValue: "binoculars.circle.fill") }
 
     /// 􁼙
     /// Single Localization, 2 Layersets
@@ -1641,7 +1641,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let birdCircle = SFSymbol(rawValue: "bird.circle")
+    static var birdCircle: SFSymbol { .init(rawValue: "bird.circle") }
 
     /// 􁼚
     /// Single Localization, 3 Layersets
@@ -1650,7 +1650,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let birdCircleFill = SFSymbol(rawValue: "bird.circle.fill")
+    static var birdCircleFill: SFSymbol { .init(rawValue: "bird.circle.fill") }
 
     /// 􂈱
     /// Single Localization, 2 Layersets
@@ -1663,7 +1663,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "bitcoinsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "bitcoinsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "bitcoinsignArrowTriangleheadCounterclockwiseRotate90")
-    static let bitcoinsignArrowCirclepath = SFSymbol(rawValue: "bitcoinsign.arrow.circlepath")
+    static var bitcoinsignArrowCirclepath: SFSymbol { .init(rawValue: "bitcoinsign.arrow.circlepath") }
 
     /// 􀘳
     /// Single Localization, 3 Layersets
@@ -1672,7 +1672,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeAutomatic = SFSymbol(rawValue: "bolt.badge.automatic")
+    static var boltBadgeAutomatic: SFSymbol { .init(rawValue: "bolt.badge.automatic") }
 
     /// 􀘴
     /// Single Localization, 3 Layersets
@@ -1681,7 +1681,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeAutomaticFill = SFSymbol(rawValue: "bolt.badge.automatic.fill")
+    static var boltBadgeAutomaticFill: SFSymbol { .init(rawValue: "bolt.badge.automatic.fill") }
 
     /// 􁸏
     /// Single Localization, 3 Layersets
@@ -1690,7 +1690,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeCheckmark = SFSymbol(rawValue: "bolt.badge.checkmark")
+    static var boltBadgeCheckmark: SFSymbol { .init(rawValue: "bolt.badge.checkmark") }
 
     /// 􁸑
     /// Single Localization, 3 Layersets
@@ -1699,7 +1699,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeCheckmarkFill = SFSymbol(rawValue: "bolt.badge.checkmark.fill")
+    static var boltBadgeCheckmarkFill: SFSymbol { .init(rawValue: "bolt.badge.checkmark.fill") }
 
     /// 􁸓
     /// Single Localization, 3 Layersets
@@ -1708,7 +1708,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeXmark = SFSymbol(rawValue: "bolt.badge.xmark")
+    static var boltBadgeXmark: SFSymbol { .init(rawValue: "bolt.badge.xmark") }
 
     /// 􁸕
     /// Single Localization, 3 Layersets
@@ -1717,7 +1717,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltBadgeXmarkFill = SFSymbol(rawValue: "bolt.badge.xmark.fill")
+    static var boltBadgeXmarkFill: SFSymbol { .init(rawValue: "bolt.badge.xmark.fill") }
 
     /// 􁥽
     /// Single Localization, 2 Layersets
@@ -1725,7 +1725,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bookAndWrench = SFSymbol(rawValue: "book.and.wrench")
+    static var bookAndWrench: SFSymbol { .init(rawValue: "book.and.wrench") }
 
     /// 􁰸
     /// Single Localization, 2 Layersets
@@ -1733,7 +1733,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bookAndWrenchFill = SFSymbol(rawValue: "book.and.wrench.fill")
+    static var bookAndWrenchFill: SFSymbol { .init(rawValue: "book.and.wrench.fill") }
 
     /// 􁜾
     /// Single Localization, 2 Layersets
@@ -1741,7 +1741,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bookPages = SFSymbol(rawValue: "book.pages")
+    static var bookPages: SFSymbol { .init(rawValue: "book.pages") }
 
     /// 􁜿
     /// Single Localization, 3 Layersets
@@ -1750,14 +1750,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let bookPagesFill = SFSymbol(rawValue: "book.pages.fill")
+    static var bookPagesFill: SFSymbol { .init(rawValue: "book.pages.fill") }
 
     /// 􂂇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let brainFill = SFSymbol(rawValue: "brain.fill")
+    static var brainFill: SFSymbol { .init(rawValue: "brain.fill") }
 
     /// 􂃈
     /// Single Localization, 2 Layersets
@@ -1765,7 +1765,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brainFilledHeadProfile = SFSymbol(rawValue: "brain.filled.head.profile")
+    static var brainFilledHeadProfile: SFSymbol { .init(rawValue: "brain.filled.head.profile") }
 
     /// 􂂆
     /// Single Localization, 2 Layersets
@@ -1773,7 +1773,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brainHeadProfileFill = SFSymbol(rawValue: "brain.head.profile.fill")
+    static var brainHeadProfileFill: SFSymbol { .init(rawValue: "brain.head.profile.fill") }
 
     /// 􂈲
     /// Single Localization, 2 Layersets
@@ -1786,14 +1786,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "brazilianrealsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "brazilianrealsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "brazilianrealsignArrowTriangleheadCounterclockwiseRotate90")
-    static let brazilianrealsignArrowCirclepath = SFSymbol(rawValue: "brazilianrealsign.arrow.circlepath")
+    static var brazilianrealsignArrowCirclepath: SFSymbol { .init(rawValue: "brazilianrealsign.arrow.circlepath") }
 
     /// 􂄹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubble = SFSymbol(rawValue: "bubble")
+    static var bubble: SFSymbol { .init(rawValue: "bubble") }
 
     /// 􂄻
     /// Single Localization, 2 Layersets
@@ -1801,7 +1801,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleCircle = SFSymbol(rawValue: "bubble.circle")
+    static var bubbleCircle: SFSymbol { .init(rawValue: "bubble.circle") }
 
     /// 􂄼
     /// Single Localization, 3 Layersets
@@ -1810,14 +1810,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bubbleCircleFill = SFSymbol(rawValue: "bubble.circle.fill")
+    static var bubbleCircleFill: SFSymbol { .init(rawValue: "bubble.circle.fill") }
 
     /// 􂄺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bubbleFill = SFSymbol(rawValue: "bubble.fill")
+    static var bubbleFill: SFSymbol { .init(rawValue: "bubble.fill") }
 
     /// 􂃧
     /// 2 Localizations, 2 Layersets
@@ -1829,7 +1829,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleLeftAndTextBubbleRight = SymbolWith1Localization<Rtl>(rawValue: "bubble.left.and.text.bubble.right")
+    static var bubbleLeftAndTextBubbleRight: SymbolWith1Localization<Rtl> { .init(rawValue: "bubble.left.and.text.bubble.right") }
 
     /// 􂃨
     /// 2 Localizations, 2 Layersets
@@ -1841,77 +1841,77 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleLeftAndTextBubbleRightFill = SymbolWith1Localization<Rtl>(rawValue: "bubble.left.and.text.bubble.right.fill")
+    static var bubbleLeftAndTextBubbleRightFill: SymbolWith1Localization<Rtl> { .init(rawValue: "bubble.left.and.text.bubble.right.fill") }
 
     /// 􁸅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledbottomHorizontalLeft = SFSymbol(rawValue: "button.angledbottom.horizontal.left")
+    static var buttonAngledbottomHorizontalLeft: SFSymbol { .init(rawValue: "button.angledbottom.horizontal.left") }
 
     /// 􁸆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledbottomHorizontalLeftFill = SFSymbol(rawValue: "button.angledbottom.horizontal.left.fill")
+    static var buttonAngledbottomHorizontalLeftFill: SFSymbol { .init(rawValue: "button.angledbottom.horizontal.left.fill") }
 
     /// 􁸃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledbottomHorizontalRight = SFSymbol(rawValue: "button.angledbottom.horizontal.right")
+    static var buttonAngledbottomHorizontalRight: SFSymbol { .init(rawValue: "button.angledbottom.horizontal.right") }
 
     /// 􁸄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledbottomHorizontalRightFill = SFSymbol(rawValue: "button.angledbottom.horizontal.right.fill")
+    static var buttonAngledbottomHorizontalRightFill: SFSymbol { .init(rawValue: "button.angledbottom.horizontal.right.fill") }
 
     /// 􁷯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledtopVerticalLeft = SFSymbol(rawValue: "button.angledtop.vertical.left")
+    static var buttonAngledtopVerticalLeft: SFSymbol { .init(rawValue: "button.angledtop.vertical.left") }
 
     /// 􁷰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledtopVerticalLeftFill = SFSymbol(rawValue: "button.angledtop.vertical.left.fill")
+    static var buttonAngledtopVerticalLeftFill: SFSymbol { .init(rawValue: "button.angledtop.vertical.left.fill") }
 
     /// 􁷱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledtopVerticalRight = SFSymbol(rawValue: "button.angledtop.vertical.right")
+    static var buttonAngledtopVerticalRight: SFSymbol { .init(rawValue: "button.angledtop.vertical.right") }
 
     /// 􁷲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonAngledtopVerticalRightFill = SFSymbol(rawValue: "button.angledtop.vertical.right.fill")
+    static var buttonAngledtopVerticalRightFill: SFSymbol { .init(rawValue: "button.angledtop.vertical.right.fill") }
 
     /// 􁸞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonHorizontal = SFSymbol(rawValue: "button.horizontal")
+    static var buttonHorizontal: SFSymbol { .init(rawValue: "button.horizontal") }
 
     /// 􁸟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonHorizontalFill = SFSymbol(rawValue: "button.horizontal.fill")
+    static var buttonHorizontalFill: SFSymbol { .init(rawValue: "button.horizontal.fill") }
 
     /// 􂁫
     /// Single Localization, 2 Layersets
@@ -1919,7 +1919,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonHorizontalTopPress = SFSymbol(rawValue: "button.horizontal.top.press")
+    static var buttonHorizontalTopPress: SFSymbol { .init(rawValue: "button.horizontal.top.press") }
 
     /// 􂁬
     /// Single Localization, 2 Layersets
@@ -1927,35 +1927,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonHorizontalTopPressFill = SFSymbol(rawValue: "button.horizontal.top.press.fill")
+    static var buttonHorizontalTopPressFill: SFSymbol { .init(rawValue: "button.horizontal.top.press.fill") }
 
     /// 􀩺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonRoundedbottomHorizontal = SFSymbol(rawValue: "button.roundedbottom.horizontal")
+    static var buttonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "button.roundedbottom.horizontal") }
 
     /// 􀩻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonRoundedbottomHorizontalFill = SFSymbol(rawValue: "button.roundedbottom.horizontal.fill")
+    static var buttonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "button.roundedbottom.horizontal.fill") }
 
     /// 􀩸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonRoundedtopHorizontal = SFSymbol(rawValue: "button.roundedtop.horizontal")
+    static var buttonRoundedtopHorizontal: SFSymbol { .init(rawValue: "button.roundedtop.horizontal") }
 
     /// 􀩹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let buttonRoundedtopHorizontalFill = SFSymbol(rawValue: "button.roundedtop.horizontal.fill")
+    static var buttonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "button.roundedtop.horizontal.fill") }
 
     /// 􂂉
     /// Single Localization, 2 Layersets
@@ -1963,7 +1963,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonVerticalLeftPress = SFSymbol(rawValue: "button.vertical.left.press")
+    static var buttonVerticalLeftPress: SFSymbol { .init(rawValue: "button.vertical.left.press") }
 
     /// 􂂊
     /// Single Localization, 2 Layersets
@@ -1971,7 +1971,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonVerticalLeftPressFill = SFSymbol(rawValue: "button.vertical.left.press.fill")
+    static var buttonVerticalLeftPressFill: SFSymbol { .init(rawValue: "button.vertical.left.press.fill") }
 
     /// 􂁩
     /// Single Localization, 2 Layersets
@@ -1979,7 +1979,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonVerticalRightPress = SFSymbol(rawValue: "button.vertical.right.press")
+    static var buttonVerticalRightPress: SFSymbol { .init(rawValue: "button.vertical.right.press") }
 
     /// 􂁪
     /// Single Localization, 2 Layersets
@@ -1987,7 +1987,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let buttonVerticalRightPressFill = SFSymbol(rawValue: "button.vertical.right.press.fill")
+    static var buttonVerticalRightPressFill: SFSymbol { .init(rawValue: "button.vertical.right.press.fill") }
 
     /// 􁊒
     /// Single Localization, 2 Layersets
@@ -1995,7 +1995,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let cableCoaxial = SFSymbol(rawValue: "cable.coaxial")
+    static var cableCoaxial: SFSymbol { .init(rawValue: "cable.coaxial") }
 
     /// 􂇥
     /// Single Localization, 2 Layersets
@@ -2003,7 +2003,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cableConnectorSlash = SFSymbol(rawValue: "cable.connector.slash")
+    static var cableConnectorSlash: SFSymbol { .init(rawValue: "cable.connector.slash") }
 
     /// 􁻧
     /// 2 Localizations, 3 Layersets
@@ -2016,7 +2016,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarBadgeCheckmark = SymbolWith1Localization<Rtl>(rawValue: "calendar.badge.checkmark")
+    static var calendarBadgeCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "calendar.badge.checkmark") }
 
     /// 􁤥
     /// Single Localization, 3 Layersets
@@ -2025,7 +2025,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cameraBadgeClock = SFSymbol(rawValue: "camera.badge.clock")
+    static var cameraBadgeClock: SFSymbol { .init(rawValue: "camera.badge.clock") }
 
     /// 􁤦
     /// Single Localization, 3 Layersets
@@ -2034,7 +2034,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cameraBadgeClockFill = SFSymbol(rawValue: "camera.badge.clock.fill")
+    static var cameraBadgeClockFill: SFSymbol { .init(rawValue: "camera.badge.clock.fill") }
 
     /// 􀢘
     /// Single Localization, 3 Layersets
@@ -2043,7 +2043,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cameraBadgeEllipsisFill = SFSymbol(rawValue: "camera.badge.ellipsis.fill")
+    static var cameraBadgeEllipsisFill: SFSymbol { .init(rawValue: "camera.badge.ellipsis.fill") }
 
     /// 􂄉
     /// Single Localization, 2 Layersets
@@ -2051,7 +2051,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carFrontWavesDown = SFSymbol(rawValue: "car.front.waves.down")
+    static var carFrontWavesDown: SFSymbol { .init(rawValue: "car.front.waves.down") }
 
     /// 􂄊
     /// Single Localization, 2 Layersets
@@ -2059,7 +2059,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carFrontWavesDownFill = SFSymbol(rawValue: "car.front.waves.down.fill")
+    static var carFrontWavesDownFill: SFSymbol { .init(rawValue: "car.front.waves.down.fill") }
 
     /// 􁣩
     /// Single Localization, 3 Layersets
@@ -2068,7 +2068,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carRearAndCollisionRoadLane = SFSymbol(rawValue: "car.rear.and.collision.road.lane")
+    static var carRearAndCollisionRoadLane: SFSymbol { .init(rawValue: "car.rear.and.collision.road.lane") }
 
     /// 􁣪
     /// Single Localization, 3 Layersets
@@ -2077,7 +2077,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carRearAndCollisionRoadLaneSlash = SFSymbol(rawValue: "car.rear.and.collision.road.lane.slash")
+    static var carRearAndCollisionRoadLaneSlash: SFSymbol { .init(rawValue: "car.rear.and.collision.road.lane.slash") }
 
     /// 􁥎
     /// Single Localization, 2 Layersets
@@ -2085,7 +2085,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillDown = SFSymbol(rawValue: "car.side.hill.down")
+    static var carSideHillDown: SFSymbol { .init(rawValue: "car.side.hill.down") }
 
     /// 􁥏
     /// Single Localization, 2 Layersets
@@ -2093,7 +2093,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillDownFill = SFSymbol(rawValue: "car.side.hill.down.fill")
+    static var carSideHillDownFill: SFSymbol { .init(rawValue: "car.side.hill.down.fill") }
 
     /// 􁤍
     /// Single Localization, 2 Layersets
@@ -2101,7 +2101,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillUp = SFSymbol(rawValue: "car.side.hill.up")
+    static var carSideHillUp: SFSymbol { .init(rawValue: "car.side.hill.up") }
 
     /// 􁤎
     /// Single Localization, 2 Layersets
@@ -2109,7 +2109,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillUpFill = SFSymbol(rawValue: "car.side.hill.up.fill")
+    static var carSideHillUpFill: SFSymbol { .init(rawValue: "car.side.hill.up.fill") }
 
     /// 􁣹
     /// Single Localization, 2 Layersets
@@ -2117,7 +2117,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideLock = SFSymbol(rawValue: "car.side.lock")
+    static var carSideLock: SFSymbol { .init(rawValue: "car.side.lock") }
 
     /// 􁣺
     /// Single Localization, 2 Layersets
@@ -2125,7 +2125,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideLockFill = SFSymbol(rawValue: "car.side.lock.fill")
+    static var carSideLockFill: SFSymbol { .init(rawValue: "car.side.lock.fill") }
 
     /// 􁣻
     /// Single Localization, 2 Layersets
@@ -2133,7 +2133,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideLockOpen = SFSymbol(rawValue: "car.side.lock.open")
+    static var carSideLockOpen: SFSymbol { .init(rawValue: "car.side.lock.open") }
 
     /// 􁣼
     /// Single Localization, 2 Layersets
@@ -2141,7 +2141,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideLockOpenFill = SFSymbol(rawValue: "car.side.lock.open.fill")
+    static var carSideLockOpenFill: SFSymbol { .init(rawValue: "car.side.lock.open.fill") }
 
     /// 􁵴
     /// Single Localization, 2 Layersets
@@ -2149,7 +2149,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndCollisionAndCarSideFront = SFSymbol(rawValue: "car.side.rear.and.collision.and.car.side.front")
+    static var carSideRearAndCollisionAndCarSideFront: SFSymbol { .init(rawValue: "car.side.rear.and.collision.and.car.side.front") }
 
     /// 􁵵
     /// Single Localization, 2 Layersets
@@ -2157,7 +2157,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndCollisionAndCarSideFrontSlash = SFSymbol(rawValue: "car.side.rear.and.collision.and.car.side.front.slash")
+    static var carSideRearAndCollisionAndCarSideFrontSlash: SFSymbol { .init(rawValue: "car.side.rear.and.collision.and.car.side.front.slash") }
 
     /// 􁵸
     /// Single Localization, 2 Layersets
@@ -2165,7 +2165,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndExclamationmarkAndCarSideFront = SFSymbol(rawValue: "car.side.rear.and.exclamationmark.and.car.side.front")
+    static var carSideRearAndExclamationmarkAndCarSideFront: SFSymbol { .init(rawValue: "car.side.rear.and.exclamationmark.and.car.side.front") }
 
     /// 􁵷
     /// Single Localization, 2 Layersets
@@ -2173,7 +2173,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndWave3AndCarSideFront = SFSymbol(rawValue: "car.side.rear.and.wave.3.and.car.side.front")
+    static var carSideRearAndWave3AndCarSideFront: SFSymbol { .init(rawValue: "car.side.rear.and.wave.3.and.car.side.front") }
 
     /// 􁵹
     /// Single Localization, 2 Layersets
@@ -2181,7 +2181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let carTopDoorSlidingLeftOpen = SFSymbol(rawValue: "car.top.door.sliding.left.open")
+    static var carTopDoorSlidingLeftOpen: SFSymbol { .init(rawValue: "car.top.door.sliding.left.open") }
 
     /// 􁵺
     /// Single Localization, 2 Layersets
@@ -2189,7 +2189,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let carTopDoorSlidingLeftOpenFill = SFSymbol(rawValue: "car.top.door.sliding.left.open.fill")
+    static var carTopDoorSlidingLeftOpenFill: SFSymbol { .init(rawValue: "car.top.door.sliding.left.open.fill") }
 
     /// 􁵻
     /// Single Localization, 2 Layersets
@@ -2197,7 +2197,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let carTopDoorSlidingRightOpen = SFSymbol(rawValue: "car.top.door.sliding.right.open")
+    static var carTopDoorSlidingRightOpen: SFSymbol { .init(rawValue: "car.top.door.sliding.right.open") }
 
     /// 􁵼
     /// Single Localization, 2 Layersets
@@ -2205,7 +2205,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let carTopDoorSlidingRightOpenFill = SFSymbol(rawValue: "car.top.door.sliding.right.open.fill")
+    static var carTopDoorSlidingRightOpenFill: SFSymbol { .init(rawValue: "car.top.door.sliding.right.open.fill") }
 
     /// 􂂛
     /// Single Localization, 2 Layersets
@@ -2218,7 +2218,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleFrontLeft")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleFrontLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleFrontLeft")
-    static let carTopFrontleftArrowtriangle = SFSymbol(rawValue: "car.top.frontleft.arrowtriangle")
+    static var carTopFrontleftArrowtriangle: SFSymbol { .init(rawValue: "car.top.frontleft.arrowtriangle") }
 
     /// 􂂜
     /// Single Localization, 2 Layersets
@@ -2231,7 +2231,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleFrontLeftFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleFrontLeftFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleFrontLeftFill")
-    static let carTopFrontleftArrowtriangleFill = SFSymbol(rawValue: "car.top.frontleft.arrowtriangle.fill")
+    static var carTopFrontleftArrowtriangleFill: SFSymbol { .init(rawValue: "car.top.frontleft.arrowtriangle.fill") }
 
     /// 􂂝
     /// Single Localization, 2 Layersets
@@ -2244,7 +2244,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleFrontRight")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleFrontRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleFrontRight")
-    static let carTopFrontrightArrowtriangle = SFSymbol(rawValue: "car.top.frontright.arrowtriangle")
+    static var carTopFrontrightArrowtriangle: SFSymbol { .init(rawValue: "car.top.frontright.arrowtriangle") }
 
     /// 􂂞
     /// Single Localization, 2 Layersets
@@ -2257,7 +2257,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleFrontRightFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleFrontRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleFrontRightFill")
-    static let carTopFrontrightArrowtriangleFill = SFSymbol(rawValue: "car.top.frontright.arrowtriangle.fill")
+    static var carTopFrontrightArrowtriangleFill: SFSymbol { .init(rawValue: "car.top.frontright.arrowtriangle.fill") }
 
     /// 􁢤
     /// Single Localization, 3 Layersets
@@ -2266,7 +2266,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRightBadgeExclamationmark = SFSymbol(rawValue: "car.top.radiowaves.rear.right.badge.exclamationmark")
+    static var carTopRadiowavesRearRightBadgeExclamationmark: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.badge.exclamationmark") }
 
     /// 􁢥
     /// Single Localization, 3 Layersets
@@ -2275,7 +2275,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRightBadgeExclamationmarkFill = SFSymbol(rawValue: "car.top.radiowaves.rear.right.badge.exclamationmark.fill")
+    static var carTopRadiowavesRearRightBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.badge.exclamationmark.fill") }
 
     /// 􁢢
     /// Single Localization, 3 Layersets
@@ -2284,7 +2284,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRightBadgeXmark = SFSymbol(rawValue: "car.top.radiowaves.rear.right.badge.xmark")
+    static var carTopRadiowavesRearRightBadgeXmark: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.badge.xmark") }
 
     /// 􁢣
     /// Single Localization, 3 Layersets
@@ -2293,7 +2293,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carTopRadiowavesRearRightBadgeXmarkFill = SFSymbol(rawValue: "car.top.radiowaves.rear.right.badge.xmark.fill")
+    static var carTopRadiowavesRearRightBadgeXmarkFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.badge.xmark.fill") }
 
     /// 􂂑
     /// Single Localization, 2 Layersets
@@ -2306,7 +2306,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleRearLeft")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleRearLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleRearLeft")
-    static let carTopRearleftArrowtriangle = SFSymbol(rawValue: "car.top.rearleft.arrowtriangle")
+    static var carTopRearleftArrowtriangle: SFSymbol { .init(rawValue: "car.top.rearleft.arrowtriangle") }
 
     /// 􂂒
     /// Single Localization, 2 Layersets
@@ -2319,7 +2319,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleRearLeftFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleRearLeftFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleRearLeftFill")
-    static let carTopRearleftArrowtriangleFill = SFSymbol(rawValue: "car.top.rearleft.arrowtriangle.fill")
+    static var carTopRearleftArrowtriangleFill: SFSymbol { .init(rawValue: "car.top.rearleft.arrowtriangle.fill") }
 
     /// 􂂓
     /// Single Localization, 2 Layersets
@@ -2332,7 +2332,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleRearRight")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleRearRight")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleRearRight")
-    static let carTopRearrightArrowtriangle = SFSymbol(rawValue: "car.top.rearright.arrowtriangle")
+    static var carTopRearrightArrowtriangle: SFSymbol { .init(rawValue: "car.top.rearright.arrowtriangle") }
 
     /// 􂂔
     /// Single Localization, 2 Layersets
@@ -2345,14 +2345,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "carTopArrowtriangleRearRightFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "carTopArrowtriangleRearRightFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "carTopArrowtriangleRearRightFill")
-    static let carTopRearrightArrowtriangleFill = SFSymbol(rawValue: "car.top.rearright.arrowtriangle.fill")
+    static var carTopRearrightArrowtriangleFill: SFSymbol { .init(rawValue: "car.top.rearright.arrowtriangle.fill") }
 
     /// 􁊜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carWindowLeft = SFSymbol(rawValue: "car.window.left")
+    static var carWindowLeft: SFSymbol { .init(rawValue: "car.window.left") }
 
     /// 􁊠
     /// Single Localization, 3 Layersets
@@ -2361,7 +2361,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carWindowLeftBadgeExclamationmark = SFSymbol(rawValue: "car.window.left.badge.exclamationmark")
+    static var carWindowLeftBadgeExclamationmark: SFSymbol { .init(rawValue: "car.window.left.badge.exclamationmark") }
 
     /// 􁊣
     /// Single Localization, 3 Layersets
@@ -2370,7 +2370,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carWindowLeftBadgeXmark = SFSymbol(rawValue: "car.window.left.badge.xmark")
+    static var carWindowLeftBadgeXmark: SFSymbol { .init(rawValue: "car.window.left.badge.xmark") }
 
     /// 􁊞
     /// Single Localization, 2 Layersets
@@ -2378,7 +2378,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowLeftExclamationmark = SFSymbol(rawValue: "car.window.left.exclamationmark")
+    static var carWindowLeftExclamationmark: SFSymbol { .init(rawValue: "car.window.left.exclamationmark") }
 
     /// 􁊡
     /// Single Localization, 2 Layersets
@@ -2386,14 +2386,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowLeftXmark = SFSymbol(rawValue: "car.window.left.xmark")
+    static var carWindowLeftXmark: SFSymbol { .init(rawValue: "car.window.left.xmark") }
 
     /// 􁉜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carWindowRight = SFSymbol(rawValue: "car.window.right")
+    static var carWindowRight: SFSymbol { .init(rawValue: "car.window.right") }
 
     /// 􁉟
     /// Single Localization, 3 Layersets
@@ -2402,7 +2402,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carWindowRightBadgeExclamationmark = SFSymbol(rawValue: "car.window.right.badge.exclamationmark")
+    static var carWindowRightBadgeExclamationmark: SFSymbol { .init(rawValue: "car.window.right.badge.exclamationmark") }
 
     /// 􁉡
     /// Single Localization, 3 Layersets
@@ -2411,7 +2411,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carWindowRightBadgeXmark = SFSymbol(rawValue: "car.window.right.badge.xmark")
+    static var carWindowRightBadgeXmark: SFSymbol { .init(rawValue: "car.window.right.badge.xmark") }
 
     /// 􁉞
     /// Single Localization, 2 Layersets
@@ -2419,7 +2419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowRightExclamationmark = SFSymbol(rawValue: "car.window.right.exclamationmark")
+    static var carWindowRightExclamationmark: SFSymbol { .init(rawValue: "car.window.right.exclamationmark") }
 
     /// 􁊚
     /// Single Localization, 2 Layersets
@@ -2427,14 +2427,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowRightXmark = SFSymbol(rawValue: "car.window.right.xmark")
+    static var carWindowRightXmark: SFSymbol { .init(rawValue: "car.window.right.xmark") }
 
     /// 􁦔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carseatLeft = SFSymbol(rawValue: "carseat.left")
+    static var carseatLeft: SFSymbol { .init(rawValue: "carseat.left") }
 
     /// 􁖟
     /// Single Localization, 2 Layersets
@@ -2442,7 +2442,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft1 = SFSymbol(rawValue: "carseat.left.1")
+    static var carseatLeft1: SFSymbol { .init(rawValue: "carseat.left.1") }
 
     /// 􁖠
     /// Single Localization, 2 Layersets
@@ -2450,7 +2450,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft1Fill = SFSymbol(rawValue: "carseat.left.1.fill")
+    static var carseatLeft1Fill: SFSymbol { .init(rawValue: "carseat.left.1.fill") }
 
     /// 􁖡
     /// Single Localization, 2 Layersets
@@ -2458,7 +2458,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft2 = SFSymbol(rawValue: "carseat.left.2")
+    static var carseatLeft2: SFSymbol { .init(rawValue: "carseat.left.2") }
 
     /// 􁖢
     /// Single Localization, 2 Layersets
@@ -2466,7 +2466,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft2Fill = SFSymbol(rawValue: "carseat.left.2.fill")
+    static var carseatLeft2Fill: SFSymbol { .init(rawValue: "carseat.left.2.fill") }
 
     /// 􁖣
     /// Single Localization, 2 Layersets
@@ -2474,7 +2474,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft3 = SFSymbol(rawValue: "carseat.left.3")
+    static var carseatLeft3: SFSymbol { .init(rawValue: "carseat.left.3") }
 
     /// 􁖤
     /// Single Localization, 2 Layersets
@@ -2482,7 +2482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeft3Fill = SFSymbol(rawValue: "carseat.left.3.fill")
+    static var carseatLeft3Fill: SFSymbol { .init(rawValue: "carseat.left.3.fill") }
 
     /// 􁋍
     /// Single Localization, 2 Layersets
@@ -2490,7 +2490,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftAndHeatWaves = SFSymbol(rawValue: "carseat.left.and.heat.waves")
+    static var carseatLeftAndHeatWaves: SFSymbol { .init(rawValue: "carseat.left.and.heat.waves") }
 
     /// 􁋎
     /// Single Localization, 2 Layersets
@@ -2498,7 +2498,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftAndHeatWavesFill = SFSymbol(rawValue: "carseat.left.and.heat.waves.fill")
+    static var carseatLeftAndHeatWavesFill: SFSymbol { .init(rawValue: "carseat.left.and.heat.waves.fill") }
 
     /// 􁦌
     /// Single Localization, 2 Layersets
@@ -2506,7 +2506,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftBackrestUpAndDown = SFSymbol(rawValue: "carseat.left.backrest.up.and.down")
+    static var carseatLeftBackrestUpAndDown: SFSymbol { .init(rawValue: "carseat.left.backrest.up.and.down") }
 
     /// 􁦍
     /// Single Localization, 2 Layersets
@@ -2514,7 +2514,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftBackrestUpAndDownFill = SFSymbol(rawValue: "carseat.left.backrest.up.and.down.fill")
+    static var carseatLeftBackrestUpAndDownFill: SFSymbol { .init(rawValue: "carseat.left.backrest.up.and.down.fill") }
 
     /// 􁋑
     /// Single Localization, 2 Layersets
@@ -2522,7 +2522,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftFan = SFSymbol(rawValue: "carseat.left.fan")
+    static var carseatLeftFan: SFSymbol { .init(rawValue: "carseat.left.fan") }
 
     /// 􁋒
     /// Single Localization, 2 Layersets
@@ -2530,14 +2530,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftFanFill = SFSymbol(rawValue: "carseat.left.fan.fill")
+    static var carseatLeftFanFill: SFSymbol { .init(rawValue: "carseat.left.fan.fill") }
 
     /// 􁦕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carseatLeftFill = SFSymbol(rawValue: "carseat.left.fill")
+    static var carseatLeftFill: SFSymbol { .init(rawValue: "carseat.left.fill") }
 
     /// 􁦈
     /// Single Localization, 2 Layersets
@@ -2545,7 +2545,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftForwardAndBackward = SFSymbol(rawValue: "carseat.left.forward.and.backward")
+    static var carseatLeftForwardAndBackward: SFSymbol { .init(rawValue: "carseat.left.forward.and.backward") }
 
     /// 􁦉
     /// Single Localization, 2 Layersets
@@ -2553,7 +2553,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftForwardAndBackwardFill = SFSymbol(rawValue: "carseat.left.forward.and.backward.fill")
+    static var carseatLeftForwardAndBackwardFill: SFSymbol { .init(rawValue: "carseat.left.forward.and.backward.fill") }
 
     /// 􁵽
     /// Single Localization, 2 Layersets
@@ -2561,7 +2561,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftMassage = SFSymbol(rawValue: "carseat.left.massage")
+    static var carseatLeftMassage: SFSymbol { .init(rawValue: "carseat.left.massage") }
 
     /// 􁵾
     /// Single Localization, 2 Layersets
@@ -2569,7 +2569,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftMassageFill = SFSymbol(rawValue: "carseat.left.massage.fill")
+    static var carseatLeftMassageFill: SFSymbol { .init(rawValue: "carseat.left.massage.fill") }
 
     /// 􁦐
     /// Single Localization, 2 Layersets
@@ -2577,7 +2577,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftUpAndDown = SFSymbol(rawValue: "carseat.left.up.and.down")
+    static var carseatLeftUpAndDown: SFSymbol { .init(rawValue: "carseat.left.up.and.down") }
 
     /// 􁦑
     /// Single Localization, 2 Layersets
@@ -2585,14 +2585,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatLeftUpAndDownFill = SFSymbol(rawValue: "carseat.left.up.and.down.fill")
+    static var carseatLeftUpAndDownFill: SFSymbol { .init(rawValue: "carseat.left.up.and.down.fill") }
 
     /// 􁦖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carseatRight = SFSymbol(rawValue: "carseat.right")
+    static var carseatRight: SFSymbol { .init(rawValue: "carseat.right") }
 
     /// 􁋕
     /// Single Localization, 2 Layersets
@@ -2600,7 +2600,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight1 = SFSymbol(rawValue: "carseat.right.1")
+    static var carseatRight1: SFSymbol { .init(rawValue: "carseat.right.1") }
 
     /// 􁋖
     /// Single Localization, 2 Layersets
@@ -2608,7 +2608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight1Fill = SFSymbol(rawValue: "carseat.right.1.fill")
+    static var carseatRight1Fill: SFSymbol { .init(rawValue: "carseat.right.1.fill") }
 
     /// 􁋗
     /// Single Localization, 2 Layersets
@@ -2616,7 +2616,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight2 = SFSymbol(rawValue: "carseat.right.2")
+    static var carseatRight2: SFSymbol { .init(rawValue: "carseat.right.2") }
 
     /// 􁋘
     /// Single Localization, 2 Layersets
@@ -2624,7 +2624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight2Fill = SFSymbol(rawValue: "carseat.right.2.fill")
+    static var carseatRight2Fill: SFSymbol { .init(rawValue: "carseat.right.2.fill") }
 
     /// 􁋙
     /// Single Localization, 2 Layersets
@@ -2632,7 +2632,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight3 = SFSymbol(rawValue: "carseat.right.3")
+    static var carseatRight3: SFSymbol { .init(rawValue: "carseat.right.3") }
 
     /// 􁋚
     /// Single Localization, 2 Layersets
@@ -2640,7 +2640,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRight3Fill = SFSymbol(rawValue: "carseat.right.3.fill")
+    static var carseatRight3Fill: SFSymbol { .init(rawValue: "carseat.right.3.fill") }
 
     /// 􁋏
     /// Single Localization, 2 Layersets
@@ -2648,7 +2648,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightAndHeatWaves = SFSymbol(rawValue: "carseat.right.and.heat.waves")
+    static var carseatRightAndHeatWaves: SFSymbol { .init(rawValue: "carseat.right.and.heat.waves") }
 
     /// 􁋐
     /// Single Localization, 2 Layersets
@@ -2656,7 +2656,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightAndHeatWavesFill = SFSymbol(rawValue: "carseat.right.and.heat.waves.fill")
+    static var carseatRightAndHeatWavesFill: SFSymbol { .init(rawValue: "carseat.right.and.heat.waves.fill") }
 
     /// 􁦎
     /// Single Localization, 2 Layersets
@@ -2664,7 +2664,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightBackrestUpAndDown = SFSymbol(rawValue: "carseat.right.backrest.up.and.down")
+    static var carseatRightBackrestUpAndDown: SFSymbol { .init(rawValue: "carseat.right.backrest.up.and.down") }
 
     /// 􁦏
     /// Single Localization, 2 Layersets
@@ -2672,7 +2672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightBackrestUpAndDownFill = SFSymbol(rawValue: "carseat.right.backrest.up.and.down.fill")
+    static var carseatRightBackrestUpAndDownFill: SFSymbol { .init(rawValue: "carseat.right.backrest.up.and.down.fill") }
 
     /// 􁋓
     /// Single Localization, 2 Layersets
@@ -2680,7 +2680,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightFan = SFSymbol(rawValue: "carseat.right.fan")
+    static var carseatRightFan: SFSymbol { .init(rawValue: "carseat.right.fan") }
 
     /// 􁋔
     /// Single Localization, 2 Layersets
@@ -2688,14 +2688,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightFanFill = SFSymbol(rawValue: "carseat.right.fan.fill")
+    static var carseatRightFanFill: SFSymbol { .init(rawValue: "carseat.right.fan.fill") }
 
     /// 􁦗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carseatRightFill = SFSymbol(rawValue: "carseat.right.fill")
+    static var carseatRightFill: SFSymbol { .init(rawValue: "carseat.right.fill") }
 
     /// 􁦊
     /// Single Localization, 2 Layersets
@@ -2703,7 +2703,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightForwardAndBackward = SFSymbol(rawValue: "carseat.right.forward.and.backward")
+    static var carseatRightForwardAndBackward: SFSymbol { .init(rawValue: "carseat.right.forward.and.backward") }
 
     /// 􁦋
     /// Single Localization, 2 Layersets
@@ -2711,7 +2711,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightForwardAndBackwardFill = SFSymbol(rawValue: "carseat.right.forward.and.backward.fill")
+    static var carseatRightForwardAndBackwardFill: SFSymbol { .init(rawValue: "carseat.right.forward.and.backward.fill") }
 
     /// 􁵿
     /// Single Localization, 2 Layersets
@@ -2719,7 +2719,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightMassage = SFSymbol(rawValue: "carseat.right.massage")
+    static var carseatRightMassage: SFSymbol { .init(rawValue: "carseat.right.massage") }
 
     /// 􁶀
     /// Single Localization, 2 Layersets
@@ -2727,7 +2727,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightMassageFill = SFSymbol(rawValue: "carseat.right.massage.fill")
+    static var carseatRightMassageFill: SFSymbol { .init(rawValue: "carseat.right.massage.fill") }
 
     /// 􁦒
     /// Single Localization, 2 Layersets
@@ -2735,7 +2735,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightUpAndDown = SFSymbol(rawValue: "carseat.right.up.and.down")
+    static var carseatRightUpAndDown: SFSymbol { .init(rawValue: "carseat.right.up.and.down") }
 
     /// 􁦓
     /// Single Localization, 2 Layersets
@@ -2743,14 +2743,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carseatRightUpAndDownFill = SFSymbol(rawValue: "carseat.right.up.and.down.fill")
+    static var carseatRightUpAndDownFill: SFSymbol { .init(rawValue: "carseat.right.up.and.down.fill") }
 
     /// 􂁾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let cat = SFSymbol(rawValue: "cat")
+    static var cat: SFSymbol { .init(rawValue: "cat") }
 
     /// 􂂀
     /// Single Localization, 2 Layersets
@@ -2758,7 +2758,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let catCircle = SFSymbol(rawValue: "cat.circle")
+    static var catCircle: SFSymbol { .init(rawValue: "cat.circle") }
 
     /// 􂂁
     /// Single Localization, 3 Layersets
@@ -2767,14 +2767,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let catCircleFill = SFSymbol(rawValue: "cat.circle.fill")
+    static var catCircleFill: SFSymbol { .init(rawValue: "cat.circle.fill") }
 
     /// 􂁿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let catFill = SFSymbol(rawValue: "cat.fill")
+    static var catFill: SFSymbol { .init(rawValue: "cat.fill") }
 
     /// 􂈨
     /// Single Localization, 2 Layersets
@@ -2787,7 +2787,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "cedisignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "cedisignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "cedisignArrowTriangleheadCounterclockwiseRotate90")
-    static let cedisignArrowCirclepath = SFSymbol(rawValue: "cedisign.arrow.circlepath")
+    static var cedisignArrowCirclepath: SFSymbol { .init(rawValue: "cedisign.arrow.circlepath") }
 
     /// 􂈓
     /// Single Localization, 2 Layersets
@@ -2800,7 +2800,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "centsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "centsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "centsignArrowTriangleheadCounterclockwiseRotate90")
-    static let centsignArrowCirclepath = SFSymbol(rawValue: "centsign.arrow.circlepath")
+    static var centsignArrowCirclepath: SFSymbol { .init(rawValue: "centsign.arrow.circlepath") }
 
     /// 􀤍
     /// 20 Localizations, 3 Layersets
@@ -2831,7 +2831,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let characterMagnify = SymbolWith19Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh>(rawValue: "character.magnify")
+    static var characterMagnify: SymbolWith19Localizations<Ar, Bn_v6_3, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh> { .init(rawValue: "character.magnify") }
 
     /// 􂆏
     /// Single Localization, 2 Layersets
@@ -2839,7 +2839,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartBarXaxisAscending = SFSymbol(rawValue: "chart.bar.xaxis.ascending")
+    static var chartBarXaxisAscending: SFSymbol { .init(rawValue: "chart.bar.xaxis.ascending") }
 
     /// 􂆐
     /// 2 Localizations, 3 Layersets
@@ -2852,7 +2852,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartBarXaxisAscendingBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "chart.bar.xaxis.ascending.badge.clock")
+    static var chartBarXaxisAscendingBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "chart.bar.xaxis.ascending.badge.clock") }
 
     /// 􂄗
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2862,7 +2862,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let checkmarkApplewatch = SFSymbol(rawValue: "checkmark.applewatch")
+    static var checkmarkApplewatch: SFSymbol { .init(rawValue: "checkmark.applewatch") }
 
     /// 􁣛
     /// Single Localization, 2 Layersets
@@ -2875,7 +2875,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "checkmarkArrowTriangleheadCounterclockwise")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "checkmarkArrowTriangleheadCounterclockwise")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "checkmarkArrowTriangleheadCounterclockwise")
-    static let checkmarkGobackward = SFSymbol(rawValue: "checkmark.gobackward")
+    static var checkmarkGobackward: SFSymbol { .init(rawValue: "checkmark.gobackward") }
 
     /// 􂂼
     /// Single Localization, 2 Layersets
@@ -2883,7 +2883,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkRectangleStack = SFSymbol(rawValue: "checkmark.rectangle.stack")
+    static var checkmarkRectangleStack: SFSymbol { .init(rawValue: "checkmark.rectangle.stack") }
 
     /// 􂂽
     /// Single Localization, 3 Layersets
@@ -2892,14 +2892,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkRectangleStackFill = SFSymbol(rawValue: "checkmark.rectangle.stack.fill")
+    static var checkmarkRectangleStackFill: SFSymbol { .init(rawValue: "checkmark.rectangle.stack.fill") }
 
     /// 􁺑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chineseyuanrenminbisign = SFSymbol(rawValue: "chineseyuanrenminbisign")
+    static var chineseyuanrenminbisign: SFSymbol { .init(rawValue: "chineseyuanrenminbisign") }
 
     /// 􂈳
     /// Single Localization, 2 Layersets
@@ -2912,7 +2912,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90")
-    static let chineseyuanrenminbisignArrowCirclepath = SFSymbol(rawValue: "chineseyuanrenminbisign.arrow.circlepath")
+    static var chineseyuanrenminbisignArrowCirclepath: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.arrow.circlepath") }
 
     /// 􀯣
     /// Single Localization, 2 Layersets
@@ -2920,7 +2920,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignCircle = SFSymbol(rawValue: "chineseyuanrenminbisign.circle")
+    static var chineseyuanrenminbisignCircle: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.circle") }
 
     /// 􀯤
     /// Single Localization, 3 Layersets
@@ -2929,7 +2929,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chineseyuanrenminbisignCircleFill = SFSymbol(rawValue: "chineseyuanrenminbisign.circle.fill")
+    static var chineseyuanrenminbisignCircleFill: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.circle.fill") }
 
     /// 􀯥
     /// Single Localization, 2 Layersets
@@ -2937,7 +2937,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignSquare = SFSymbol(rawValue: "chineseyuanrenminbisign.square")
+    static var chineseyuanrenminbisignSquare: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.square") }
 
     /// 􀯦
     /// Single Localization, 3 Layersets
@@ -2946,7 +2946,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chineseyuanrenminbisignSquareFill = SFSymbol(rawValue: "chineseyuanrenminbisign.square.fill")
+    static var chineseyuanrenminbisignSquareFill: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.square.fill") }
 
     /// 􂀂
     /// Single Localization, 3 Layersets
@@ -2955,7 +2955,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeCheckmark = SFSymbol(rawValue: "circle.badge.checkmark")
+    static var circleBadgeCheckmark: SFSymbol { .init(rawValue: "circle.badge.checkmark") }
 
     /// 􂀃
     /// Single Localization, 3 Layersets
@@ -2964,7 +2964,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeCheckmarkFill = SFSymbol(rawValue: "circle.badge.checkmark.fill")
+    static var circleBadgeCheckmarkFill: SFSymbol { .init(rawValue: "circle.badge.checkmark.fill") }
 
     /// 􂁔
     /// Single Localization, 3 Layersets
@@ -2973,7 +2973,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeExclamationmark = SFSymbol(rawValue: "circle.badge.exclamationmark")
+    static var circleBadgeExclamationmark: SFSymbol { .init(rawValue: "circle.badge.exclamationmark") }
 
     /// 􂁕
     /// Single Localization, 3 Layersets
@@ -2982,7 +2982,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeExclamationmarkFill = SFSymbol(rawValue: "circle.badge.exclamationmark.fill")
+    static var circleBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "circle.badge.exclamationmark.fill") }
 
     /// 􂁄
     /// Single Localization, 3 Layersets
@@ -2991,7 +2991,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeMinus = SFSymbol(rawValue: "circle.badge.minus")
+    static var circleBadgeMinus: SFSymbol { .init(rawValue: "circle.badge.minus") }
 
     /// 􂁅
     /// Single Localization, 3 Layersets
@@ -3000,7 +3000,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeMinusFill = SFSymbol(rawValue: "circle.badge.minus.fill")
+    static var circleBadgeMinusFill: SFSymbol { .init(rawValue: "circle.badge.minus.fill") }
 
     /// 􂁀
     /// Single Localization, 3 Layersets
@@ -3009,7 +3009,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgePlus = SFSymbol(rawValue: "circle.badge.plus")
+    static var circleBadgePlus: SFSymbol { .init(rawValue: "circle.badge.plus") }
 
     /// 􂁁
     /// Single Localization, 3 Layersets
@@ -3018,7 +3018,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgePlusFill = SFSymbol(rawValue: "circle.badge.plus.fill")
+    static var circleBadgePlusFill: SFSymbol { .init(rawValue: "circle.badge.plus.fill") }
 
     /// 􂁌
     /// 2 Localizations, 3 Layersets
@@ -3031,7 +3031,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeQuestionmark = SymbolWith1Localization<Ar>(rawValue: "circle.badge.questionmark")
+    static var circleBadgeQuestionmark: SymbolWith1Localization<Ar> { .init(rawValue: "circle.badge.questionmark") }
 
     /// 􂁍
     /// 2 Localizations, 3 Layersets
@@ -3044,7 +3044,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeQuestionmarkFill = SymbolWith1Localization<Ar>(rawValue: "circle.badge.questionmark.fill")
+    static var circleBadgeQuestionmarkFill: SymbolWith1Localization<Ar> { .init(rawValue: "circle.badge.questionmark.fill") }
 
     /// 􂁈
     /// Single Localization, 3 Layersets
@@ -3053,7 +3053,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeXmark = SFSymbol(rawValue: "circle.badge.xmark")
+    static var circleBadgeXmark: SFSymbol { .init(rawValue: "circle.badge.xmark") }
 
     /// 􂁉
     /// Single Localization, 3 Layersets
@@ -3062,14 +3062,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleBadgeXmarkFill = SFSymbol(rawValue: "circle.badge.xmark.fill")
+    static var circleBadgeXmarkFill: SFSymbol { .init(rawValue: "circle.badge.xmark.fill") }
 
     /// 􁹰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleBottomhalfFilledInverse = SFSymbol(rawValue: "circle.bottomhalf.filled.inverse")
+    static var circleBottomhalfFilledInverse: SFSymbol { .init(rawValue: "circle.bottomhalf.filled.inverse") }
 
     /// 􁹨
     /// Single Localization, Single Layerset
@@ -3081,7 +3081,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "circleBottomrighthalfPatternCheckered")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "circleBottomrighthalfPatternCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "circleBottomrighthalfPatternCheckered")
-    static let circleBottomrighthalfCheckered = SFSymbol(rawValue: "circle.bottomrighthalf.checkered")
+    static var circleBottomrighthalfCheckered: SFSymbol { .init(rawValue: "circle.bottomrighthalf.checkered") }
 
     /// 􁊕
     /// Single Localization, 2 Layersets
@@ -3089,7 +3089,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleDottedAndCircle = SFSymbol(rawValue: "circle.dotted.and.circle")
+    static var circleDottedAndCircle: SFSymbol { .init(rawValue: "circle.dotted.and.circle") }
 
     /// 􁹧
     /// Single Localization, 2 Layersets
@@ -3097,7 +3097,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleDottedCircle = SFSymbol(rawValue: "circle.dotted.circle")
+    static var circleDottedCircle: SFSymbol { .init(rawValue: "circle.dotted.circle") }
 
     /// 􁷟
     /// Single Localization, 3 Layersets
@@ -3106,7 +3106,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleDottedCircleFill = SFSymbol(rawValue: "circle.dotted.circle.fill")
+    static var circleDottedCircleFill: SFSymbol { .init(rawValue: "circle.dotted.circle.fill") }
 
     /// 􂃻
     /// Single Localization, 2 Layersets
@@ -3114,7 +3114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleFilledIpad = SFSymbol(rawValue: "circle.filled.ipad")
+    static var circleFilledIpad: SFSymbol { .init(rawValue: "circle.filled.ipad") }
 
     /// 􂃼
     /// Single Localization, 3 Layersets
@@ -3123,7 +3123,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleFilledIpadFill = SFSymbol(rawValue: "circle.filled.ipad.fill")
+    static var circleFilledIpadFill: SFSymbol { .init(rawValue: "circle.filled.ipad.fill") }
 
     /// 􂃽
     /// Single Localization, 2 Layersets
@@ -3131,7 +3131,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleFilledIpadLandscape = SFSymbol(rawValue: "circle.filled.ipad.landscape")
+    static var circleFilledIpadLandscape: SFSymbol { .init(rawValue: "circle.filled.ipad.landscape") }
 
     /// 􂃾
     /// Single Localization, 3 Layersets
@@ -3140,7 +3140,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleFilledIpadLandscapeFill = SFSymbol(rawValue: "circle.filled.ipad.landscape.fill")
+    static var circleFilledIpadLandscapeFill: SFSymbol { .init(rawValue: "circle.filled.ipad.landscape.fill") }
 
     /// 􂃯
     /// Single Localization, 2 Layersets
@@ -3148,7 +3148,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleFilledIphone = SFSymbol(rawValue: "circle.filled.iphone")
+    static var circleFilledIphone: SFSymbol { .init(rawValue: "circle.filled.iphone") }
 
     /// 􂃰
     /// Single Localization, 3 Layersets
@@ -3157,56 +3157,56 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleFilledIphoneFill = SFSymbol(rawValue: "circle.filled.iphone.fill")
+    static var circleFilledIphoneFill: SFSymbol { .init(rawValue: "circle.filled.iphone.fill") }
 
     /// 􁹭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfFilledInverse = SFSymbol(rawValue: "circle.lefthalf.filled.inverse")
+    static var circleLefthalfFilledInverse: SFSymbol { .init(rawValue: "circle.lefthalf.filled.inverse") }
 
     /// 􁹣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfFilledRighthalfStripedHorizontal = SFSymbol(rawValue: "circle.lefthalf.filled.righthalf.striped.horizontal")
+    static var circleLefthalfFilledRighthalfStripedHorizontal: SFSymbol { .init(rawValue: "circle.lefthalf.filled.righthalf.striped.horizontal") }
 
     /// 􁹤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfFilledRighthalfStripedHorizontalInverse = SFSymbol(rawValue: "circle.lefthalf.filled.righthalf.striped.horizontal.inverse")
+    static var circleLefthalfFilledRighthalfStripedHorizontalInverse: SFSymbol { .init(rawValue: "circle.lefthalf.filled.righthalf.striped.horizontal.inverse") }
 
     /// 􁹥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfStripedHorizontal = SFSymbol(rawValue: "circle.lefthalf.striped.horizontal")
+    static var circleLefthalfStripedHorizontal: SFSymbol { .init(rawValue: "circle.lefthalf.striped.horizontal") }
 
     /// 􁹦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleLefthalfStripedHorizontalInverse = SFSymbol(rawValue: "circle.lefthalf.striped.horizontal.inverse")
+    static var circleLefthalfStripedHorizontalInverse: SFSymbol { .init(rawValue: "circle.lefthalf.striped.horizontal.inverse") }
 
     /// 􁹮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleRighthalfFilledInverse = SFSymbol(rawValue: "circle.righthalf.filled.inverse")
+    static var circleRighthalfFilledInverse: SFSymbol { .init(rawValue: "circle.righthalf.filled.inverse") }
 
     /// 􁹯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleTophalfFilledInverse = SFSymbol(rawValue: "circle.tophalf.filled.inverse")
+    static var circleTophalfFilledInverse: SFSymbol { .init(rawValue: "circle.tophalf.filled.inverse") }
 
     /// 􁷞
     /// Single Localization, 3 Layersets
@@ -3220,7 +3220,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "cloudRainbowCrop")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "cloudRainbowCrop")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "cloudRainbowCrop")
-    static let cloudRainbowHalf = SFSymbol(rawValue: "cloud.rainbow.half")
+    static var cloudRainbowHalf: SFSymbol { .init(rawValue: "cloud.rainbow.half") }
 
     /// 􁷠
     /// Single Localization, 3 Layersets
@@ -3234,7 +3234,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "cloudRainbowCropFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "cloudRainbowCropFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "cloudRainbowCropFill")
-    static let cloudRainbowHalfFill = SFSymbol(rawValue: "cloud.rainbow.half.fill")
+    static var cloudRainbowHalfFill: SFSymbol { .init(rawValue: "cloud.rainbow.half.fill") }
 
     /// 􂈧
     /// Single Localization, 2 Layersets
@@ -3247,7 +3247,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "coloncurrencysignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "coloncurrencysignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "coloncurrencysignArrowTriangleheadCounterclockwiseRotate90")
-    static let coloncurrencysignArrowCirclepath = SFSymbol(rawValue: "coloncurrencysign.arrow.circlepath")
+    static var coloncurrencysignArrowCirclepath: SFSymbol { .init(rawValue: "coloncurrencysign.arrow.circlepath") }
 
     /// 􁣐
     /// Single Localization, 3 Layersets
@@ -3256,7 +3256,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let creditcardTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "creditcard.trianglebadge.exclamationmark.fill")
+    static var creditcardTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "creditcard.trianglebadge.exclamationmark.fill") }
 
     /// 􂈩
     /// Single Localization, 2 Layersets
@@ -3269,7 +3269,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "cruzeirosignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "cruzeirosignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "cruzeirosignArrowTriangleheadCounterclockwiseRotate90")
-    static let cruzeirosignArrowCirclepath = SFSymbol(rawValue: "cruzeirosign.arrow.circlepath")
+    static var cruzeirosignArrowCirclepath: SFSymbol { .init(rawValue: "cruzeirosign.arrow.circlepath") }
 
     /// 􁷁
     /// Single Localization, 2 Layersets
@@ -3282,7 +3282,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 26.0, renamed: "pointerArrowSlash")
     @available(watchOS, introduced: 10.0, deprecated: 26.0, renamed: "pointerArrowSlash")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowSlash")
-    static let cursorarrowSlash = SFSymbol(rawValue: "cursorarrow.slash")
+    static var cursorarrowSlash: SFSymbol { .init(rawValue: "cursorarrow.slash") }
 
     /// 􁷂
     /// Single Localization, 2 Layersets
@@ -3295,7 +3295,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 26.0, renamed: "pointerArrowSlashSquare")
     @available(watchOS, introduced: 10.0, deprecated: 26.0, renamed: "pointerArrowSlashSquare")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowSlashSquare")
-    static let cursorarrowSlashSquare = SFSymbol(rawValue: "cursorarrow.slash.square")
+    static var cursorarrowSlashSquare: SFSymbol { .init(rawValue: "cursorarrow.slash.square") }
 
     /// 􁷃
     /// Single Localization, 3 Layersets
@@ -3309,14 +3309,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 26.0, renamed: "pointerArrowSlashSquareFill")
     @available(watchOS, introduced: 10.0, deprecated: 26.0, renamed: "pointerArrowSlashSquareFill")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "pointerArrowSlashSquareFill")
-    static let cursorarrowSlashSquareFill = SFSymbol(rawValue: "cursorarrow.slash.square.fill")
+    static var cursorarrowSlashSquareFill: SFSymbol { .init(rawValue: "cursorarrow.slash.square.fill") }
 
     /// 􁤮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let danishkronesign = SFSymbol(rawValue: "danishkronesign")
+    static var danishkronesign: SFSymbol { .init(rawValue: "danishkronesign") }
 
     /// 􂈷
     /// Single Localization, 2 Layersets
@@ -3329,7 +3329,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "danishkronesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "danishkronesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "danishkronesignArrowTriangleheadCounterclockwiseRotate90")
-    static let danishkronesignArrowCirclepath = SFSymbol(rawValue: "danishkronesign.arrow.circlepath")
+    static var danishkronesignArrowCirclepath: SFSymbol { .init(rawValue: "danishkronesign.arrow.circlepath") }
 
     /// 􀮬
     /// Single Localization, 2 Layersets
@@ -3337,7 +3337,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignCircle = SFSymbol(rawValue: "danishkronesign.circle")
+    static var danishkronesignCircle: SFSymbol { .init(rawValue: "danishkronesign.circle") }
 
     /// 􀮭
     /// Single Localization, 3 Layersets
@@ -3346,7 +3346,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let danishkronesignCircleFill = SFSymbol(rawValue: "danishkronesign.circle.fill")
+    static var danishkronesignCircleFill: SFSymbol { .init(rawValue: "danishkronesign.circle.fill") }
 
     /// 􀮮
     /// Single Localization, 2 Layersets
@@ -3354,7 +3354,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignSquare = SFSymbol(rawValue: "danishkronesign.square")
+    static var danishkronesignSquare: SFSymbol { .init(rawValue: "danishkronesign.square") }
 
     /// 􀮯
     /// Single Localization, 3 Layersets
@@ -3363,7 +3363,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let danishkronesignSquareFill = SFSymbol(rawValue: "danishkronesign.square.fill")
+    static var danishkronesignSquareFill: SFSymbol { .init(rawValue: "danishkronesign.square.fill") }
 
     /// 􁿖
     /// Single Localization, 2 Layersets
@@ -3371,7 +3371,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dishwasherCircle = SFSymbol(rawValue: "dishwasher.circle")
+    static var dishwasherCircle: SFSymbol { .init(rawValue: "dishwasher.circle") }
 
     /// 􁿗
     /// Single Localization, 3 Layersets
@@ -3380,7 +3380,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dishwasherCircleFill = SFSymbol(rawValue: "dishwasher.circle.fill")
+    static var dishwasherCircleFill: SFSymbol { .init(rawValue: "dishwasher.circle.fill") }
 
     /// 􀫾
     /// Single Localization, 3 Layersets
@@ -3394,7 +3394,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "documentBadgeClock")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "documentBadgeClock")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeClock")
-    static let docBadgeClock = SFSymbol(rawValue: "doc.badge.clock")
+    static var docBadgeClock: SFSymbol { .init(rawValue: "doc.badge.clock") }
 
     /// 􀫿
     /// Single Localization, 3 Layersets
@@ -3408,7 +3408,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "documentBadgeClockFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "documentBadgeClockFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "documentBadgeClockFill")
-    static let docBadgeClockFill = SFSymbol(rawValue: "doc.badge.clock.fill")
+    static var docBadgeClockFill: SFSymbol { .init(rawValue: "doc.badge.clock.fill") }
 
     /// 􂇲
     /// 3 Localizations, 2 Layersets
@@ -3426,7 +3426,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "questionmarkTextPage")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "questionmarkTextPage")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "questionmarkTextPage")
-    static let docQuestionmark = SymbolWith2Localizations<Ar, Rtl>(rawValue: "doc.questionmark")
+    static var docQuestionmark: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "doc.questionmark") }
 
     /// 􂇳
     /// 3 Localizations, Single Layerset
@@ -3443,14 +3443,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "questionmarkTextPageFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "questionmarkTextPageFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "questionmarkTextPageFill")
-    static let docQuestionmarkFill = SymbolWith2Localizations<Ar, Rtl>(rawValue: "doc.questionmark.fill")
+    static var docQuestionmarkFill: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "doc.questionmark.fill") }
 
     /// 􂀆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dog = SFSymbol(rawValue: "dog")
+    static var dog: SFSymbol { .init(rawValue: "dog") }
 
     /// 􂀾
     /// Single Localization, 2 Layersets
@@ -3458,7 +3458,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dogCircle = SFSymbol(rawValue: "dog.circle")
+    static var dogCircle: SFSymbol { .init(rawValue: "dog.circle") }
 
     /// 􂀿
     /// Single Localization, 3 Layersets
@@ -3467,14 +3467,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dogCircleFill = SFSymbol(rawValue: "dog.circle.fill")
+    static var dogCircleFill: SFSymbol { .init(rawValue: "dog.circle.fill") }
 
     /// 􂀇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dogFill = SFSymbol(rawValue: "dog.fill")
+    static var dogFill: SFSymbol { .init(rawValue: "dog.fill") }
 
     /// 􂈛
     /// Single Localization, 2 Layersets
@@ -3487,14 +3487,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "dongsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "dongsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "dongsignArrowTriangleheadCounterclockwiseRotate90")
-    static let dongsignArrowCirclepath = SFSymbol(rawValue: "dongsign.arrow.circlepath")
+    static var dongsignArrowCirclepath: SFSymbol { .init(rawValue: "dongsign.arrow.circlepath") }
 
     /// 􂇏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dotScope = SFSymbol(rawValue: "dot.scope")
+    static var dotScope: SFSymbol { .init(rawValue: "dot.scope") }
 
     /// 􂇌
     /// Single Localization, 2 Layersets
@@ -3502,7 +3502,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotScopeDisplay = SFSymbol(rawValue: "dot.scope.display")
+    static var dotScopeDisplay: SFSymbol { .init(rawValue: "dot.scope.display") }
 
     /// 􁿍
     /// Single Localization, 2 Layersets
@@ -3510,14 +3510,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotScopeLaptopcomputer = SFSymbol(rawValue: "dot.scope.laptopcomputer")
+    static var dotScopeLaptopcomputer: SFSymbol { .init(rawValue: "dot.scope.laptopcomputer") }
 
     /// 􁹡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let dropHalffull = SFSymbol(rawValue: "drop.halffull")
+    static var dropHalffull: SFSymbol { .init(rawValue: "drop.halffull") }
 
     /// 􁤈
     /// Single Localization, 2 Layersets
@@ -3525,7 +3525,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dropTransmission = SFSymbol(rawValue: "drop.transmission")
+    static var dropTransmission: SFSymbol { .init(rawValue: "drop.transmission") }
 
     /// 􁿒
     /// Single Localization, 2 Layersets
@@ -3533,7 +3533,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dryerCircle = SFSymbol(rawValue: "dryer.circle")
+    static var dryerCircle: SFSymbol { .init(rawValue: "dryer.circle") }
 
     /// 􁿓
     /// Single Localization, 3 Layersets
@@ -3542,7 +3542,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dryerCircleFill = SFSymbol(rawValue: "dryer.circle.fill")
+    static var dryerCircleFill: SFSymbol { .init(rawValue: "dryer.circle.fill") }
 
     /// 􀵣
     /// Single Localization, 3 Layersets
@@ -3551,7 +3551,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let earBadgeWaveform = SFSymbol(rawValue: "ear.badge.waveform")
+    static var earBadgeWaveform: SFSymbol { .init(rawValue: "ear.badge.waveform") }
 
     /// 􁊦
     /// Single Localization, 3 Layersets
@@ -3560,7 +3560,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let engineCombustionBadgeExclamationmark = SFSymbol(rawValue: "engine.combustion.badge.exclamationmark")
+    static var engineCombustionBadgeExclamationmark: SFSymbol { .init(rawValue: "engine.combustion.badge.exclamationmark") }
 
     /// 􁊧
     /// Single Localization, 3 Layersets
@@ -3569,7 +3569,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let engineCombustionBadgeExclamationmarkFill = SFSymbol(rawValue: "engine.combustion.badge.exclamationmark.fill")
+    static var engineCombustionBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "engine.combustion.badge.exclamationmark.fill") }
 
     /// 􁷻
     /// Single Localization, 3 Layersets
@@ -3578,7 +3578,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgePersonCrop = SFSymbol(rawValue: "envelope.badge.person.crop")
+    static var envelopeBadgePersonCrop: SFSymbol { .init(rawValue: "envelope.badge.person.crop") }
 
     /// 􁷽
     /// Single Localization, 3 Layersets
@@ -3587,7 +3587,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgePersonCropFill = SFSymbol(rawValue: "envelope.badge.person.crop.fill")
+    static var envelopeBadgePersonCropFill: SFSymbol { .init(rawValue: "envelope.badge.person.crop.fill") }
 
     /// 􂈚
     /// Single Localization, 2 Layersets
@@ -3600,14 +3600,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "eurosignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "eurosignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "eurosignArrowTriangleheadCounterclockwiseRotate90")
-    static let eurosignArrowCirclepath = SFSymbol(rawValue: "eurosign.arrow.circlepath")
+    static var eurosignArrowCirclepath: SFSymbol { .init(rawValue: "eurosign.arrow.circlepath") }
 
     /// 􁤴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eurozonesign = SFSymbol(rawValue: "eurozonesign")
+    static var eurozonesign: SFSymbol { .init(rawValue: "eurozonesign") }
 
     /// 􂈸
     /// Single Localization, 2 Layersets
@@ -3620,7 +3620,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "eurozonesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "eurozonesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "eurozonesignArrowTriangleheadCounterclockwiseRotate90")
-    static let eurozonesignArrowCirclepath = SFSymbol(rawValue: "eurozonesign.arrow.circlepath")
+    static var eurozonesignArrowCirclepath: SFSymbol { .init(rawValue: "eurozonesign.arrow.circlepath") }
 
     /// 􁤵
     /// Single Localization, 2 Layersets
@@ -3628,7 +3628,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignCircle = SFSymbol(rawValue: "eurozonesign.circle")
+    static var eurozonesignCircle: SFSymbol { .init(rawValue: "eurozonesign.circle") }
 
     /// 􁤶
     /// Single Localization, 3 Layersets
@@ -3637,7 +3637,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eurozonesignCircleFill = SFSymbol(rawValue: "eurozonesign.circle.fill")
+    static var eurozonesignCircleFill: SFSymbol { .init(rawValue: "eurozonesign.circle.fill") }
 
     /// 􁤷
     /// Single Localization, 2 Layersets
@@ -3645,7 +3645,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignSquare = SFSymbol(rawValue: "eurozonesign.square")
+    static var eurozonesignSquare: SFSymbol { .init(rawValue: "eurozonesign.square") }
 
     /// 􁤸
     /// Single Localization, 3 Layersets
@@ -3654,14 +3654,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eurozonesignSquareFill = SFSymbol(rawValue: "eurozonesign.square.fill")
+    static var eurozonesignSquareFill: SFSymbol { .init(rawValue: "eurozonesign.square.fill") }
 
     /// 􁊨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let evCharger = SFSymbol(rawValue: "ev.charger")
+    static var evCharger: SFSymbol { .init(rawValue: "ev.charger") }
 
     /// 􁰪
     /// Single Localization, 2 Layersets
@@ -3669,7 +3669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerArrowtriangleLeft = SFSymbol(rawValue: "ev.charger.arrowtriangle.left")
+    static var evChargerArrowtriangleLeft: SFSymbol { .init(rawValue: "ev.charger.arrowtriangle.left") }
 
     /// 􁰫
     /// Single Localization, 2 Layersets
@@ -3677,7 +3677,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerArrowtriangleLeftFill = SFSymbol(rawValue: "ev.charger.arrowtriangle.left.fill")
+    static var evChargerArrowtriangleLeftFill: SFSymbol { .init(rawValue: "ev.charger.arrowtriangle.left.fill") }
 
     /// 􁰲
     /// Single Localization, 2 Layersets
@@ -3685,7 +3685,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerArrowtriangleRight = SFSymbol(rawValue: "ev.charger.arrowtriangle.right")
+    static var evChargerArrowtriangleRight: SFSymbol { .init(rawValue: "ev.charger.arrowtriangle.right") }
 
     /// 􁰳
     /// Single Localization, 2 Layersets
@@ -3693,7 +3693,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerArrowtriangleRightFill = SFSymbol(rawValue: "ev.charger.arrowtriangle.right.fill")
+    static var evChargerArrowtriangleRightFill: SFSymbol { .init(rawValue: "ev.charger.arrowtriangle.right.fill") }
 
     /// 􁰶
     /// Single Localization, 2 Layersets
@@ -3701,7 +3701,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerExclamationmark = SFSymbol(rawValue: "ev.charger.exclamationmark")
+    static var evChargerExclamationmark: SFSymbol { .init(rawValue: "ev.charger.exclamationmark") }
 
     /// 􁰷
     /// Single Localization, 2 Layersets
@@ -3709,14 +3709,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerExclamationmarkFill = SFSymbol(rawValue: "ev.charger.exclamationmark.fill")
+    static var evChargerExclamationmarkFill: SFSymbol { .init(rawValue: "ev.charger.exclamationmark.fill") }
 
     /// 􁊩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let evChargerFill = SFSymbol(rawValue: "ev.charger.fill")
+    static var evChargerFill: SFSymbol { .init(rawValue: "ev.charger.fill") }
 
     /// 􁰦
     /// Single Localization, 2 Layersets
@@ -3724,7 +3724,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerSlash = SFSymbol(rawValue: "ev.charger.slash")
+    static var evChargerSlash: SFSymbol { .init(rawValue: "ev.charger.slash") }
 
     /// 􁰧
     /// Single Localization, 2 Layersets
@@ -3732,7 +3732,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evChargerSlashFill = SFSymbol(rawValue: "ev.charger.slash.fill")
+    static var evChargerSlashFill: SFSymbol { .init(rawValue: "ev.charger.slash.fill") }
 
     /// 􁺰
     /// Single Localization, 2 Layersets
@@ -3740,7 +3740,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcGbT = SFSymbol(rawValue: "ev.plug.ac.gb.t")
+    static var evPlugAcGbT: SFSymbol { .init(rawValue: "ev.plug.ac.gb.t") }
 
     /// 􁺱
     /// Single Localization, 2 Layersets
@@ -3748,7 +3748,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcGbTFill = SFSymbol(rawValue: "ev.plug.ac.gb.t.fill")
+    static var evPlugAcGbTFill: SFSymbol { .init(rawValue: "ev.plug.ac.gb.t.fill") }
 
     /// 􁺬
     /// Single Localization, 2 Layersets
@@ -3756,7 +3756,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcType1 = SFSymbol(rawValue: "ev.plug.ac.type.1")
+    static var evPlugAcType1: SFSymbol { .init(rawValue: "ev.plug.ac.type.1") }
 
     /// 􁺭
     /// Single Localization, 2 Layersets
@@ -3764,7 +3764,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcType1Fill = SFSymbol(rawValue: "ev.plug.ac.type.1.fill")
+    static var evPlugAcType1Fill: SFSymbol { .init(rawValue: "ev.plug.ac.type.1.fill") }
 
     /// 􁺮
     /// Single Localization, 2 Layersets
@@ -3772,7 +3772,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcType2 = SFSymbol(rawValue: "ev.plug.ac.type.2")
+    static var evPlugAcType2: SFSymbol { .init(rawValue: "ev.plug.ac.type.2") }
 
     /// 􁺯
     /// Single Localization, 2 Layersets
@@ -3780,7 +3780,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugAcType2Fill = SFSymbol(rawValue: "ev.plug.ac.type.2.fill")
+    static var evPlugAcType2Fill: SFSymbol { .init(rawValue: "ev.plug.ac.type.2.fill") }
 
     /// 􁺲
     /// Single Localization, 2 Layersets
@@ -3788,7 +3788,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcCcs1 = SFSymbol(rawValue: "ev.plug.dc.ccs1")
+    static var evPlugDcCcs1: SFSymbol { .init(rawValue: "ev.plug.dc.ccs1") }
 
     /// 􁺳
     /// Single Localization, 2 Layersets
@@ -3796,7 +3796,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcCcs1Fill = SFSymbol(rawValue: "ev.plug.dc.ccs1.fill")
+    static var evPlugDcCcs1Fill: SFSymbol { .init(rawValue: "ev.plug.dc.ccs1.fill") }
 
     /// 􁺴
     /// Single Localization, 2 Layersets
@@ -3804,7 +3804,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcCcs2 = SFSymbol(rawValue: "ev.plug.dc.ccs2")
+    static var evPlugDcCcs2: SFSymbol { .init(rawValue: "ev.plug.dc.ccs2") }
 
     /// 􁺵
     /// Single Localization, 2 Layersets
@@ -3812,7 +3812,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcCcs2Fill = SFSymbol(rawValue: "ev.plug.dc.ccs2.fill")
+    static var evPlugDcCcs2Fill: SFSymbol { .init(rawValue: "ev.plug.dc.ccs2.fill") }
 
     /// 􁺶
     /// Single Localization, 2 Layersets
@@ -3820,7 +3820,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcChademo = SFSymbol(rawValue: "ev.plug.dc.chademo")
+    static var evPlugDcChademo: SFSymbol { .init(rawValue: "ev.plug.dc.chademo") }
 
     /// 􁺷
     /// Single Localization, 2 Layersets
@@ -3828,7 +3828,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcChademoFill = SFSymbol(rawValue: "ev.plug.dc.chademo.fill")
+    static var evPlugDcChademoFill: SFSymbol { .init(rawValue: "ev.plug.dc.chademo.fill") }
 
     /// 􁺸
     /// Single Localization, 2 Layersets
@@ -3836,7 +3836,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcGbT = SFSymbol(rawValue: "ev.plug.dc.gb.t")
+    static var evPlugDcGbT: SFSymbol { .init(rawValue: "ev.plug.dc.gb.t") }
 
     /// 􁺹
     /// Single Localization, 2 Layersets
@@ -3844,7 +3844,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcGbTFill = SFSymbol(rawValue: "ev.plug.dc.gb.t.fill")
+    static var evPlugDcGbTFill: SFSymbol { .init(rawValue: "ev.plug.dc.gb.t.fill") }
 
     /// 􁺺
     /// Single Localization, 2 Layersets
@@ -3852,7 +3852,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcNacs = SFSymbol(rawValue: "ev.plug.dc.nacs")
+    static var evPlugDcNacs: SFSymbol { .init(rawValue: "ev.plug.dc.nacs") }
 
     /// 􁺻
     /// Single Localization, 2 Layersets
@@ -3860,7 +3860,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let evPlugDcNacsFill = SFSymbol(rawValue: "ev.plug.dc.nacs.fill")
+    static var evPlugDcNacsFill: SFSymbol { .init(rawValue: "ev.plug.dc.nacs.fill") }
 
     /// 􂈂
     /// Single Localization, 2 Layersets
@@ -3868,7 +3868,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1)
-    static let exclamationmarkMagnifyingglass = SFSymbol(rawValue: "exclamationmark.magnifyingglass")
+    static var exclamationmarkMagnifyingglass: SFSymbol { .init(rawValue: "exclamationmark.magnifyingglass") }
 
     /// 􁀓
     /// Single Localization, 3 Layersets
@@ -3877,7 +3877,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let exclamationmarkTirepressure = SFSymbol(rawValue: "exclamationmark.tirepressure")
+    static var exclamationmarkTirepressure: SFSymbol { .init(rawValue: "exclamationmark.tirepressure") }
 
     /// 􁀮
     /// Single Localization, 3 Layersets
@@ -3886,7 +3886,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let exclamationmarkWarninglight = SFSymbol(rawValue: "exclamationmark.warninglight")
+    static var exclamationmarkWarninglight: SFSymbol { .init(rawValue: "exclamationmark.warninglight") }
 
     /// 􁀯
     /// Single Localization, 3 Layersets
@@ -3895,7 +3895,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let exclamationmarkWarninglightFill = SFSymbol(rawValue: "exclamationmark.warninglight.fill")
+    static var exclamationmarkWarninglightFill: SFSymbol { .init(rawValue: "exclamationmark.warninglight.fill") }
 
     /// 􂀶
     /// Single Localization, 2 Layersets
@@ -3903,14 +3903,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eyeglassesSlash = SFSymbol(rawValue: "eyeglasses.slash")
+    static var eyeglassesSlash: SFSymbol { .init(rawValue: "eyeglasses.slash") }
 
     /// 􁁋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fan = SFSymbol(rawValue: "fan")
+    static var fan: SFSymbol { .init(rawValue: "fan") }
 
     /// 􁲉
     /// Single Localization, 3 Layersets
@@ -3919,7 +3919,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fanBadgeAutomatic = SFSymbol(rawValue: "fan.badge.automatic")
+    static var fanBadgeAutomatic: SFSymbol { .init(rawValue: "fan.badge.automatic") }
 
     /// 􁲊
     /// Single Localization, 3 Layersets
@@ -3928,14 +3928,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fanBadgeAutomaticFill = SFSymbol(rawValue: "fan.badge.automatic.fill")
+    static var fanBadgeAutomaticFill: SFSymbol { .init(rawValue: "fan.badge.automatic.fill") }
 
     /// 􁁌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fanFill = SFSymbol(rawValue: "fan.fill")
+    static var fanFill: SFSymbol { .init(rawValue: "fan.fill") }
 
     /// 􁝚
     /// Single Localization, 2 Layersets
@@ -3943,7 +3943,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanSlash = SFSymbol(rawValue: "fan.slash")
+    static var fanSlash: SFSymbol { .init(rawValue: "fan.slash") }
 
     /// 􁝛
     /// Single Localization, 2 Layersets
@@ -3951,7 +3951,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanSlashFill = SFSymbol(rawValue: "fan.slash.fill")
+    static var fanSlashFill: SFSymbol { .init(rawValue: "fan.slash.fill") }
 
     /// 􁿼
     /// Single Localization, 2 Layersets
@@ -3959,14 +3959,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let fieldOfViewUltrawide = SFSymbol(rawValue: "field.of.view.ultrawide")
+    static var fieldOfViewUltrawide: SFSymbol { .init(rawValue: "field.of.view.ultrawide") }
 
     /// 􁿽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fieldOfViewUltrawideFill = SFSymbol(rawValue: "field.of.view.ultrawide.fill")
+    static var fieldOfViewUltrawideFill: SFSymbol { .init(rawValue: "field.of.view.ultrawide.fill") }
 
     /// 􁿾
     /// Single Localization, 2 Layersets
@@ -3974,28 +3974,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let fieldOfViewWide = SFSymbol(rawValue: "field.of.view.wide")
+    static var fieldOfViewWide: SFSymbol { .init(rawValue: "field.of.view.wide") }
 
     /// 􁿿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fieldOfViewWideFill = SFSymbol(rawValue: "field.of.view.wide.fill")
+    static var fieldOfViewWideFill: SFSymbol { .init(rawValue: "field.of.view.wide.fill") }
 
     /// 􀕽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure = SFSymbol(rawValue: "figure")
+    static var figure: SFSymbol { .init(rawValue: "figure") }
 
     /// 􀘷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure2 = SFSymbol(rawValue: "figure.2")
+    static var figure2: SFSymbol { .init(rawValue: "figure.2") }
 
     /// 􀹽
     /// Single Localization, 2 Layersets
@@ -4003,7 +4003,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figure2Circle = SFSymbol(rawValue: "figure.2.circle")
+    static var figure2Circle: SFSymbol { .init(rawValue: "figure.2.circle") }
 
     /// 􀹾
     /// Single Localization, 3 Layersets
@@ -4012,14 +4012,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figure2CircleFill = SFSymbol(rawValue: "figure.2.circle.fill")
+    static var figure2CircleFill: SFSymbol { .init(rawValue: "figure.2.circle.fill") }
 
     /// 􁣽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureChild = SFSymbol(rawValue: "figure.child")
+    static var figureChild: SFSymbol { .init(rawValue: "figure.child") }
 
     /// 􁥾
     /// Single Localization, 2 Layersets
@@ -4027,7 +4027,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureChildAndLock = SFSymbol(rawValue: "figure.child.and.lock")
+    static var figureChildAndLock: SFSymbol { .init(rawValue: "figure.child.and.lock") }
 
     /// 􁥿
     /// Single Localization, 2 Layersets
@@ -4035,7 +4035,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureChildAndLockFill = SFSymbol(rawValue: "figure.child.and.lock.fill")
+    static var figureChildAndLockFill: SFSymbol { .init(rawValue: "figure.child.and.lock.fill") }
 
     /// 􁦀
     /// Single Localization, 2 Layersets
@@ -4043,7 +4043,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureChildAndLockOpen = SFSymbol(rawValue: "figure.child.and.lock.open")
+    static var figureChildAndLockOpen: SFSymbol { .init(rawValue: "figure.child.and.lock.open") }
 
     /// 􁦁
     /// Single Localization, 2 Layersets
@@ -4051,7 +4051,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureChildAndLockOpenFill = SFSymbol(rawValue: "figure.child.and.lock.open.fill")
+    static var figureChildAndLockOpenFill: SFSymbol { .init(rawValue: "figure.child.and.lock.open.fill") }
 
     /// 􁣾
     /// Single Localization, 2 Layersets
@@ -4059,7 +4059,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureChildCircle = SFSymbol(rawValue: "figure.child.circle")
+    static var figureChildCircle: SFSymbol { .init(rawValue: "figure.child.circle") }
 
     /// 􁣿
     /// Single Localization, 3 Layersets
@@ -4068,7 +4068,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureChildCircleFill = SFSymbol(rawValue: "figure.child.circle.fill")
+    static var figureChildCircleFill: SFSymbol { .init(rawValue: "figure.child.circle.fill") }
 
     /// 􁺼
     /// Single Localization, Single Layerset
@@ -4080,7 +4080,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeft")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeft")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeft")
-    static let figureSeatedSide = SFSymbol(rawValue: "figure.seated.side")
+    static var figureSeatedSide: SFSymbol { .init(rawValue: "figure.seated.side") }
 
     /// 􁁶
     /// Single Localization, 2 Layersets
@@ -4093,7 +4093,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionLower")
-    static let figureSeatedSideAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.air.distribution.lower")
+    static var figureSeatedSideAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.lower") }
 
     /// 􁁵
     /// Single Localization, 2 Layersets
@@ -4106,7 +4106,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionMiddle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionMiddle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionMiddle")
-    static let figureSeatedSideAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.air.distribution.middle")
+    static var figureSeatedSideAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.middle") }
 
     /// 􁁸
     /// Single Localization, 2 Layersets
@@ -4119,7 +4119,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLower")
-    static let figureSeatedSideAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.air.distribution.middle.and.lower")
+    static var figureSeatedSideAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.middle.and.lower") }
 
     /// 􁻀
     /// Single Localization, 2 Layersets
@@ -4132,7 +4132,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLowerAngled")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLowerAngled")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionMiddleAndLowerAngled")
-    static let figureSeatedSideAirDistributionMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.air.distribution.middle.and.lower.angled")
+    static var figureSeatedSideAirDistributionMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.middle.and.lower.angled") }
 
     /// 􁁷
     /// Single Localization, 2 Layersets
@@ -4145,7 +4145,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionUpper")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionUpper")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionUpper")
-    static let figureSeatedSideAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.air.distribution.upper")
+    static var figureSeatedSideAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.upper") }
 
     /// 􁺿
     /// Single Localization, 2 Layersets
@@ -4158,7 +4158,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndLowerAngled")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndLowerAngled")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndLowerAngled")
-    static let figureSeatedSideAirDistributionUpperAngledAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.air.distribution.upper.angled.and.lower.angled")
+    static var figureSeatedSideAirDistributionUpperAngledAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.upper.angled.and.lower.angled") }
 
     /// 􁺾
     /// Single Localization, 2 Layersets
@@ -4171,7 +4171,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddle")
-    static let figureSeatedSideAirDistributionUpperAngledAndMiddle = SFSymbol(rawValue: "figure.seated.side.air.distribution.upper.angled.and.middle")
+    static var figureSeatedSideAirDistributionUpperAngledAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.upper.angled.and.middle") }
 
     /// 􁺽
     /// Single Localization, 2 Layersets
@@ -4184,7 +4184,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddleAndLowerAngled")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddleAndLowerAngled")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAirDistributionUpperAngledAndMiddleAndLowerAngled")
-    static let figureSeatedSideAirDistributionUpperAngledAndMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.air.distribution.upper.angled.and.middle.and.lower.angled")
+    static var figureSeatedSideAirDistributionUpperAngledAndMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.air.distribution.upper.angled.and.middle.and.lower.angled") }
 
     /// 􁲍
     /// Single Localization, 2 Layersets
@@ -4197,7 +4197,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftAutomatic")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftAutomatic")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftAutomatic")
-    static let figureSeatedSideAutomatic = SFSymbol(rawValue: "figure.seated.side.automatic")
+    static var figureSeatedSideAutomatic: SFSymbol { .init(rawValue: "figure.seated.side.automatic") }
 
     /// 􁻒
     /// Single Localization, 2 Layersets
@@ -4210,7 +4210,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionLower")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.lower")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.lower") }
 
     /// 􁻑
     /// Single Localization, 2 Layersets
@@ -4223,7 +4223,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddle")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.middle")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.middle") }
 
     /// 􁻍
     /// Single Localization, 2 Layersets
@@ -4236,7 +4236,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.middle.and.lower")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.middle.and.lower") }
 
     /// 􁻐
     /// Single Localization, 2 Layersets
@@ -4249,7 +4249,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpper")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpper")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpper")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper") }
 
     /// 􁻏
     /// Single Localization, 2 Layersets
@@ -4262,7 +4262,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndLower")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndLower = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.lower")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndLower: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.lower") }
 
     /// 􁻎
     /// Single Localization, 2 Layersets
@@ -4275,7 +4275,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.middle")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.middle") }
 
     /// 􁻌
     /// Single Localization, 2 Layersets
@@ -4288,7 +4288,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower")
-    static let figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower")
+    static var figureSeatedSideWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower") }
 
     /// 􁷚
     /// Single Localization, 3 Layersets
@@ -4297,7 +4297,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWalkMotionTrianglebadgeExclamationmark = SFSymbol(rawValue: "figure.walk.motion.trianglebadge.exclamationmark")
+    static var figureWalkMotionTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "figure.walk.motion.trianglebadge.exclamationmark") }
 
     /// 􂁞
     /// Single Localization, 2 Layersets
@@ -4305,7 +4305,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fireworks = SFSymbol(rawValue: "fireworks")
+    static var fireworks: SFSymbol { .init(rawValue: "fireworks") }
 
     /// 􂃱
     /// Single Localization, 2 Layersets
@@ -4313,7 +4313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flashlightOffCircle = SFSymbol(rawValue: "flashlight.off.circle")
+    static var flashlightOffCircle: SFSymbol { .init(rawValue: "flashlight.off.circle") }
 
     /// 􂃲
     /// Single Localization, 3 Layersets
@@ -4322,7 +4322,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flashlightOffCircleFill = SFSymbol(rawValue: "flashlight.off.circle.fill")
+    static var flashlightOffCircleFill: SFSymbol { .init(rawValue: "flashlight.off.circle.fill") }
 
     /// 􂃳
     /// Single Localization, 2 Layersets
@@ -4330,7 +4330,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flashlightOnCircle = SFSymbol(rawValue: "flashlight.on.circle")
+    static var flashlightOnCircle: SFSymbol { .init(rawValue: "flashlight.on.circle") }
 
     /// 􂃴
     /// Single Localization, 3 Layersets
@@ -4339,7 +4339,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flashlightOnCircleFill = SFSymbol(rawValue: "flashlight.on.circle.fill")
+    static var flashlightOnCircleFill: SFSymbol { .init(rawValue: "flashlight.on.circle.fill") }
 
     /// 􂃵
     /// Single Localization, 2 Layersets
@@ -4347,7 +4347,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flashlightSlash = SFSymbol(rawValue: "flashlight.slash")
+    static var flashlightSlash: SFSymbol { .init(rawValue: "flashlight.slash") }
 
     /// 􂃶
     /// Single Localization, 2 Layersets
@@ -4355,7 +4355,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flashlightSlashCircle = SFSymbol(rawValue: "flashlight.slash.circle")
+    static var flashlightSlashCircle: SFSymbol { .init(rawValue: "flashlight.slash.circle") }
 
     /// 􂃷
     /// Single Localization, 3 Layersets
@@ -4364,7 +4364,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flashlightSlashCircleFill = SFSymbol(rawValue: "flashlight.slash.circle.fill")
+    static var flashlightSlashCircleFill: SFSymbol { .init(rawValue: "flashlight.slash.circle.fill") }
 
     /// 􁰍
     /// Single Localization, 2 Layersets
@@ -4372,7 +4372,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let flask = SFSymbol(rawValue: "flask")
+    static var flask: SFSymbol { .init(rawValue: "flask") }
 
     /// 􁰎
     /// Single Localization, 2 Layersets
@@ -4380,7 +4380,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let flaskFill = SFSymbol(rawValue: "flask.fill")
+    static var flaskFill: SFSymbol { .init(rawValue: "flask.fill") }
 
     /// 􂈗
     /// Single Localization, 2 Layersets
@@ -4393,7 +4393,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "florinsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "florinsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "florinsignArrowTriangleheadCounterclockwiseRotate90")
-    static let florinsignArrowCirclepath = SFSymbol(rawValue: "florinsign.arrow.circlepath")
+    static var florinsignArrowCirclepath: SFSymbol { .init(rawValue: "florinsign.arrow.circlepath") }
 
     /// 􂈖
     /// Single Localization, 2 Layersets
@@ -4406,7 +4406,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "francsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "francsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "francsignArrowTriangleheadCounterclockwiseRotate90")
-    static let francsignArrowCirclepath = SFSymbol(rawValue: "francsign.arrow.circlepath")
+    static var francsignArrowCirclepath: SFSymbol { .init(rawValue: "francsign.arrow.circlepath") }
 
     /// 􁈾
     /// Single Localization, 2 Layersets
@@ -4414,7 +4414,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpArrowtriangleLeft = SFSymbol(rawValue: "fuelpump.arrowtriangle.left")
+    static var fuelpumpArrowtriangleLeft: SFSymbol { .init(rawValue: "fuelpump.arrowtriangle.left") }
 
     /// 􁈿
     /// Single Localization, 2 Layersets
@@ -4422,7 +4422,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpArrowtriangleLeftFill = SFSymbol(rawValue: "fuelpump.arrowtriangle.left.fill")
+    static var fuelpumpArrowtriangleLeftFill: SFSymbol { .init(rawValue: "fuelpump.arrowtriangle.left.fill") }
 
     /// 􁈼
     /// Single Localization, 2 Layersets
@@ -4430,7 +4430,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpArrowtriangleRight = SFSymbol(rawValue: "fuelpump.arrowtriangle.right")
+    static var fuelpumpArrowtriangleRight: SFSymbol { .init(rawValue: "fuelpump.arrowtriangle.right") }
 
     /// 􁈽
     /// Single Localization, 2 Layersets
@@ -4438,7 +4438,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpArrowtriangleRightFill = SFSymbol(rawValue: "fuelpump.arrowtriangle.right.fill")
+    static var fuelpumpArrowtriangleRightFill: SFSymbol { .init(rawValue: "fuelpump.arrowtriangle.right.fill") }
 
     /// 􁥦
     /// Single Localization, 2 Layersets
@@ -4446,7 +4446,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpExclamationmark = SFSymbol(rawValue: "fuelpump.exclamationmark")
+    static var fuelpumpExclamationmark: SFSymbol { .init(rawValue: "fuelpump.exclamationmark") }
 
     /// 􁥧
     /// Single Localization, 2 Layersets
@@ -4454,7 +4454,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpExclamationmarkFill = SFSymbol(rawValue: "fuelpump.exclamationmark.fill")
+    static var fuelpumpExclamationmarkFill: SFSymbol { .init(rawValue: "fuelpump.exclamationmark.fill") }
 
     /// 􁰚
     /// Single Localization, 2 Layersets
@@ -4462,7 +4462,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpSlash = SFSymbol(rawValue: "fuelpump.slash")
+    static var fuelpumpSlash: SFSymbol { .init(rawValue: "fuelpump.slash") }
 
     /// 􁰛
     /// Single Localization, 2 Layersets
@@ -4470,7 +4470,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fuelpumpSlashFill = SFSymbol(rawValue: "fuelpump.slash.fill")
+    static var fuelpumpSlashFill: SFSymbol { .init(rawValue: "fuelpump.slash.fill") }
 
     /// 􁫏
     /// Single Localization, 2 Layersets
@@ -4478,7 +4478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle33percent = SFSymbol(rawValue: "gauge.open.with.lines.needle.33percent")
+    static var gaugeOpenWithLinesNeedle33percent: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.33percent") }
 
     /// 􁉰
     /// Single Localization, 2 Layersets
@@ -4486,7 +4486,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle33percentAndArrowtriangle = SFSymbol(rawValue: "gauge.open.with.lines.needle.33percent.and.arrowtriangle")
+    static var gaugeOpenWithLinesNeedle33percentAndArrowtriangle: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.33percent.and.arrowtriangle") }
 
     /// 􁊐
     /// Single Localization, 2 Layersets
@@ -4499,7 +4499,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "gaugeOpenWithLinesNeedle33percentAndArrowTriangleheadFrom0percentTo50percent")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "gaugeOpenWithLinesNeedle33percentAndArrowTriangleheadFrom0percentTo50percent")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "gaugeOpenWithLinesNeedle33percentAndArrowTriangleheadFrom0percentTo50percent")
-    static let gaugeOpenWithLinesNeedle33percentAndArrowtriangleFrom0percentTo50percent = SFSymbol(rawValue: "gauge.open.with.lines.needle.33percent.and.arrowtriangle.from.0percent.to.50percent")
+    static var gaugeOpenWithLinesNeedle33percentAndArrowtriangleFrom0percentTo50percent: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.33percent.and.arrowtriangle.from.0percent.to.50percent") }
 
     /// 􁖗
     /// Single Localization, 2 Layersets
@@ -4507,7 +4507,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var gaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􁖜
     /// Single Localization, 2 Layersets
@@ -4515,7 +4515,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle67percentAndArrowtriangleAndCar = SFSymbol(rawValue: "gauge.open.with.lines.needle.67percent.and.arrowtriangle.and.car")
+    static var gaugeOpenWithLinesNeedle67percentAndArrowtriangleAndCar: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.67percent.and.arrowtriangle.and.car") }
 
     /// 􁖘
     /// Single Localization, 2 Layersets
@@ -4523,7 +4523,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle84percentExclamation = SFSymbol(rawValue: "gauge.open.with.lines.needle.84percent.exclamation")
+    static var gaugeOpenWithLinesNeedle84percentExclamation: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.84percent.exclamation") }
 
     /// 􁐙
     /// Single Localization, 2 Layersets
@@ -4531,7 +4531,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedle0percent = SFSymbol(rawValue: "gauge.with.dots.needle.0percent")
+    static var gaugeWithDotsNeedle0percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.0percent") }
 
     /// 􁰉
     /// Single Localization, 2 Layersets
@@ -4539,7 +4539,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedle33percent = SFSymbol(rawValue: "gauge.with.dots.needle.33percent")
+    static var gaugeWithDotsNeedle33percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.33percent") }
 
     /// 􁐚
     /// Single Localization, 2 Layersets
@@ -4547,7 +4547,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedle50percent = SFSymbol(rawValue: "gauge.with.dots.needle.50percent")
+    static var gaugeWithDotsNeedle50percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.50percent") }
 
     /// 􀍾
     /// Single Localization, 2 Layersets
@@ -4555,7 +4555,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedle67percent = SFSymbol(rawValue: "gauge.with.dots.needle.67percent")
+    static var gaugeWithDotsNeedle67percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.67percent") }
 
     /// 􁐛
     /// Single Localization, 2 Layersets
@@ -4563,7 +4563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedle100percent = SFSymbol(rawValue: "gauge.with.dots.needle.100percent")
+    static var gaugeWithDotsNeedle100percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.100percent") }
 
     /// 􁐗
     /// Single Localization, 2 Layersets
@@ -4571,7 +4571,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedleBottom0percent = SFSymbol(rawValue: "gauge.with.dots.needle.bottom.0percent")
+    static var gaugeWithDotsNeedleBottom0percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.bottom.0percent") }
 
     /// 􀍽
     /// Single Localization, 2 Layersets
@@ -4579,7 +4579,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedleBottom50percent = SFSymbol(rawValue: "gauge.with.dots.needle.bottom.50percent")
+    static var gaugeWithDotsNeedleBottom50percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.bottom.50percent") }
 
     /// 􀓧
     /// Single Localization, 3 Layersets
@@ -4588,7 +4588,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let gaugeWithDotsNeedleBottom50percentBadgeMinus = SFSymbol(rawValue: "gauge.with.dots.needle.bottom.50percent.badge.minus")
+    static var gaugeWithDotsNeedleBottom50percentBadgeMinus: SFSymbol { .init(rawValue: "gauge.with.dots.needle.bottom.50percent.badge.minus") }
 
     /// 􀓓
     /// Single Localization, 3 Layersets
@@ -4597,7 +4597,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let gaugeWithDotsNeedleBottom50percentBadgePlus = SFSymbol(rawValue: "gauge.with.dots.needle.bottom.50percent.badge.plus")
+    static var gaugeWithDotsNeedleBottom50percentBadgePlus: SFSymbol { .init(rawValue: "gauge.with.dots.needle.bottom.50percent.badge.plus") }
 
     /// 􁐘
     /// Single Localization, 2 Layersets
@@ -4605,7 +4605,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithDotsNeedleBottom100percent = SFSymbol(rawValue: "gauge.with.dots.needle.bottom.100percent")
+    static var gaugeWithDotsNeedleBottom100percent: SFSymbol { .init(rawValue: "gauge.with.dots.needle.bottom.100percent") }
 
     /// 􁖫
     /// Single Localization, 2 Layersets
@@ -4613,7 +4613,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithNeedle = SFSymbol(rawValue: "gauge.with.needle")
+    static var gaugeWithNeedle: SFSymbol { .init(rawValue: "gauge.with.needle") }
 
     /// 􁖬
     /// Single Localization, 2 Layersets
@@ -4621,14 +4621,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeWithNeedleFill = SFSymbol(rawValue: "gauge.with.needle.fill")
+    static var gaugeWithNeedleFill: SFSymbol { .init(rawValue: "gauge.with.needle.fill") }
 
     /// 􁸝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gearshiftLayoutSixspeed = SFSymbol(rawValue: "gearshift.layout.sixspeed")
+    static var gearshiftLayoutSixspeed: SFSymbol { .init(rawValue: "gearshift.layout.sixspeed") }
 
     /// 􂈦
     /// Single Localization, 2 Layersets
@@ -4641,7 +4641,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "guaranisignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "guaranisignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "guaranisignArrowTriangleheadCounterclockwiseRotate90")
-    static let guaranisignArrowCirclepath = SFSymbol(rawValue: "guaranisign.arrow.circlepath")
+    static var guaranisignArrowCirclepath: SFSymbol { .init(rawValue: "guaranisign.arrow.circlepath") }
 
     /// 􂂱
     /// Single Localization, Single Layerset
@@ -4653,7 +4653,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "duffleBag")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "duffleBag")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "duffleBag")
-    static let gymBag = SFSymbol(rawValue: "gym.bag")
+    static var gymBag: SFSymbol { .init(rawValue: "gym.bag") }
 
     /// 􂂲
     /// Single Localization, Single Layerset
@@ -4665,7 +4665,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "duffleBagFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "duffleBagFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "duffleBagFill")
-    static let gymBagFill = SFSymbol(rawValue: "gym.bag.fill")
+    static var gymBagFill: SFSymbol { .init(rawValue: "gym.bag.fill") }
 
     /// 􁾀
     /// Single Localization, 2 Layersets
@@ -4673,7 +4673,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handPointUpLeftAndText = SFSymbol(rawValue: "hand.point.up.left.and.text")
+    static var handPointUpLeftAndText: SFSymbol { .init(rawValue: "hand.point.up.left.and.text") }
 
     /// 􁾁
     /// Single Localization, 2 Layersets
@@ -4681,7 +4681,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handPointUpLeftAndTextFill = SFSymbol(rawValue: "hand.point.up.left.and.text.fill")
+    static var handPointUpLeftAndTextFill: SFSymbol { .init(rawValue: "hand.point.up.left.and.text.fill") }
 
     /// 􁿜
     /// Single Localization, 2 Layersets
@@ -4689,7 +4689,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handbagCircle = SFSymbol(rawValue: "handbag.circle")
+    static var handbagCircle: SFSymbol { .init(rawValue: "handbag.circle") }
 
     /// 􁿝
     /// Single Localization, 3 Layersets
@@ -4698,7 +4698,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handbagCircleFill = SFSymbol(rawValue: "handbag.circle.fill")
+    static var handbagCircleFill: SFSymbol { .init(rawValue: "handbag.circle.fill") }
 
     /// 􀲮
     /// Single Localization, 2 Layersets
@@ -4706,7 +4706,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handsAndSparkles = SFSymbol(rawValue: "hands.and.sparkles")
+    static var handsAndSparkles: SFSymbol { .init(rawValue: "hands.and.sparkles") }
 
     /// 􀲯
     /// Single Localization, 2 Layersets
@@ -4714,14 +4714,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handsAndSparklesFill = SFSymbol(rawValue: "hands.and.sparkles.fill")
+    static var handsAndSparklesFill: SFSymbol { .init(rawValue: "hands.and.sparkles.fill") }
 
     /// 􀠖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hanger = SFSymbol(rawValue: "hanger")
+    static var hanger: SFSymbol { .init(rawValue: "hanger") }
 
     /// 􂀸
     /// Single Localization, 2 Layersets
@@ -4729,7 +4729,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hareCircle = SFSymbol(rawValue: "hare.circle")
+    static var hareCircle: SFSymbol { .init(rawValue: "hare.circle") }
 
     /// 􂀹
     /// Single Localization, 3 Layersets
@@ -4738,7 +4738,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hareCircleFill = SFSymbol(rawValue: "hare.circle.fill")
+    static var hareCircleFill: SFSymbol { .init(rawValue: "hare.circle.fill") }
 
     /// 􁟹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4753,21 +4753,21 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "headProfileArrowForwardAndVisionPro")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "headProfileArrowForwardAndVisionPro")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "headProfileArrowForwardAndVisionPro")
-    static let headProfileArrowForwardAndVisionpro = SFSymbol(rawValue: "head.profile.arrow.forward.and.visionpro")
+    static var headProfileArrowForwardAndVisionpro: SFSymbol { .init(rawValue: "head.profile.arrow.forward.and.visionpro") }
 
     /// 􁰹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let heatWaves = SFSymbol(rawValue: "heat.waves")
+    static var heatWaves: SFSymbol { .init(rawValue: "heat.waves") }
 
     /// 􁄵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let horn = SFSymbol(rawValue: "horn")
+    static var horn: SFSymbol { .init(rawValue: "horn") }
 
     /// 􁄷
     /// Single Localization, 2 Layersets
@@ -4775,7 +4775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hornBlast = SFSymbol(rawValue: "horn.blast")
+    static var hornBlast: SFSymbol { .init(rawValue: "horn.blast") }
 
     /// 􁄸
     /// Single Localization, 2 Layersets
@@ -4783,14 +4783,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hornBlastFill = SFSymbol(rawValue: "horn.blast.fill")
+    static var hornBlastFill: SFSymbol { .init(rawValue: "horn.blast.fill") }
 
     /// 􁄶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hornFill = SFSymbol(rawValue: "horn.fill")
+    static var hornFill: SFSymbol { .init(rawValue: "horn.fill") }
 
     /// 􂇗
     /// Single Localization, 3 Layersets
@@ -4804,7 +4804,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 26.0, renamed: "hourglassBadgeLock")
     @available(watchOS, introduced: 10.0, deprecated: 26.0, renamed: "hourglassBadgeLock")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "hourglassBadgeLock")
-    static let hourglassAndLock = SFSymbol(rawValue: "hourglass.and.lock")
+    static var hourglassAndLock: SFSymbol { .init(rawValue: "hourglass.and.lock") }
 
     /// 􂈤
     /// Single Localization, 2 Layersets
@@ -4817,7 +4817,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "hryvniasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "hryvniasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "hryvniasignArrowTriangleheadCounterclockwiseRotate90")
-    static let hryvniasignArrowCirclepath = SFSymbol(rawValue: "hryvniasign.arrow.circlepath")
+    static var hryvniasignArrowCirclepath: SFSymbol { .init(rawValue: "hryvniasign.arrow.circlepath") }
 
     /// 􂈜
     /// Single Localization, 2 Layersets
@@ -4830,7 +4830,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "indianrupeesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "indianrupeesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "indianrupeesignArrowTriangleheadCounterclockwiseRotate90")
-    static let indianrupeesignArrowCirclepath = SFSymbol(rawValue: "indianrupeesign.arrow.circlepath")
+    static var indianrupeesignArrowCirclepath: SFSymbol { .init(rawValue: "indianrupeesign.arrow.circlepath") }
 
     /// 􁤩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4839,7 +4839,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad case.
-    static let ipadCase = SFSymbol(rawValue: "ipad.case")
+    static var ipadCase: SFSymbol { .init(rawValue: "ipad.case") }
 
     /// 􁤪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4848,7 +4848,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad and iPhone case.
-    static let ipadCaseAndIphoneCase = SFSymbol(rawValue: "ipad.case.and.iphone.case")
+    static var ipadCaseAndIphoneCase: SFSymbol { .init(rawValue: "ipad.case.and.iphone.case") }
 
     /// 􁣶
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4858,7 +4858,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadSizes = SFSymbol(rawValue: "ipad.sizes")
+    static var ipadSizes: SFSymbol { .init(rawValue: "ipad.sizes") }
 
     /// 􁰿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4873,7 +4873,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "iphoneAndArrowLeftAndArrowRightInward")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "iphoneAndArrowLeftAndArrowRightInward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "iphoneAndArrowLeftAndArrowRightInward")
-    static let iphoneAndArrowLeftAndArrowRight = SFSymbol(rawValue: "iphone.and.arrow.left.and.arrow.right")
+    static var iphoneAndArrowLeftAndArrowRight: SFSymbol { .init(rawValue: "iphone.and.arrow.left.and.arrow.right") }
 
     /// 􁤨
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -4882,7 +4882,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone case.
-    static let iphoneCase = SFSymbol(rawValue: "iphone.case")
+    static var iphoneCase: SFSymbol { .init(rawValue: "iphone.case") }
 
     /// 􁣴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -4892,7 +4892,7 @@ public extension SFSymbol {
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneSizes = SFSymbol(rawValue: "iphone.sizes")
+    static var iphoneSizes: SFSymbol { .init(rawValue: "iphone.sizes") }
 
     /// 􂃜
     /// Single Localization, 2 Layersets
@@ -4900,7 +4900,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kashidaArabic = SFSymbol(rawValue: "kashida.arabic")
+    static var kashidaArabic: SFSymbol { .init(rawValue: "kashida.arabic") }
 
     /// 􂇮
     /// Single Localization, 2 Layersets
@@ -4908,7 +4908,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyRadiowavesForwardSlash = SFSymbol(rawValue: "key.radiowaves.forward.slash")
+    static var keyRadiowavesForwardSlash: SFSymbol { .init(rawValue: "key.radiowaves.forward.slash") }
 
     /// 􂇰
     /// Single Localization, 2 Layersets
@@ -4916,7 +4916,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyRadiowavesForwardSlashFill = SFSymbol(rawValue: "key.radiowaves.forward.slash.fill")
+    static var keyRadiowavesForwardSlashFill: SFSymbol { .init(rawValue: "key.radiowaves.forward.slash.fill") }
 
     /// 􂅦
     /// Single Localization, 2 Layersets
@@ -4924,7 +4924,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keySlash = SFSymbol(rawValue: "key.slash")
+    static var keySlash: SFSymbol { .init(rawValue: "key.slash") }
 
     /// 􂅧
     /// Single Localization, 2 Layersets
@@ -4932,7 +4932,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keySlashFill = SFSymbol(rawValue: "key.slash.fill")
+    static var keySlashFill: SFSymbol { .init(rawValue: "key.slash.fill") }
 
     /// 􂈠
     /// Single Localization, 2 Layersets
@@ -4945,7 +4945,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "kipsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "kipsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "kipsignArrowTriangleheadCounterclockwiseRotate90")
-    static let kipsignArrowCirclepath = SFSymbol(rawValue: "kipsign.arrow.circlepath")
+    static var kipsignArrowCirclepath: SFSymbol { .init(rawValue: "kipsign.arrow.circlepath") }
 
     /// 􀨇
     /// Single Localization, 2 Layersets
@@ -4953,7 +4953,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lButtonRoundedbottomHorizontal = SFSymbol(rawValue: "l.button.roundedbottom.horizontal")
+    static var lButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "l.button.roundedbottom.horizontal") }
 
     /// 􀨈
     /// Single Localization, 3 Layersets
@@ -4962,7 +4962,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "l.button.roundedbottom.horizontal.fill")
+    static var lButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "l.button.roundedbottom.horizontal.fill") }
 
     /// 􀨉
     /// Single Localization, 2 Layersets
@@ -4970,7 +4970,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l1ButtonRoundedbottomHorizontal = SFSymbol(rawValue: "l1.button.roundedbottom.horizontal")
+    static var l1ButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "l1.button.roundedbottom.horizontal") }
 
     /// 􀨊
     /// Single Localization, 3 Layersets
@@ -4979,7 +4979,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l1ButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "l1.button.roundedbottom.horizontal.fill")
+    static var l1ButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "l1.button.roundedbottom.horizontal.fill") }
 
     /// 􁺁
     /// Single Localization, 2 Layersets
@@ -4987,7 +4987,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l1Circle = SFSymbol(rawValue: "l1.circle")
+    static var l1Circle: SFSymbol { .init(rawValue: "l1.circle") }
 
     /// 􁺂
     /// Single Localization, 3 Layersets
@@ -4996,7 +4996,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l1CircleFill = SFSymbol(rawValue: "l1.circle.fill")
+    static var l1CircleFill: SFSymbol { .init(rawValue: "l1.circle.fill") }
 
     /// 􁷳
     /// Single Localization, 2 Layersets
@@ -5004,7 +5004,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l2ButtonAngledtopVerticalLeft = SFSymbol(rawValue: "l2.button.angledtop.vertical.left")
+    static var l2ButtonAngledtopVerticalLeft: SFSymbol { .init(rawValue: "l2.button.angledtop.vertical.left") }
 
     /// 􁷴
     /// Single Localization, 3 Layersets
@@ -5013,7 +5013,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l2ButtonAngledtopVerticalLeftFill = SFSymbol(rawValue: "l2.button.angledtop.vertical.left.fill")
+    static var l2ButtonAngledtopVerticalLeftFill: SFSymbol { .init(rawValue: "l2.button.angledtop.vertical.left.fill") }
 
     /// 􀨋
     /// Single Localization, 2 Layersets
@@ -5021,7 +5021,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l2ButtonRoundedtopHorizontal = SFSymbol(rawValue: "l2.button.roundedtop.horizontal")
+    static var l2ButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "l2.button.roundedtop.horizontal") }
 
     /// 􀨌
     /// Single Localization, 3 Layersets
@@ -5030,7 +5030,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l2ButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "l2.button.roundedtop.horizontal.fill")
+    static var l2ButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "l2.button.roundedtop.horizontal.fill") }
 
     /// 􁺅
     /// Single Localization, 2 Layersets
@@ -5038,7 +5038,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l2Circle = SFSymbol(rawValue: "l2.circle")
+    static var l2Circle: SFSymbol { .init(rawValue: "l2.circle") }
 
     /// 􁺆
     /// Single Localization, 3 Layersets
@@ -5047,7 +5047,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l2CircleFill = SFSymbol(rawValue: "l2.circle.fill")
+    static var l2CircleFill: SFSymbol { .init(rawValue: "l2.circle.fill") }
 
     /// 􁸇
     /// Single Localization, 2 Layersets
@@ -5055,7 +5055,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l3ButtonAngledbottomHorizontalLeft = SFSymbol(rawValue: "l3.button.angledbottom.horizontal.left")
+    static var l3ButtonAngledbottomHorizontalLeft: SFSymbol { .init(rawValue: "l3.button.angledbottom.horizontal.left") }
 
     /// 􁸈
     /// Single Localization, 3 Layersets
@@ -5064,7 +5064,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l3ButtonAngledbottomHorizontalLeftFill = SFSymbol(rawValue: "l3.button.angledbottom.horizontal.left.fill")
+    static var l3ButtonAngledbottomHorizontalLeftFill: SFSymbol { .init(rawValue: "l3.button.angledbottom.horizontal.left.fill") }
 
     /// 􁸠
     /// Single Localization, 2 Layersets
@@ -5072,7 +5072,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let l4ButtonHorizontal = SFSymbol(rawValue: "l4.button.horizontal")
+    static var l4ButtonHorizontal: SFSymbol { .init(rawValue: "l4.button.horizontal") }
 
     /// 􁸡
     /// Single Localization, 3 Layersets
@@ -5081,7 +5081,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let l4ButtonHorizontalFill = SFSymbol(rawValue: "l4.button.horizontal.fill")
+    static var l4ButtonHorizontalFill: SFSymbol { .init(rawValue: "l4.button.horizontal.fill") }
 
     /// 􁼛
     /// Single Localization, 2 Layersets
@@ -5089,7 +5089,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ladybugCircle = SFSymbol(rawValue: "ladybug.circle")
+    static var ladybugCircle: SFSymbol { .init(rawValue: "ladybug.circle") }
 
     /// 􁼜
     /// Single Localization, 3 Layersets
@@ -5098,7 +5098,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ladybugCircleFill = SFSymbol(rawValue: "ladybug.circle.fill")
+    static var ladybugCircleFill: SFSymbol { .init(rawValue: "ladybug.circle.fill") }
 
     /// 􂈰
     /// Single Localization, 2 Layersets
@@ -5111,14 +5111,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "larisignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "larisignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "larisignArrowTriangleheadCounterclockwiseRotate90")
-    static let larisignArrowCirclepath = SFSymbol(rawValue: "larisign.arrow.circlepath")
+    static var larisignArrowCirclepath: SFSymbol { .init(rawValue: "larisign.arrow.circlepath") }
 
     /// 􂁝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let laserBurst = SFSymbol(rawValue: "laser.burst")
+    static var laserBurst: SFSymbol { .init(rawValue: "laser.burst") }
 
     /// 􀣳
     /// Single Localization, 2 Layersets
@@ -5126,7 +5126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lassoBadgeSparkles = SFSymbol(rawValue: "lasso.badge.sparkles")
+    static var lassoBadgeSparkles: SFSymbol { .init(rawValue: "lasso.badge.sparkles") }
 
     /// 􀨓
     /// Single Localization, 2 Layersets
@@ -5134,7 +5134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lbButtonRoundedbottomHorizontal = SFSymbol(rawValue: "lb.button.roundedbottom.horizontal")
+    static var lbButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "lb.button.roundedbottom.horizontal") }
 
     /// 􀨔
     /// Single Localization, 3 Layersets
@@ -5143,7 +5143,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lbButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "lb.button.roundedbottom.horizontal.fill")
+    static var lbButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "lb.button.roundedbottom.horizontal.fill") }
 
     /// 􁺃
     /// Single Localization, 2 Layersets
@@ -5151,7 +5151,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lbCircle = SFSymbol(rawValue: "lb.circle")
+    static var lbCircle: SFSymbol { .init(rawValue: "lb.circle") }
 
     /// 􁺄
     /// Single Localization, 3 Layersets
@@ -5160,14 +5160,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lbCircleFill = SFSymbol(rawValue: "lb.circle.fill")
+    static var lbCircleFill: SFSymbol { .init(rawValue: "lb.circle.fill") }
 
     /// 􁣣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let left = SFSymbol(rawValue: "left")
+    static var left: SFSymbol { .init(rawValue: "left") }
 
     /// 􁣤
     /// Single Localization, 2 Layersets
@@ -5175,7 +5175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let leftCircle = SFSymbol(rawValue: "left.circle")
+    static var leftCircle: SFSymbol { .init(rawValue: "left.circle") }
 
     /// 􁣥
     /// Single Localization, 3 Layersets
@@ -5184,7 +5184,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let leftCircleFill = SFSymbol(rawValue: "left.circle.fill")
+    static var leftCircleFill: SFSymbol { .init(rawValue: "left.circle.fill") }
 
     /// 􁺪
     /// Single Localization, 2 Layersets
@@ -5192,7 +5192,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let licenseplate = SFSymbol(rawValue: "licenseplate")
+    static var licenseplate: SFSymbol { .init(rawValue: "licenseplate") }
 
     /// 􁺫
     /// Single Localization, 3 Layersets
@@ -5201,7 +5201,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let licenseplateFill = SFSymbol(rawValue: "licenseplate.fill")
+    static var licenseplateFill: SFSymbol { .init(rawValue: "licenseplate.fill") }
 
     /// 􁷘
     /// Single Localization, 2 Layersets
@@ -5209,7 +5209,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulbMax = SFSymbol(rawValue: "lightbulb.max")
+    static var lightbulbMax: SFSymbol { .init(rawValue: "lightbulb.max") }
 
     /// 􁷙
     /// Single Localization, 2 Layersets
@@ -5217,7 +5217,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulbMaxFill = SFSymbol(rawValue: "lightbulb.max.fill")
+    static var lightbulbMaxFill: SFSymbol { .init(rawValue: "lightbulb.max.fill") }
 
     /// 􁷖
     /// Single Localization, 2 Layersets
@@ -5225,7 +5225,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulbMin = SFSymbol(rawValue: "lightbulb.min")
+    static var lightbulbMin: SFSymbol { .init(rawValue: "lightbulb.min") }
 
     /// 􁹄
     /// Single Localization, 3 Layersets
@@ -5234,7 +5234,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightbulbMinBadgeExclamationmark = SFSymbol(rawValue: "lightbulb.min.badge.exclamationmark")
+    static var lightbulbMinBadgeExclamationmark: SFSymbol { .init(rawValue: "lightbulb.min.badge.exclamationmark") }
 
     /// 􁹅
     /// Single Localization, 3 Layersets
@@ -5243,7 +5243,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lightbulbMinBadgeExclamationmarkFill = SFSymbol(rawValue: "lightbulb.min.badge.exclamationmark.fill")
+    static var lightbulbMinBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "lightbulb.min.badge.exclamationmark.fill") }
 
     /// 􁷗
     /// Single Localization, 2 Layersets
@@ -5251,21 +5251,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lightbulbMinFill = SFSymbol(rawValue: "lightbulb.min.fill")
+    static var lightbulbMinFill: SFSymbol { .init(rawValue: "lightbulb.min.fill") }
 
     /// 􀷺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightrail = SFSymbol(rawValue: "lightrail")
+    static var lightrail: SFSymbol { .init(rawValue: "lightrail") }
 
     /// 􀷻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lightrailFill = SFSymbol(rawValue: "lightrail.fill")
+    static var lightrailFill: SFSymbol { .init(rawValue: "lightrail.fill") }
 
     /// 􁹩
     /// Single Localization, 2 Layersets
@@ -5273,7 +5273,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let lightspectrumHorizontal = SFSymbol(rawValue: "lightspectrum.horizontal")
+    static var lightspectrumHorizontal: SFSymbol { .init(rawValue: "lightspectrum.horizontal") }
 
     /// 􁷹
     /// Single Localization, 2 Layersets
@@ -5281,7 +5281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let line3HorizontalButtonAngledtopVerticalRight = SFSymbol(rawValue: "line.3.horizontal.button.angledtop.vertical.right")
+    static var line3HorizontalButtonAngledtopVerticalRight: SFSymbol { .init(rawValue: "line.3.horizontal.button.angledtop.vertical.right") }
 
     /// 􁷺
     /// Single Localization, 3 Layersets
@@ -5290,14 +5290,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let line3HorizontalButtonAngledtopVerticalRightFill = SFSymbol(rawValue: "line.3.horizontal.button.angledtop.vertical.right.fill")
+    static var line3HorizontalButtonAngledtopVerticalRightFill: SFSymbol { .init(rawValue: "line.3.horizontal.button.angledtop.vertical.right.fill") }
 
     /// 􂀙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let linesMeasurementVertical = SFSymbol(rawValue: "lines.measurement.vertical")
+    static var linesMeasurementVertical: SFSymbol { .init(rawValue: "lines.measurement.vertical") }
 
     /// 􂈢
     /// Single Localization, 2 Layersets
@@ -5310,7 +5310,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "lirasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "lirasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "lirasignArrowTriangleheadCounterclockwiseRotate90")
-    static let lirasignArrowCirclepath = SFSymbol(rawValue: "lirasign.arrow.circlepath")
+    static var lirasignArrowCirclepath: SFSymbol { .init(rawValue: "lirasign.arrow.circlepath") }
 
     /// 􀙔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5321,7 +5321,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Live Photos feature.
-    static let livephotoBadgeAutomatic = SFSymbol(rawValue: "livephoto.badge.automatic")
+    static var livephotoBadgeAutomatic: SFSymbol { .init(rawValue: "livephoto.badge.automatic") }
 
     /// 􁼵
     /// Single Localization, 2 Layersets
@@ -5329,7 +5329,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lizardCircle = SFSymbol(rawValue: "lizard.circle")
+    static var lizardCircle: SFSymbol { .init(rawValue: "lizard.circle") }
 
     /// 􁼶
     /// Single Localization, 3 Layersets
@@ -5338,7 +5338,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lizardCircleFill = SFSymbol(rawValue: "lizard.circle.fill")
+    static var lizardCircleFill: SFSymbol { .init(rawValue: "lizard.circle.fill") }
 
     /// 􁸢
     /// Single Localization, 2 Layersets
@@ -5346,7 +5346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lmButtonHorizontal = SFSymbol(rawValue: "lm.button.horizontal")
+    static var lmButtonHorizontal: SFSymbol { .init(rawValue: "lm.button.horizontal") }
 
     /// 􁸣
     /// Single Localization, 3 Layersets
@@ -5355,7 +5355,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lmButtonHorizontalFill = SFSymbol(rawValue: "lm.button.horizontal.fill")
+    static var lmButtonHorizontalFill: SFSymbol { .init(rawValue: "lm.button.horizontal.fill") }
 
     /// 􁰏
     /// Single Localization, 2 Layersets
@@ -5363,7 +5363,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockAppDashed = SFSymbol(rawValue: "lock.app.dashed")
+    static var lockAppDashed: SFSymbol { .init(rawValue: "lock.app.dashed") }
 
     /// 􂆉
     /// Single Localization, 3 Layersets
@@ -5372,7 +5372,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeClock = SFSymbol(rawValue: "lock.badge.clock")
+    static var lockBadgeClock: SFSymbol { .init(rawValue: "lock.badge.clock") }
 
     /// 􂆊
     /// Single Localization, 3 Layersets
@@ -5381,7 +5381,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeClockFill = SFSymbol(rawValue: "lock.badge.clock.fill")
+    static var lockBadgeClockFill: SFSymbol { .init(rawValue: "lock.badge.clock.fill") }
 
     /// 􂄜
     /// Single Localization, 2 Layersets
@@ -5389,7 +5389,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockCircleDotted = SFSymbol(rawValue: "lock.circle.dotted")
+    static var lockCircleDotted: SFSymbol { .init(rawValue: "lock.circle.dotted") }
 
     /// 􁸋
     /// Single Localization, 2 Layersets
@@ -5397,7 +5397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lsbButtonAngledbottomHorizontalLeft = SFSymbol(rawValue: "lsb.button.angledbottom.horizontal.left")
+    static var lsbButtonAngledbottomHorizontalLeft: SFSymbol { .init(rawValue: "lsb.button.angledbottom.horizontal.left") }
 
     /// 􁸌
     /// Single Localization, 3 Layersets
@@ -5406,7 +5406,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lsbButtonAngledbottomHorizontalLeftFill = SFSymbol(rawValue: "lsb.button.angledbottom.horizontal.left.fill")
+    static var lsbButtonAngledbottomHorizontalLeftFill: SFSymbol { .init(rawValue: "lsb.button.angledbottom.horizontal.left.fill") }
 
     /// 􀨗
     /// Single Localization, 2 Layersets
@@ -5414,7 +5414,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ltButtonRoundedtopHorizontal = SFSymbol(rawValue: "lt.button.roundedtop.horizontal")
+    static var ltButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "lt.button.roundedtop.horizontal") }
 
     /// 􀨘
     /// Single Localization, 3 Layersets
@@ -5423,7 +5423,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ltButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "lt.button.roundedtop.horizontal.fill")
+    static var ltButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "lt.button.roundedtop.horizontal.fill") }
 
     /// 􁺇
     /// Single Localization, 2 Layersets
@@ -5431,7 +5431,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ltCircle = SFSymbol(rawValue: "lt.circle")
+    static var ltCircle: SFSymbol { .init(rawValue: "lt.circle") }
 
     /// 􁺈
     /// Single Localization, 3 Layersets
@@ -5440,7 +5440,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ltCircleFill = SFSymbol(rawValue: "lt.circle.fill")
+    static var ltCircleFill: SFSymbol { .init(rawValue: "lt.circle.fill") }
 
     /// 􁸤
     /// Single Localization, 2 Layersets
@@ -5448,7 +5448,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let m1ButtonHorizontal = SFSymbol(rawValue: "m1.button.horizontal")
+    static var m1ButtonHorizontal: SFSymbol { .init(rawValue: "m1.button.horizontal") }
 
     /// 􁸥
     /// Single Localization, 3 Layersets
@@ -5457,7 +5457,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let m1ButtonHorizontalFill = SFSymbol(rawValue: "m1.button.horizontal.fill")
+    static var m1ButtonHorizontalFill: SFSymbol { .init(rawValue: "m1.button.horizontal.fill") }
 
     /// 􁸦
     /// Single Localization, 2 Layersets
@@ -5465,7 +5465,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let m2ButtonHorizontal = SFSymbol(rawValue: "m2.button.horizontal")
+    static var m2ButtonHorizontal: SFSymbol { .init(rawValue: "m2.button.horizontal") }
 
     /// 􁸧
     /// Single Localization, 3 Layersets
@@ -5474,7 +5474,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let m2ButtonHorizontalFill = SFSymbol(rawValue: "m2.button.horizontal.fill")
+    static var m2ButtonHorizontalFill: SFSymbol { .init(rawValue: "m2.button.horizontal.fill") }
 
     /// 􁸨
     /// Single Localization, 2 Layersets
@@ -5482,7 +5482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let m3ButtonHorizontal = SFSymbol(rawValue: "m3.button.horizontal")
+    static var m3ButtonHorizontal: SFSymbol { .init(rawValue: "m3.button.horizontal") }
 
     /// 􁸩
     /// Single Localization, 3 Layersets
@@ -5491,7 +5491,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let m3ButtonHorizontalFill = SFSymbol(rawValue: "m3.button.horizontal.fill")
+    static var m3ButtonHorizontalFill: SFSymbol { .init(rawValue: "m3.button.horizontal.fill") }
 
     /// 􁸪
     /// Single Localization, 2 Layersets
@@ -5499,7 +5499,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let m4ButtonHorizontal = SFSymbol(rawValue: "m4.button.horizontal")
+    static var m4ButtonHorizontal: SFSymbol { .init(rawValue: "m4.button.horizontal") }
 
     /// 􁸫
     /// Single Localization, 3 Layersets
@@ -5508,7 +5508,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let m4ButtonHorizontalFill = SFSymbol(rawValue: "m4.button.horizontal.fill")
+    static var m4ButtonHorizontalFill: SFSymbol { .init(rawValue: "m4.button.horizontal.fill") }
 
     /// 􁟬
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5518,7 +5518,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbook = SFSymbol(rawValue: "macbook")
+    static var macbook: SFSymbol { .init(rawValue: "macbook") }
 
     /// 􁜙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5533,7 +5533,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "macbookAndVisionPro")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "macbookAndVisionPro")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "macbookAndVisionPro")
-    static let macbookAndVisionpro = SFSymbol(rawValue: "macbook.and.visionpro")
+    static var macbookAndVisionpro: SFSymbol { .init(rawValue: "macbook.and.visionpro") }
 
     /// 􁟫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5543,7 +5543,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookGen1 = SFSymbol(rawValue: "macbook.gen1")
+    static var macbookGen1: SFSymbol { .init(rawValue: "macbook.gen1") }
 
     /// 􁈸
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5553,7 +5553,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookGen2 = SFSymbol(rawValue: "macbook.gen2")
+    static var macbookGen2: SFSymbol { .init(rawValue: "macbook.gen2") }
 
     /// 􁝸
     /// 2 Localizations, 2 Layersets
@@ -5570,7 +5570,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 26.0, renamed: "macwindowAndPointerArrow")
     @available(watchOS, introduced: 10.0, deprecated: 26.0, renamed: "macwindowAndPointerArrow")
     @available(visionOS, introduced: 1.0, deprecated: 26.0, renamed: "macwindowAndPointerArrow")
-    static let macwindowAndCursorarrow = SymbolWith1Localization<Rtl>(rawValue: "macwindow.and.cursorarrow")
+    static var macwindowAndCursorarrow: SymbolWith1Localization<Rtl> { .init(rawValue: "macwindow.and.cursorarrow") }
 
     /// 􂈭
     /// Single Localization, 2 Layersets
@@ -5583,7 +5583,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "manatsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "manatsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "manatsignArrowTriangleheadCounterclockwiseRotate90")
-    static let manatsignArrowCirclepath = SFSymbol(rawValue: "manatsign.arrow.circlepath")
+    static var manatsignArrowCirclepath: SFSymbol { .init(rawValue: "manatsign.arrow.circlepath") }
 
     /// 􁼡
     /// Single Localization, 3 Layersets
@@ -5592,7 +5592,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mappinAndEllipseCircle = SFSymbol(rawValue: "mappin.and.ellipse.circle")
+    static var mappinAndEllipseCircle: SFSymbol { .init(rawValue: "mappin.and.ellipse.circle") }
 
     /// 􁼢
     /// Single Localization, 3 Layersets
@@ -5601,7 +5601,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let mappinAndEllipseCircleFill = SFSymbol(rawValue: "mappin.and.ellipse.circle.fill")
+    static var mappinAndEllipseCircleFill: SFSymbol { .init(rawValue: "mappin.and.ellipse.circle.fill") }
 
     /// 􀼁
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5612,7 +5612,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeWaveform = SFSymbol(rawValue: "message.badge.waveform")
+    static var messageBadgeWaveform: SFSymbol { .init(rawValue: "message.badge.waveform") }
 
     /// 􀼂
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5623,7 +5623,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let messageBadgeWaveformFill = SFSymbol(rawValue: "message.badge.waveform.fill")
+    static var messageBadgeWaveformFill: SFSymbol { .init(rawValue: "message.badge.waveform.fill") }
 
     /// 􂈫
     /// Single Localization, 2 Layersets
@@ -5636,7 +5636,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "millsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "millsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "millsignArrowTriangleheadCounterclockwiseRotate90")
-    static let millsignArrowCirclepath = SFSymbol(rawValue: "millsign.arrow.circlepath")
+    static var millsignArrowCirclepath: SFSymbol { .init(rawValue: "millsign.arrow.circlepath") }
 
     /// 􁶽
     /// Single Localization, 2 Layersets
@@ -5644,7 +5644,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonDust = SFSymbol(rawValue: "moon.dust")
+    static var moonDust: SFSymbol { .init(rawValue: "moon.dust") }
 
     /// 􁶿
     /// Single Localization, 2 Layersets
@@ -5652,7 +5652,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonDustCircle = SFSymbol(rawValue: "moon.dust.circle")
+    static var moonDustCircle: SFSymbol { .init(rawValue: "moon.dust.circle") }
 
     /// 􁷀
     /// Single Localization, 3 Layersets
@@ -5661,7 +5661,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonDustCircleFill = SFSymbol(rawValue: "moon.dust.circle.fill")
+    static var moonDustCircleFill: SFSymbol { .init(rawValue: "moon.dust.circle.fill") }
 
     /// 􁶾
     /// Single Localization, 3 Layersets
@@ -5670,7 +5670,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonDustFill = SFSymbol(rawValue: "moon.dust.fill")
+    static var moonDustFill: SFSymbol { .init(rawValue: "moon.dust.fill") }
 
     /// 􂂳
     /// Single Localization, 2 Layersets
@@ -5678,7 +5678,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonrise = SFSymbol(rawValue: "moonrise")
+    static var moonrise: SFSymbol { .init(rawValue: "moonrise") }
 
     /// 􂂵
     /// Single Localization, 2 Layersets
@@ -5686,7 +5686,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonriseCircle = SFSymbol(rawValue: "moonrise.circle")
+    static var moonriseCircle: SFSymbol { .init(rawValue: "moonrise.circle") }
 
     /// 􂂶
     /// Single Localization, 3 Layersets
@@ -5695,7 +5695,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonriseCircleFill = SFSymbol(rawValue: "moonrise.circle.fill")
+    static var moonriseCircleFill: SFSymbol { .init(rawValue: "moonrise.circle.fill") }
 
     /// 􂂴
     /// Single Localization, 3 Layersets
@@ -5704,7 +5704,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonriseFill = SFSymbol(rawValue: "moonrise.fill")
+    static var moonriseFill: SFSymbol { .init(rawValue: "moonrise.fill") }
 
     /// 􂂷
     /// Single Localization, 2 Layersets
@@ -5712,7 +5712,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonset = SFSymbol(rawValue: "moonset")
+    static var moonset: SFSymbol { .init(rawValue: "moonset") }
 
     /// 􂂹
     /// Single Localization, 2 Layersets
@@ -5720,7 +5720,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonsetCircle = SFSymbol(rawValue: "moonset.circle")
+    static var moonsetCircle: SFSymbol { .init(rawValue: "moonset.circle") }
 
     /// 􂂺
     /// Single Localization, 3 Layersets
@@ -5729,7 +5729,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonsetCircleFill = SFSymbol(rawValue: "moonset.circle.fill")
+    static var moonsetCircleFill: SFSymbol { .init(rawValue: "moonset.circle.fill") }
 
     /// 􂂸
     /// Single Localization, 3 Layersets
@@ -5738,7 +5738,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let moonsetFill = SFSymbol(rawValue: "moonset.fill")
+    static var moonsetFill: SFSymbol { .init(rawValue: "moonset.fill") }
 
     /// 􀜤
     /// Single Localization, 2 Layersets
@@ -5746,7 +5746,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let movieclapper = SFSymbol(rawValue: "movieclapper")
+    static var movieclapper: SFSymbol { .init(rawValue: "movieclapper") }
 
     /// 􁶺
     /// Single Localization, 2 Layersets
@@ -5754,7 +5754,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let movieclapperFill = SFSymbol(rawValue: "movieclapper.fill")
+    static var movieclapperFill: SFSymbol { .init(rawValue: "movieclapper.fill") }
 
     /// 􂈥
     /// Single Localization, 2 Layersets
@@ -5767,7 +5767,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "nairasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "nairasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "nairasignArrowTriangleheadCounterclockwiseRotate90")
-    static let nairasignArrowCirclepath = SFSymbol(rawValue: "nairasign.arrow.circlepath")
+    static var nairasignArrowCirclepath: SFSymbol { .init(rawValue: "nairasign.arrow.circlepath") }
 
     /// 􁣡
     /// Single Localization, 3 Layersets
@@ -5776,14 +5776,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let networkSlash = SFSymbol(rawValue: "network.slash")
+    static var networkSlash: SFSymbol { .init(rawValue: "network.slash") }
 
     /// 􁤬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let norwegiankronesign = SFSymbol(rawValue: "norwegiankronesign")
+    static var norwegiankronesign: SFSymbol { .init(rawValue: "norwegiankronesign") }
 
     /// 􂈵
     /// Single Localization, 2 Layersets
@@ -5796,7 +5796,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "norwegiankronesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "norwegiankronesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "norwegiankronesignArrowTriangleheadCounterclockwiseRotate90")
-    static let norwegiankronesignArrowCirclepath = SFSymbol(rawValue: "norwegiankronesign.arrow.circlepath")
+    static var norwegiankronesignArrowCirclepath: SFSymbol { .init(rawValue: "norwegiankronesign.arrow.circlepath") }
 
     /// 􀮤
     /// Single Localization, 2 Layersets
@@ -5804,7 +5804,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignCircle = SFSymbol(rawValue: "norwegiankronesign.circle")
+    static var norwegiankronesignCircle: SFSymbol { .init(rawValue: "norwegiankronesign.circle") }
 
     /// 􀮥
     /// Single Localization, 3 Layersets
@@ -5813,7 +5813,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let norwegiankronesignCircleFill = SFSymbol(rawValue: "norwegiankronesign.circle.fill")
+    static var norwegiankronesignCircleFill: SFSymbol { .init(rawValue: "norwegiankronesign.circle.fill") }
 
     /// 􀮦
     /// Single Localization, 2 Layersets
@@ -5821,7 +5821,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignSquare = SFSymbol(rawValue: "norwegiankronesign.square")
+    static var norwegiankronesignSquare: SFSymbol { .init(rawValue: "norwegiankronesign.square") }
 
     /// 􀮧
     /// Single Localization, 3 Layersets
@@ -5830,7 +5830,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let norwegiankronesignSquareFill = SFSymbol(rawValue: "norwegiankronesign.square.fill")
+    static var norwegiankronesignSquareFill: SFSymbol { .init(rawValue: "norwegiankronesign.square.fill") }
 
     /// 􁢙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -5840,7 +5840,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Optic ID feature.
-    static let opticid = SFSymbol(rawValue: "opticid")
+    static var opticid: SFSymbol { .init(rawValue: "opticid") }
 
     /// 􁣂
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -5851,7 +5851,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Optic ID feature.
-    static let opticidFill = SFSymbol(rawValue: "opticid.fill")
+    static var opticidFill: SFSymbol { .init(rawValue: "opticid.fill") }
 
     /// 􁸬
     /// Single Localization, 2 Layersets
@@ -5859,7 +5859,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let p1ButtonHorizontal = SFSymbol(rawValue: "p1.button.horizontal")
+    static var p1ButtonHorizontal: SFSymbol { .init(rawValue: "p1.button.horizontal") }
 
     /// 􁸭
     /// Single Localization, 3 Layersets
@@ -5868,7 +5868,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let p1ButtonHorizontalFill = SFSymbol(rawValue: "p1.button.horizontal.fill")
+    static var p1ButtonHorizontalFill: SFSymbol { .init(rawValue: "p1.button.horizontal.fill") }
 
     /// 􁸮
     /// Single Localization, 2 Layersets
@@ -5876,7 +5876,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let p2ButtonHorizontal = SFSymbol(rawValue: "p2.button.horizontal")
+    static var p2ButtonHorizontal: SFSymbol { .init(rawValue: "p2.button.horizontal") }
 
     /// 􁸯
     /// Single Localization, 3 Layersets
@@ -5885,7 +5885,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let p2ButtonHorizontalFill = SFSymbol(rawValue: "p2.button.horizontal.fill")
+    static var p2ButtonHorizontalFill: SFSymbol { .init(rawValue: "p2.button.horizontal.fill") }
 
     /// 􁸰
     /// Single Localization, 2 Layersets
@@ -5893,7 +5893,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let p3ButtonHorizontal = SFSymbol(rawValue: "p3.button.horizontal")
+    static var p3ButtonHorizontal: SFSymbol { .init(rawValue: "p3.button.horizontal") }
 
     /// 􁸱
     /// Single Localization, 3 Layersets
@@ -5902,7 +5902,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let p3ButtonHorizontalFill = SFSymbol(rawValue: "p3.button.horizontal.fill")
+    static var p3ButtonHorizontalFill: SFSymbol { .init(rawValue: "p3.button.horizontal.fill") }
 
     /// 􁸲
     /// Single Localization, 2 Layersets
@@ -5910,7 +5910,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let p4ButtonHorizontal = SFSymbol(rawValue: "p4.button.horizontal")
+    static var p4ButtonHorizontal: SFSymbol { .init(rawValue: "p4.button.horizontal") }
 
     /// 􁸳
     /// Single Localization, 3 Layersets
@@ -5919,35 +5919,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let p4ButtonHorizontalFill = SFSymbol(rawValue: "p4.button.horizontal.fill")
+    static var p4ButtonHorizontalFill: SFSymbol { .init(rawValue: "p4.button.horizontal.fill") }
 
     /// 􁸴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paddleshifterLeft = SFSymbol(rawValue: "paddleshifter.left")
+    static var paddleshifterLeft: SFSymbol { .init(rawValue: "paddleshifter.left") }
 
     /// 􁸵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paddleshifterLeftFill = SFSymbol(rawValue: "paddleshifter.left.fill")
+    static var paddleshifterLeftFill: SFSymbol { .init(rawValue: "paddleshifter.left.fill") }
 
     /// 􁸶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paddleshifterRight = SFSymbol(rawValue: "paddleshifter.right")
+    static var paddleshifterRight: SFSymbol { .init(rawValue: "paddleshifter.right") }
 
     /// 􁸷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paddleshifterRightFill = SFSymbol(rawValue: "paddleshifter.right.fill")
+    static var paddleshifterRightFill: SFSymbol { .init(rawValue: "paddleshifter.right.fill") }
 
     /// 􁷿
     /// Single Localization, 3 Layersets
@@ -5956,7 +5956,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let panoBadgePlay = SFSymbol(rawValue: "pano.badge.play")
+    static var panoBadgePlay: SFSymbol { .init(rawValue: "pano.badge.play") }
 
     /// 􁸀
     /// Single Localization, 3 Layersets
@@ -5965,7 +5965,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let panoBadgePlayFill = SFSymbol(rawValue: "pano.badge.play.fill")
+    static var panoBadgePlayFill: SFSymbol { .init(rawValue: "pano.badge.play.fill") }
 
     /// 􁖲
     /// Single Localization, 2 Layersets
@@ -5973,7 +5973,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignRadiowavesLeftAndRight = SFSymbol(rawValue: "parkingsign.radiowaves.left.and.right")
+    static var parkingsignRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "parkingsign.radiowaves.left.and.right") }
 
     /// 􁥨
     /// Single Localization, 2 Layersets
@@ -5981,14 +5981,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignRadiowavesRightAndSafetycone = SFSymbol(rawValue: "parkingsign.radiowaves.right.and.safetycone")
+    static var parkingsignRadiowavesRightAndSafetycone: SFSymbol { .init(rawValue: "parkingsign.radiowaves.right.and.safetycone") }
 
     /// 􁉨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let parkingsignSteeringwheel = SFSymbol(rawValue: "parkingsign.steeringwheel")
+    static var parkingsignSteeringwheel: SFSymbol { .init(rawValue: "parkingsign.steeringwheel") }
 
     /// 􁸗
     /// Single Localization, 2 Layersets
@@ -5996,7 +5996,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalAccelerator = SFSymbol(rawValue: "pedal.accelerator")
+    static var pedalAccelerator: SFSymbol { .init(rawValue: "pedal.accelerator") }
 
     /// 􁸘
     /// Single Localization, 2 Layersets
@@ -6004,7 +6004,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalAcceleratorFill = SFSymbol(rawValue: "pedal.accelerator.fill")
+    static var pedalAcceleratorFill: SFSymbol { .init(rawValue: "pedal.accelerator.fill") }
 
     /// 􁸙
     /// Single Localization, 2 Layersets
@@ -6012,7 +6012,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalBrake = SFSymbol(rawValue: "pedal.brake")
+    static var pedalBrake: SFSymbol { .init(rawValue: "pedal.brake") }
 
     /// 􁸚
     /// Single Localization, 2 Layersets
@@ -6020,7 +6020,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalBrakeFill = SFSymbol(rawValue: "pedal.brake.fill")
+    static var pedalBrakeFill: SFSymbol { .init(rawValue: "pedal.brake.fill") }
 
     /// 􁸛
     /// Single Localization, 2 Layersets
@@ -6028,7 +6028,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalClutch = SFSymbol(rawValue: "pedal.clutch")
+    static var pedalClutch: SFSymbol { .init(rawValue: "pedal.clutch") }
 
     /// 􁸜
     /// Single Localization, 2 Layersets
@@ -6036,7 +6036,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pedalClutchFill = SFSymbol(rawValue: "pedal.clutch.fill")
+    static var pedalClutchFill: SFSymbol { .init(rawValue: "pedal.clutch.fill") }
 
     /// 􁕍
     /// 2 Localizations, 3 Layersets
@@ -6049,7 +6049,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pencilAndListClipboard = SymbolWith1Localization<Rtl>(rawValue: "pencil.and.list.clipboard")
+    static var pencilAndListClipboard: SymbolWith1Localization<Rtl> { .init(rawValue: "pencil.and.list.clipboard") }
 
     /// 􀤒
     /// Single Localization, 2 Layersets
@@ -6057,7 +6057,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pencilAndScribble = SFSymbol(rawValue: "pencil.and.scribble")
+    static var pencilAndScribble: SFSymbol { .init(rawValue: "pencil.and.scribble") }
 
     /// 􁿵
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6068,7 +6068,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgeArrowForwardFill = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.arrow.forward.fill")
+    static var pencilTipCropCircleBadgeArrowForwardFill: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.arrow.forward.fill") }
 
     /// 􁿳
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6079,7 +6079,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgeMinusFill = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.minus.fill")
+    static var pencilTipCropCircleBadgeMinusFill: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.minus.fill") }
 
     /// 􁾝
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6090,7 +6090,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleBadgePlusFill = SFSymbol(rawValue: "pencil.tip.crop.circle.badge.plus.fill")
+    static var pencilTipCropCircleBadgePlusFill: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.badge.plus.fill") }
 
     /// 􁾛
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6101,7 +6101,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 17.1, macOS 14.1, tvOS 17.1, watchOS 10.1)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Markup feature.
-    static let pencilTipCropCircleFill = SFSymbol(rawValue: "pencil.tip.crop.circle.fill")
+    static var pencilTipCropCircleFill: SFSymbol { .init(rawValue: "pencil.tip.crop.circle.fill") }
 
     /// 􁷩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6111,7 +6111,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to sharing or using a shared password or passkey.
-    static let person2BadgeKey = SFSymbol(rawValue: "person.2.badge.key")
+    static var person2BadgeKey: SFSymbol { .init(rawValue: "person.2.badge.key") }
 
     /// 􁷫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6121,7 +6121,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to sharing or using a shared password or passkey.
-    static let person2BadgeKeyFill = SFSymbol(rawValue: "person.2.badge.key.fill")
+    static var person2BadgeKeyFill: SFSymbol { .init(rawValue: "person.2.badge.key.fill") }
 
     /// 􁠃
     /// Single Localization, 2 Layersets
@@ -6129,7 +6129,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personAndBackgroundStripedHorizontal = SFSymbol(rawValue: "person.and.background.striped.horizontal")
+    static var personAndBackgroundStripedHorizontal: SFSymbol { .init(rawValue: "person.and.background.striped.horizontal") }
 
     /// 􂄽
     /// Single Localization, 2 Layersets
@@ -6137,7 +6137,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personBubble = SFSymbol(rawValue: "person.bubble")
+    static var personBubble: SFSymbol { .init(rawValue: "person.bubble") }
 
     /// 􂄾
     /// Single Localization, 3 Layersets
@@ -6146,7 +6146,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let personBubbleFill = SFSymbol(rawValue: "person.bubble.fill")
+    static var personBubbleFill: SFSymbol { .init(rawValue: "person.bubble.fill") }
 
     /// 􁽓
     /// Single Localization, 2 Layersets
@@ -6154,7 +6154,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personBustCircle = SFSymbol(rawValue: "person.bust.circle")
+    static var personBustCircle: SFSymbol { .init(rawValue: "person.bust.circle") }
 
     /// 􁽔
     /// Single Localization, 3 Layersets
@@ -6163,7 +6163,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personBustCircleFill = SFSymbol(rawValue: "person.bust.circle.fill")
+    static var personBustCircleFill: SFSymbol { .init(rawValue: "person.bust.circle.fill") }
 
     /// 􂅪
     /// Single Localization, 2 Layersets
@@ -6171,7 +6171,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropCircleDashedCircle = SFSymbol(rawValue: "person.crop.circle.dashed.circle")
+    static var personCropCircleDashedCircle: SFSymbol { .init(rawValue: "person.crop.circle.dashed.circle") }
 
     /// 􂃿
     /// Single Localization, 3 Layersets
@@ -6180,7 +6180,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropCircleDashedCircleFill = SFSymbol(rawValue: "person.crop.circle.dashed.circle.fill")
+    static var personCropCircleDashedCircleFill: SFSymbol { .init(rawValue: "person.crop.circle.dashed.circle.fill") }
 
     /// 􁣔
     /// Single Localization, 2 Layersets
@@ -6188,7 +6188,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personSlash = SFSymbol(rawValue: "person.slash")
+    static var personSlash: SFSymbol { .init(rawValue: "person.slash") }
 
     /// 􁣕
     /// Single Localization, 2 Layersets
@@ -6196,7 +6196,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personSlashFill = SFSymbol(rawValue: "person.slash.fill")
+    static var personSlashFill: SFSymbol { .init(rawValue: "person.slash.fill") }
 
     /// 􂈞
     /// Single Localization, 2 Layersets
@@ -6209,7 +6209,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "pesetasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "pesetasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "pesetasignArrowTriangleheadCounterclockwiseRotate90")
-    static let pesetasignArrowCirclepath = SFSymbol(rawValue: "pesetasign.arrow.circlepath")
+    static var pesetasignArrowCirclepath: SFSymbol { .init(rawValue: "pesetasign.arrow.circlepath") }
 
     /// 􂈟
     /// Single Localization, 2 Layersets
@@ -6222,7 +6222,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "pesosignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "pesosignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "pesosignArrowTriangleheadCounterclockwiseRotate90")
-    static let pesosignArrowCirclepath = SFSymbol(rawValue: "pesosign.arrow.circlepath")
+    static var pesosignArrowCirclepath: SFSymbol { .init(rawValue: "pesosign.arrow.circlepath") }
 
     /// 􀼃
     /// Single Localization, 3 Layersets
@@ -6231,7 +6231,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBadgeWaveform = SFSymbol(rawValue: "phone.badge.waveform")
+    static var phoneBadgeWaveform: SFSymbol { .init(rawValue: "phone.badge.waveform") }
 
     /// 􀼄
     /// Single Localization, 3 Layersets
@@ -6240,7 +6240,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBadgeWaveformFill = SFSymbol(rawValue: "phone.badge.waveform.fill")
+    static var phoneBadgeWaveformFill: SFSymbol { .init(rawValue: "phone.badge.waveform.fill") }
 
     /// 􀱮
     /// 2 Localizations, 2 Layersets
@@ -6252,7 +6252,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phoneBubble = SymbolWith1Localization<Rtl>(rawValue: "phone.bubble")
+    static var phoneBubble: SymbolWith1Localization<Rtl> { .init(rawValue: "phone.bubble") }
 
     /// 􀱯
     /// 2 Localizations, 3 Layersets
@@ -6265,7 +6265,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBubbleFill = SymbolWith1Localization<Rtl>(rawValue: "phone.bubble.fill")
+    static var phoneBubbleFill: SymbolWith1Localization<Rtl> { .init(rawValue: "phone.bubble.fill") }
 
     /// 􁼧
     /// Single Localization, 2 Layersets
@@ -6273,7 +6273,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoArtframeCircle = SFSymbol(rawValue: "photo.artframe.circle")
+    static var photoArtframeCircle: SFSymbol { .init(rawValue: "photo.artframe.circle") }
 
     /// 􁼨
     /// Single Localization, 3 Layersets
@@ -6282,7 +6282,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoArtframeCircleFill = SFSymbol(rawValue: "photo.artframe.circle.fill")
+    static var photoArtframeCircleFill: SFSymbol { .init(rawValue: "photo.artframe.circle.fill") }
 
     /// 􁃲
     /// Single Localization, 3 Layersets
@@ -6291,7 +6291,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeArrowDown = SFSymbol(rawValue: "photo.badge.arrow.down")
+    static var photoBadgeArrowDown: SFSymbol { .init(rawValue: "photo.badge.arrow.down") }
 
     /// 􁃳
     /// Single Localization, 3 Layersets
@@ -6300,7 +6300,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeArrowDownFill = SFSymbol(rawValue: "photo.badge.arrow.down.fill")
+    static var photoBadgeArrowDownFill: SFSymbol { .init(rawValue: "photo.badge.arrow.down.fill") }
 
     /// 􁘹
     /// Single Localization, 3 Layersets
@@ -6309,7 +6309,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeCheckmark = SFSymbol(rawValue: "photo.badge.checkmark")
+    static var photoBadgeCheckmark: SFSymbol { .init(rawValue: "photo.badge.checkmark") }
 
     /// 􁘺
     /// Single Localization, 3 Layersets
@@ -6318,7 +6318,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeCheckmarkFill = SFSymbol(rawValue: "photo.badge.checkmark.fill")
+    static var photoBadgeCheckmarkFill: SFSymbol { .init(rawValue: "photo.badge.checkmark.fill") }
 
     /// 􁃏
     /// Single Localization, 3 Layersets
@@ -6327,7 +6327,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgePlus = SFSymbol(rawValue: "photo.badge.plus")
+    static var photoBadgePlus: SFSymbol { .init(rawValue: "photo.badge.plus") }
 
     /// 􁃐
     /// Single Localization, 3 Layersets
@@ -6336,7 +6336,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgePlusFill = SFSymbol(rawValue: "photo.badge.plus.fill")
+    static var photoBadgePlusFill: SFSymbol { .init(rawValue: "photo.badge.plus.fill") }
 
     /// 􁹙
     /// Single Localization, 2 Layersets
@@ -6344,7 +6344,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playHouse = SFSymbol(rawValue: "play.house")
+    static var playHouse: SFSymbol { .init(rawValue: "play.house") }
 
     /// 􁹚
     /// Single Localization, 3 Layersets
@@ -6353,7 +6353,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let playHouseFill = SFSymbol(rawValue: "play.house.fill")
+    static var playHouseFill: SFSymbol { .init(rawValue: "play.house.fill") }
 
     /// 􁻶
     /// Single Localization, 2 Layersets
@@ -6361,7 +6361,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftFilledForwardToPointToprightScurvepath = SFSymbol(rawValue: "point.bottomleft.filled.forward.to.point.topright.scurvepath")
+    static var pointBottomleftFilledForwardToPointToprightScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.filled.forward.to.point.topright.scurvepath") }
 
     /// 􁻷
     /// Single Localization, 2 Layersets
@@ -6374,7 +6374,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepath")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepath")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepath")
-    static let pointBottomleftForwardToArrowtriangleUturnScurvepath = SFSymbol(rawValue: "point.bottomleft.forward.to.arrowtriangle.uturn.scurvepath")
+    static var pointBottomleftForwardToArrowtriangleUturnScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrowtriangle.uturn.scurvepath") }
 
     /// 􁸹
     /// Single Localization, 2 Layersets
@@ -6387,7 +6387,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepathFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepathFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "pointBottomleftForwardToArrowTriangleUturnScurvepathFill")
-    static let pointBottomleftForwardToArrowtriangleUturnScurvepathFill = SFSymbol(rawValue: "point.bottomleft.forward.to.arrowtriangle.uturn.scurvepath.fill")
+    static var pointBottomleftForwardToArrowtriangleUturnScurvepathFill: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrowtriangle.uturn.scurvepath.fill") }
 
     /// 􁻵
     /// Single Localization, 2 Layersets
@@ -6395,7 +6395,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToPointToprightFilledScurvepath = SFSymbol(rawValue: "point.bottomleft.forward.to.point.topright.filled.scurvepath")
+    static var pointBottomleftForwardToPointToprightFilledScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.point.topright.filled.scurvepath") }
 
     /// 􁻴
     /// Single Localization, 2 Layersets
@@ -6403,7 +6403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToPointToprightScurvepath = SFSymbol(rawValue: "point.bottomleft.forward.to.point.topright.scurvepath")
+    static var pointBottomleftForwardToPointToprightScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.point.topright.scurvepath") }
 
     /// 􁸸
     /// Single Localization, 2 Layersets
@@ -6411,7 +6411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToPointToprightScurvepathFill = SFSymbol(rawValue: "point.bottomleft.forward.to.point.topright.scurvepath.fill")
+    static var pointBottomleftForwardToPointToprightScurvepathFill: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.point.topright.scurvepath.fill") }
 
     /// 􁻸
     /// Single Localization, 2 Layersets
@@ -6419,7 +6419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointForwardToPointCapsulepath = SFSymbol(rawValue: "point.forward.to.point.capsulepath")
+    static var pointForwardToPointCapsulepath: SFSymbol { .init(rawValue: "point.forward.to.point.capsulepath") }
 
     /// 􁸺
     /// Single Localization, 2 Layersets
@@ -6427,7 +6427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointForwardToPointCapsulepathFill = SFSymbol(rawValue: "point.forward.to.point.capsulepath.fill")
+    static var pointForwardToPointCapsulepathFill: SFSymbol { .init(rawValue: "point.forward.to.point.capsulepath.fill") }
 
     /// 􀣱
     /// Single Localization, 3 Layersets
@@ -6436,7 +6436,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointTopleftDownToPointBottomrightCurvepath = SFSymbol(rawValue: "point.topleft.down.to.point.bottomright.curvepath")
+    static var pointTopleftDownToPointBottomrightCurvepath: SFSymbol { .init(rawValue: "point.topleft.down.to.point.bottomright.curvepath") }
 
     /// 􀬱
     /// Single Localization, 3 Layersets
@@ -6445,7 +6445,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointTopleftDownToPointBottomrightCurvepathFill = SFSymbol(rawValue: "point.topleft.down.to.point.bottomright.curvepath.fill")
+    static var pointTopleftDownToPointBottomrightCurvepathFill: SFSymbol { .init(rawValue: "point.topleft.down.to.point.bottomright.curvepath.fill") }
 
     /// 􀾔
     /// Single Localization, 3 Layersets
@@ -6454,7 +6454,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointTopleftDownToPointBottomrightFilledCurvepath = SFSymbol(rawValue: "point.topleft.down.to.point.bottomright.filled.curvepath")
+    static var pointTopleftDownToPointBottomrightFilledCurvepath: SFSymbol { .init(rawValue: "point.topleft.down.to.point.bottomright.filled.curvepath") }
 
     /// 􀾕
     /// Single Localization, 3 Layersets
@@ -6463,14 +6463,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointTopleftFilledDownToPointBottomrightCurvepath = SFSymbol(rawValue: "point.topleft.filled.down.to.point.bottomright.curvepath")
+    static var pointTopleftFilledDownToPointBottomrightCurvepath: SFSymbol { .init(rawValue: "point.topleft.filled.down.to.point.bottomright.curvepath") }
 
     /// 􁤯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let polishzlotysign = SFSymbol(rawValue: "polishzlotysign")
+    static var polishzlotysign: SFSymbol { .init(rawValue: "polishzlotysign") }
 
     /// 􂈴
     /// Single Localization, 2 Layersets
@@ -6483,7 +6483,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "polishzlotysignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "polishzlotysignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "polishzlotysignArrowTriangleheadCounterclockwiseRotate90")
-    static let polishzlotysignArrowCirclepath = SFSymbol(rawValue: "polishzlotysign.arrow.circlepath")
+    static var polishzlotysignArrowCirclepath: SFSymbol { .init(rawValue: "polishzlotysign.arrow.circlepath") }
 
     /// 􁤰
     /// Single Localization, 2 Layersets
@@ -6491,7 +6491,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignCircle = SFSymbol(rawValue: "polishzlotysign.circle")
+    static var polishzlotysignCircle: SFSymbol { .init(rawValue: "polishzlotysign.circle") }
 
     /// 􁤱
     /// Single Localization, 3 Layersets
@@ -6500,7 +6500,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let polishzlotysignCircleFill = SFSymbol(rawValue: "polishzlotysign.circle.fill")
+    static var polishzlotysignCircleFill: SFSymbol { .init(rawValue: "polishzlotysign.circle.fill") }
 
     /// 􁤲
     /// Single Localization, 2 Layersets
@@ -6508,7 +6508,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignSquare = SFSymbol(rawValue: "polishzlotysign.square")
+    static var polishzlotysignSquare: SFSymbol { .init(rawValue: "polishzlotysign.square") }
 
     /// 􁤳
     /// Single Localization, 3 Layersets
@@ -6517,21 +6517,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let polishzlotysignSquareFill = SFSymbol(rawValue: "polishzlotysign.square.fill")
+    static var polishzlotysignSquareFill: SFSymbol { .init(rawValue: "polishzlotysign.square.fill") }
 
     /// 􁣷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powercord = SFSymbol(rawValue: "powercord")
+    static var powercord: SFSymbol { .init(rawValue: "powercord") }
 
     /// 􁣸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powercordFill = SFSymbol(rawValue: "powercord.fill")
+    static var powercordFill: SFSymbol { .init(rawValue: "powercord.fill") }
 
     /// 􀨍
     /// Single Localization, 2 Layersets
@@ -6539,7 +6539,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rButtonRoundedbottomHorizontal = SFSymbol(rawValue: "r.button.roundedbottom.horizontal")
+    static var rButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "r.button.roundedbottom.horizontal") }
 
     /// 􀨎
     /// Single Localization, 3 Layersets
@@ -6548,7 +6548,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "r.button.roundedbottom.horizontal.fill")
+    static var rButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "r.button.roundedbottom.horizontal.fill") }
 
     /// 􀨏
     /// Single Localization, 2 Layersets
@@ -6556,7 +6556,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r1ButtonRoundedbottomHorizontal = SFSymbol(rawValue: "r1.button.roundedbottom.horizontal")
+    static var r1ButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "r1.button.roundedbottom.horizontal") }
 
     /// 􀨐
     /// Single Localization, 3 Layersets
@@ -6565,7 +6565,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r1ButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "r1.button.roundedbottom.horizontal.fill")
+    static var r1ButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "r1.button.roundedbottom.horizontal.fill") }
 
     /// 􁺉
     /// Single Localization, 2 Layersets
@@ -6573,7 +6573,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r1Circle = SFSymbol(rawValue: "r1.circle")
+    static var r1Circle: SFSymbol { .init(rawValue: "r1.circle") }
 
     /// 􁺊
     /// Single Localization, 3 Layersets
@@ -6582,7 +6582,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r1CircleFill = SFSymbol(rawValue: "r1.circle.fill")
+    static var r1CircleFill: SFSymbol { .init(rawValue: "r1.circle.fill") }
 
     /// 􁷵
     /// Single Localization, 2 Layersets
@@ -6590,7 +6590,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r2ButtonAngledtopVerticalRight = SFSymbol(rawValue: "r2.button.angledtop.vertical.right")
+    static var r2ButtonAngledtopVerticalRight: SFSymbol { .init(rawValue: "r2.button.angledtop.vertical.right") }
 
     /// 􁷶
     /// Single Localization, 3 Layersets
@@ -6599,7 +6599,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r2ButtonAngledtopVerticalRightFill = SFSymbol(rawValue: "r2.button.angledtop.vertical.right.fill")
+    static var r2ButtonAngledtopVerticalRightFill: SFSymbol { .init(rawValue: "r2.button.angledtop.vertical.right.fill") }
 
     /// 􀨑
     /// Single Localization, 2 Layersets
@@ -6607,7 +6607,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r2ButtonRoundedtopHorizontal = SFSymbol(rawValue: "r2.button.roundedtop.horizontal")
+    static var r2ButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "r2.button.roundedtop.horizontal") }
 
     /// 􀨒
     /// Single Localization, 3 Layersets
@@ -6616,7 +6616,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r2ButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "r2.button.roundedtop.horizontal.fill")
+    static var r2ButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "r2.button.roundedtop.horizontal.fill") }
 
     /// 􁺍
     /// Single Localization, 2 Layersets
@@ -6624,7 +6624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r2Circle = SFSymbol(rawValue: "r2.circle")
+    static var r2Circle: SFSymbol { .init(rawValue: "r2.circle") }
 
     /// 􁺎
     /// Single Localization, 3 Layersets
@@ -6633,7 +6633,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r2CircleFill = SFSymbol(rawValue: "r2.circle.fill")
+    static var r2CircleFill: SFSymbol { .init(rawValue: "r2.circle.fill") }
 
     /// 􁸉
     /// Single Localization, 2 Layersets
@@ -6641,7 +6641,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r3ButtonAngledbottomHorizontalRight = SFSymbol(rawValue: "r3.button.angledbottom.horizontal.right")
+    static var r3ButtonAngledbottomHorizontalRight: SFSymbol { .init(rawValue: "r3.button.angledbottom.horizontal.right") }
 
     /// 􁸊
     /// Single Localization, 3 Layersets
@@ -6650,7 +6650,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r3ButtonAngledbottomHorizontalRightFill = SFSymbol(rawValue: "r3.button.angledbottom.horizontal.right.fill")
+    static var r3ButtonAngledbottomHorizontalRightFill: SFSymbol { .init(rawValue: "r3.button.angledbottom.horizontal.right.fill") }
 
     /// 􁺤
     /// Single Localization, 2 Layersets
@@ -6658,7 +6658,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let r4ButtonHorizontal = SFSymbol(rawValue: "r4.button.horizontal")
+    static var r4ButtonHorizontal: SFSymbol { .init(rawValue: "r4.button.horizontal") }
 
     /// 􁺥
     /// Single Localization, 3 Layersets
@@ -6667,7 +6667,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let r4ButtonHorizontalFill = SFSymbol(rawValue: "r4.button.horizontal.fill")
+    static var r4ButtonHorizontalFill: SFSymbol { .init(rawValue: "r4.button.horizontal.fill") }
 
     /// 􀼭
     /// Single Localization, 2 Layersets
@@ -6675,7 +6675,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let rainbow = SFSymbol(rawValue: "rainbow")
+    static var rainbow: SFSymbol { .init(rawValue: "rainbow") }
 
     /// 􀨕
     /// Single Localization, 2 Layersets
@@ -6683,7 +6683,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rbButtonRoundedbottomHorizontal = SFSymbol(rawValue: "rb.button.roundedbottom.horizontal")
+    static var rbButtonRoundedbottomHorizontal: SFSymbol { .init(rawValue: "rb.button.roundedbottom.horizontal") }
 
     /// 􀨖
     /// Single Localization, 3 Layersets
@@ -6692,7 +6692,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rbButtonRoundedbottomHorizontalFill = SFSymbol(rawValue: "rb.button.roundedbottom.horizontal.fill")
+    static var rbButtonRoundedbottomHorizontalFill: SFSymbol { .init(rawValue: "rb.button.roundedbottom.horizontal.fill") }
 
     /// 􁺋
     /// Single Localization, 2 Layersets
@@ -6700,7 +6700,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rbCircle = SFSymbol(rawValue: "rb.circle")
+    static var rbCircle: SFSymbol { .init(rawValue: "rb.circle") }
 
     /// 􁺌
     /// Single Localization, 3 Layersets
@@ -6709,7 +6709,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rbCircleFill = SFSymbol(rawValue: "rb.circle.fill")
+    static var rbCircleFill: SFSymbol { .init(rawValue: "rb.circle.fill") }
 
     /// 􀬄
     /// Single Localization, 2 Layersets
@@ -6717,7 +6717,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangle3GroupBubble = SFSymbol(rawValue: "rectangle.3.group.bubble")
+    static var rectangle3GroupBubble: SFSymbol { .init(rawValue: "rectangle.3.group.bubble") }
 
     /// 􀬅
     /// Single Localization, 3 Layersets
@@ -6726,7 +6726,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectangle3GroupBubbleFill = SFSymbol(rawValue: "rectangle.3.group.bubble.fill")
+    static var rectangle3GroupBubbleFill: SFSymbol { .init(rawValue: "rectangle.3.group.bubble.fill") }
 
     /// 􀪫
     /// Single Localization, Single Layerset
@@ -6738,7 +6738,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "rectanglePatternCheckered")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "rectanglePatternCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "rectanglePatternCheckered")
-    static let rectangleCheckered = SFSymbol(rawValue: "rectangle.checkered")
+    static var rectangleCheckered: SFSymbol { .init(rawValue: "rectangle.checkered") }
 
     /// 􂇕
     /// Single Localization, Single Layerset
@@ -6750,7 +6750,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "insetFilledRectangleAndCursorarrow")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "insetFilledRectangleAndCursorarrow")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectangleAndCursorarrow")
-    static let rectangleInsetFilledAndCursorarrow = SFSymbol(rawValue: "rectangle.inset.filled.and.cursorarrow")
+    static var rectangleInsetFilledAndCursorarrow: SFSymbol { .init(rawValue: "rectangle.inset.filled.and.cursorarrow") }
 
     /// 􂃕
     /// Single Localization, 2 Layersets
@@ -6763,7 +6763,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "insetFilledRectangleBadgeRecord")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "insetFilledRectangleBadgeRecord")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "insetFilledRectangleBadgeRecord")
-    static let rectangleInsetFilledBadgeRecord = SFSymbol(rawValue: "rectangle.inset.filled.badge.record")
+    static var rectangleInsetFilledBadgeRecord: SFSymbol { .init(rawValue: "rectangle.inset.filled.badge.record") }
 
     /// 􁻯
     /// Single Localization, 2 Layersets
@@ -6771,7 +6771,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleLandscapeRotate = SFSymbol(rawValue: "rectangle.landscape.rotate")
+    static var rectangleLandscapeRotate: SFSymbol { .init(rawValue: "rectangle.landscape.rotate") }
 
     /// 􂇓
     /// Single Localization, 2 Layersets
@@ -6779,7 +6779,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleBadgeGearshape = SFSymbol(rawValue: "rectangle.on.rectangle.badge.gearshape")
+    static var rectangleOnRectangleBadgeGearshape: SFSymbol { .init(rawValue: "rectangle.on.rectangle.badge.gearshape") }
 
     /// 􁷷
     /// Single Localization, 2 Layersets
@@ -6787,7 +6787,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleButtonAngledtopVerticalLeft = SFSymbol(rawValue: "rectangle.on.rectangle.button.angledtop.vertical.left")
+    static var rectangleOnRectangleButtonAngledtopVerticalLeft: SFSymbol { .init(rawValue: "rectangle.on.rectangle.button.angledtop.vertical.left") }
 
     /// 􁷸
     /// Single Localization, 3 Layersets
@@ -6796,7 +6796,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectangleOnRectangleButtonAngledtopVerticalLeftFill = SFSymbol(rawValue: "rectangle.on.rectangle.button.angledtop.vertical.left.fill")
+    static var rectangleOnRectangleButtonAngledtopVerticalLeftFill: SFSymbol { .init(rawValue: "rectangle.on.rectangle.button.angledtop.vertical.left.fill") }
 
     /// 􁥋
     /// Single Localization, 3 Layersets
@@ -6805,7 +6805,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectanglePortraitBadgePlus = SFSymbol(rawValue: "rectangle.portrait.badge.plus")
+    static var rectanglePortraitBadgePlus: SFSymbol { .init(rawValue: "rectangle.portrait.badge.plus") }
 
     /// 􁥌
     /// Single Localization, 3 Layersets
@@ -6814,7 +6814,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rectanglePortraitBadgePlusFill = SFSymbol(rawValue: "rectangle.portrait.badge.plus.fill")
+    static var rectanglePortraitBadgePlusFill: SFSymbol { .init(rawValue: "rectangle.portrait.badge.plus.fill") }
 
     /// 􁻮
     /// Single Localization, 2 Layersets
@@ -6822,63 +6822,63 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitRotate = SFSymbol(rawValue: "rectangle.portrait.rotate")
+    static var rectanglePortraitRotate: SFSymbol { .init(rawValue: "rectangle.portrait.rotate") }
 
     /// 􁽸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio3To4 = SFSymbol(rawValue: "rectangle.ratio.3.to.4")
+    static var rectangleRatio3To4: SFSymbol { .init(rawValue: "rectangle.ratio.3.to.4") }
 
     /// 􁽹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio3To4Fill = SFSymbol(rawValue: "rectangle.ratio.3.to.4.fill")
+    static var rectangleRatio3To4Fill: SFSymbol { .init(rawValue: "rectangle.ratio.3.to.4.fill") }
 
     /// 􁽺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio4To3 = SFSymbol(rawValue: "rectangle.ratio.4.to.3")
+    static var rectangleRatio4To3: SFSymbol { .init(rawValue: "rectangle.ratio.4.to.3") }
 
     /// 􁽻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio4To3Fill = SFSymbol(rawValue: "rectangle.ratio.4.to.3.fill")
+    static var rectangleRatio4To3Fill: SFSymbol { .init(rawValue: "rectangle.ratio.4.to.3.fill") }
 
     /// 􁽼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio9To16 = SFSymbol(rawValue: "rectangle.ratio.9.to.16")
+    static var rectangleRatio9To16: SFSymbol { .init(rawValue: "rectangle.ratio.9.to.16") }
 
     /// 􁽽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio9To16Fill = SFSymbol(rawValue: "rectangle.ratio.9.to.16.fill")
+    static var rectangleRatio9To16Fill: SFSymbol { .init(rawValue: "rectangle.ratio.9.to.16.fill") }
 
     /// 􁽾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio16To9 = SFSymbol(rawValue: "rectangle.ratio.16.to.9")
+    static var rectangleRatio16To9: SFSymbol { .init(rawValue: "rectangle.ratio.16.to.9") }
 
     /// 􁽿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleRatio16To9Fill = SFSymbol(rawValue: "rectangle.ratio.16.to.9.fill")
+    static var rectangleRatio16To9Fill: SFSymbol { .init(rawValue: "rectangle.ratio.16.to.9.fill") }
 
     /// 􁟈
     /// Single Localization, 2 Layersets
@@ -6886,7 +6886,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let retarderBrakesignalAndExclamationmark = SFSymbol(rawValue: "retarder.brakesignal.and.exclamationmark")
+    static var retarderBrakesignalAndExclamationmark: SFSymbol { .init(rawValue: "retarder.brakesignal.and.exclamationmark") }
 
     /// 􁟋
     /// Single Localization, 2 Layersets
@@ -6894,14 +6894,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let retarderBrakesignalSlash = SFSymbol(rawValue: "retarder.brakesignal.slash")
+    static var retarderBrakesignalSlash: SFSymbol { .init(rawValue: "retarder.brakesignal.slash") }
 
     /// 􁣦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let right = SFSymbol(rawValue: "right")
+    static var right: SFSymbol { .init(rawValue: "right") }
 
     /// 􁣧
     /// Single Localization, 2 Layersets
@@ -6909,7 +6909,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rightCircle = SFSymbol(rawValue: "right.circle")
+    static var rightCircle: SFSymbol { .init(rawValue: "right.circle") }
 
     /// 􁣨
     /// Single Localization, 3 Layersets
@@ -6918,35 +6918,35 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rightCircleFill = SFSymbol(rawValue: "right.circle.fill")
+    static var rightCircleFill: SFSymbol { .init(rawValue: "right.circle.fill") }
 
     /// 􁹫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let righttriangle = SFSymbol(rawValue: "righttriangle")
+    static var righttriangle: SFSymbol { .init(rawValue: "righttriangle") }
 
     /// 􁹬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let righttriangleFill = SFSymbol(rawValue: "righttriangle.fill")
+    static var righttriangleFill: SFSymbol { .init(rawValue: "righttriangle.fill") }
 
     /// 􀍸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let righttriangleSplitDiagonal = SFSymbol(rawValue: "righttriangle.split.diagonal")
+    static var righttriangleSplitDiagonal: SFSymbol { .init(rawValue: "righttriangle.split.diagonal") }
 
     /// 􀍹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let righttriangleSplitDiagonalFill = SFSymbol(rawValue: "righttriangle.split.diagonal.fill")
+    static var righttriangleSplitDiagonalFill: SFSymbol { .init(rawValue: "righttriangle.split.diagonal.fill") }
 
     /// 􁺦
     /// Single Localization, 2 Layersets
@@ -6954,7 +6954,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rmButtonHorizontal = SFSymbol(rawValue: "rm.button.horizontal")
+    static var rmButtonHorizontal: SFSymbol { .init(rawValue: "rm.button.horizontal") }
 
     /// 􁺧
     /// Single Localization, 3 Layersets
@@ -6963,7 +6963,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rmButtonHorizontalFill = SFSymbol(rawValue: "rm.button.horizontal.fill")
+    static var rmButtonHorizontalFill: SFSymbol { .init(rawValue: "rm.button.horizontal.fill") }
 
     /// 􁱀
     /// Single Localization, 2 Layersets
@@ -6971,7 +6971,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rotate3dCircle = SFSymbol(rawValue: "rotate.3d.circle")
+    static var rotate3dCircle: SFSymbol { .init(rawValue: "rotate.3d.circle") }
 
     /// 􁱁
     /// Single Localization, 3 Layersets
@@ -6980,14 +6980,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rotate3dCircleFill = SFSymbol(rawValue: "rotate.3d.circle.fill")
+    static var rotate3dCircleFill: SFSymbol { .init(rawValue: "rotate.3d.circle.fill") }
 
     /// 􁱂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rotate3dFill = SFSymbol(rawValue: "rotate.3d.fill")
+    static var rotate3dFill: SFSymbol { .init(rawValue: "rotate.3d.fill") }
 
     /// 􁸍
     /// Single Localization, 2 Layersets
@@ -6995,7 +6995,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rsbButtonAngledbottomHorizontalRight = SFSymbol(rawValue: "rsb.button.angledbottom.horizontal.right")
+    static var rsbButtonAngledbottomHorizontalRight: SFSymbol { .init(rawValue: "rsb.button.angledbottom.horizontal.right") }
 
     /// 􁸎
     /// Single Localization, 3 Layersets
@@ -7004,7 +7004,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rsbButtonAngledbottomHorizontalRightFill = SFSymbol(rawValue: "rsb.button.angledbottom.horizontal.right.fill")
+    static var rsbButtonAngledbottomHorizontalRightFill: SFSymbol { .init(rawValue: "rsb.button.angledbottom.horizontal.right.fill") }
 
     /// 􀨙
     /// Single Localization, 2 Layersets
@@ -7012,7 +7012,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rtButtonRoundedtopHorizontal = SFSymbol(rawValue: "rt.button.roundedtop.horizontal")
+    static var rtButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "rt.button.roundedtop.horizontal") }
 
     /// 􀨚
     /// Single Localization, 3 Layersets
@@ -7021,7 +7021,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rtButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "rt.button.roundedtop.horizontal.fill")
+    static var rtButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "rt.button.roundedtop.horizontal.fill") }
 
     /// 􁺏
     /// Single Localization, 2 Layersets
@@ -7029,7 +7029,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rtCircle = SFSymbol(rawValue: "rt.circle")
+    static var rtCircle: SFSymbol { .init(rawValue: "rt.circle") }
 
     /// 􁺐
     /// Single Localization, 3 Layersets
@@ -7038,7 +7038,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rtCircleFill = SFSymbol(rawValue: "rt.circle.fill")
+    static var rtCircleFill: SFSymbol { .init(rawValue: "rt.circle.fill") }
 
     /// 􂈙
     /// Single Localization, 2 Layersets
@@ -7051,7 +7051,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "rublesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "rublesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "rublesignArrowTriangleheadCounterclockwiseRotate90")
-    static let rublesignArrowCirclepath = SFSymbol(rawValue: "rublesign.arrow.circlepath")
+    static var rublesignArrowCirclepath: SFSymbol { .init(rawValue: "rublesign.arrow.circlepath") }
 
     /// 􂈮
     /// Single Localization, 2 Layersets
@@ -7064,7 +7064,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "rupeesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "rupeesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "rupeesignArrowTriangleheadCounterclockwiseRotate90")
-    static let rupeesignArrowCirclepath = SFSymbol(rawValue: "rupeesign.arrow.circlepath")
+    static var rupeesignArrowCirclepath: SFSymbol { .init(rawValue: "rupeesign.arrow.circlepath") }
 
     /// 􂇄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7079,7 +7079,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "sharedwithyouCircle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "sharedwithyouCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sharedwithyouCircle")
-    static let sharedWithYouCircle = SFSymbol(rawValue: "shared.with.you.circle")
+    static var sharedWithYouCircle: SFSymbol { .init(rawValue: "shared.with.you.circle") }
 
     /// 􂄀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7095,7 +7095,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "sharedwithyouCircleFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "sharedwithyouCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sharedwithyouCircleFill")
-    static let sharedWithYouCircleFill = SFSymbol(rawValue: "shared.with.you.circle.fill")
+    static var sharedWithYouCircleFill: SFSymbol { .init(rawValue: "shared.with.you.circle.fill") }
 
     /// 􂈬
     /// Single Localization, 2 Layersets
@@ -7108,7 +7108,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "shekelsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "shekelsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "shekelsignArrowTriangleheadCounterclockwiseRotate90")
-    static let shekelsignArrowCirclepath = SFSymbol(rawValue: "shekelsign.arrow.circlepath")
+    static var shekelsignArrowCirclepath: SFSymbol { .init(rawValue: "shekelsign.arrow.circlepath") }
 
     /// 􀵔
     /// Single Localization, Single Layerset
@@ -7120,7 +7120,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "shieldPatternCheckered")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "shieldPatternCheckered")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "shieldPatternCheckered")
-    static let shieldCheckered = SFSymbol(rawValue: "shield.checkered")
+    static var shieldCheckered: SFSymbol { .init(rawValue: "shield.checkered") }
 
     /// 􁷥
     /// Single Localization, 3 Layersets
@@ -7129,7 +7129,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shieldLefthalfFilledBadgeCheckmark = SFSymbol(rawValue: "shield.lefthalf.filled.badge.checkmark")
+    static var shieldLefthalfFilledBadgeCheckmark: SFSymbol { .init(rawValue: "shield.lefthalf.filled.badge.checkmark") }
 
     /// 􁷧
     /// Single Localization, 3 Layersets
@@ -7138,28 +7138,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shieldLefthalfFilledTrianglebadgeExclamationmark = SFSymbol(rawValue: "shield.lefthalf.filled.trianglebadge.exclamationmark")
+    static var shieldLefthalfFilledTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "shield.lefthalf.filled.trianglebadge.exclamationmark") }
 
     /// 􁣯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shoe = SFSymbol(rawValue: "shoe")
+    static var shoe: SFSymbol { .init(rawValue: "shoe") }
 
     /// 􁣱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shoe2 = SFSymbol(rawValue: "shoe.2")
+    static var shoe2: SFSymbol { .init(rawValue: "shoe.2") }
 
     /// 􁣲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shoe2Fill = SFSymbol(rawValue: "shoe.2.fill")
+    static var shoe2Fill: SFSymbol { .init(rawValue: "shoe.2.fill") }
 
     /// 􁤄
     /// Single Localization, 2 Layersets
@@ -7167,7 +7167,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeCircle = SFSymbol(rawValue: "shoe.circle")
+    static var shoeCircle: SFSymbol { .init(rawValue: "shoe.circle") }
 
     /// 􁤅
     /// Single Localization, 3 Layersets
@@ -7176,42 +7176,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shoeCircleFill = SFSymbol(rawValue: "shoe.circle.fill")
+    static var shoeCircleFill: SFSymbol { .init(rawValue: "shoe.circle.fill") }
 
     /// 􁣰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shoeFill = SFSymbol(rawValue: "shoe.fill")
+    static var shoeFill: SFSymbol { .init(rawValue: "shoe.fill") }
 
     /// 􂂩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let skateboard = SFSymbol(rawValue: "skateboard")
+    static var skateboard: SFSymbol { .init(rawValue: "skateboard") }
 
     /// 􂂪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let skateboardFill = SFSymbol(rawValue: "skateboard.fill")
+    static var skateboardFill: SFSymbol { .init(rawValue: "skateboard.fill") }
 
     /// 􂂫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let skis = SFSymbol(rawValue: "skis")
+    static var skis: SFSymbol { .init(rawValue: "skis") }
 
     /// 􂂬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let skisFill = SFSymbol(rawValue: "skis.fill")
+    static var skisFill: SFSymbol { .init(rawValue: "skis.fill") }
 
     /// 􁵤
     /// Single Localization, 2 Layersets
@@ -7219,7 +7219,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontal2Square = SFSymbol(rawValue: "slider.horizontal.2.square")
+    static var sliderHorizontal2Square: SFSymbol { .init(rawValue: "slider.horizontal.2.square") }
 
     /// 􁿌
     /// Single Localization, 2 Layersets
@@ -7227,7 +7227,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowSunMax = SFSymbol(rawValue: "slider.horizontal.below.sun.max")
+    static var sliderHorizontalBelowSunMax: SFSymbol { .init(rawValue: "slider.horizontal.below.sun.max") }
 
     /// 􁤫
     /// Single Localization, 2 Layersets
@@ -7235,21 +7235,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let smartphone = SFSymbol(rawValue: "smartphone")
+    static var smartphone: SFSymbol { .init(rawValue: "smartphone") }
 
     /// 􂂭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let snowboard = SFSymbol(rawValue: "snowboard")
+    static var snowboard: SFSymbol { .init(rawValue: "snowboard") }
 
     /// 􂂮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let snowboardFill = SFSymbol(rawValue: "snowboard.fill")
+    static var snowboardFill: SFSymbol { .init(rawValue: "snowboard.fill") }
 
     /// 􁗮
     /// 2 Localizations, 3 Layersets
@@ -7262,7 +7262,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerWave2Bubble = SymbolWith1Localization<Rtl>(rawValue: "speaker.wave.2.bubble")
+    static var speakerWave2Bubble: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.wave.2.bubble") }
 
     /// 􁗯
     /// 2 Localizations, 3 Layersets
@@ -7275,7 +7275,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerWave2BubbleFill = SymbolWith1Localization<Rtl>(rawValue: "speaker.wave.2.bubble.fill")
+    static var speakerWave2BubbleFill: SymbolWith1Localization<Rtl> { .init(rawValue: "speaker.wave.2.bubble.fill") }
 
     /// 􁸼
     /// Single Localization, 2 Layersets
@@ -7283,7 +7283,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let square2Layers3dFill = SFSymbol(rawValue: "square.2.layers.3d.fill")
+    static var square2Layers3dFill: SFSymbol { .init(rawValue: "square.2.layers.3d.fill") }
 
     /// 􀠹
     /// Single Localization, 2 Layersets
@@ -7291,7 +7291,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareArrowtriangle4Outward = SFSymbol(rawValue: "square.arrowtriangle.4.outward")
+    static var squareArrowtriangle4Outward: SFSymbol { .init(rawValue: "square.arrowtriangle.4.outward") }
 
     /// 􁥉
     /// Single Localization, 3 Layersets
@@ -7300,7 +7300,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareBadgePlus = SFSymbol(rawValue: "square.badge.plus")
+    static var squareBadgePlus: SFSymbol { .init(rawValue: "square.badge.plus") }
 
     /// 􁥊
     /// Single Localization, 3 Layersets
@@ -7309,7 +7309,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareBadgePlusFill = SFSymbol(rawValue: "square.badge.plus.fill")
+    static var squareBadgePlusFill: SFSymbol { .init(rawValue: "square.badge.plus.fill") }
 
     /// 􂁟
     /// Single Localization, 2 Layersets
@@ -7317,7 +7317,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareResize = SFSymbol(rawValue: "square.resize")
+    static var squareResize: SFSymbol { .init(rawValue: "square.resize") }
 
     /// 􁺠
     /// Single Localization, 2 Layersets
@@ -7325,7 +7325,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareResizeDown = SFSymbol(rawValue: "square.resize.down")
+    static var squareResizeDown: SFSymbol { .init(rawValue: "square.resize.down") }
 
     /// 􁺟
     /// Single Localization, 2 Layersets
@@ -7333,7 +7333,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareResizeUp = SFSymbol(rawValue: "square.resize.up")
+    static var squareResizeUp: SFSymbol { .init(rawValue: "square.resize.up") }
 
     /// 􀙐
     /// Single Localization, 3 Layersets
@@ -7342,7 +7342,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareStack3dUpBadgeAutomatic = SFSymbol(rawValue: "square.stack.3d.up.badge.automatic")
+    static var squareStack3dUpBadgeAutomatic: SFSymbol { .init(rawValue: "square.stack.3d.up.badge.automatic") }
 
     /// 􀙑
     /// Single Localization, 3 Layersets
@@ -7351,7 +7351,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareStack3dUpBadgeAutomaticFill = SFSymbol(rawValue: "square.stack.3d.up.badge.automatic.fill")
+    static var squareStack3dUpBadgeAutomaticFill: SFSymbol { .init(rawValue: "square.stack.3d.up.badge.automatic.fill") }
 
     /// 􂅡
     /// Single Localization, 3 Layersets
@@ -7360,7 +7360,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareStack3dUpTrianglebadgeExclamationmark = SFSymbol(rawValue: "square.stack.3d.up.trianglebadge.exclamationmark")
+    static var squareStack3dUpTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "square.stack.3d.up.trianglebadge.exclamationmark") }
 
     /// 􂅢
     /// Single Localization, 3 Layersets
@@ -7369,7 +7369,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareStack3dUpTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "square.stack.3d.up.trianglebadge.exclamationmark.fill")
+    static var squareStack3dUpTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "square.stack.3d.up.trianglebadge.exclamationmark.fill") }
 
     /// 􂆅
     /// Single Localization, 2 Layersets
@@ -7377,7 +7377,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0)
-    static let squaresLeadingRectangleFill = SFSymbol(rawValue: "squares.leading.rectangle.fill")
+    static var squaresLeadingRectangleFill: SFSymbol { .init(rawValue: "squares.leading.rectangle.fill") }
 
     /// 􀩢
     /// Single Localization, 2 Layersets
@@ -7385,7 +7385,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareshapeDottedSquareshape = SFSymbol(rawValue: "squareshape.dotted.squareshape")
+    static var squareshapeDottedSquareshape: SFSymbol { .init(rawValue: "squareshape.dotted.squareshape") }
 
     /// 􀫴
     /// Single Localization, 2 Layersets
@@ -7393,7 +7393,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareshapeSquareshapeDotted = SFSymbol(rawValue: "squareshape.squareshape.dotted")
+    static var squareshapeSquareshapeDotted: SFSymbol { .init(rawValue: "squareshape.squareshape.dotted") }
 
     /// 􁣖
     /// Single Localization, 2 Layersets
@@ -7401,7 +7401,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let staroflifeShield = SFSymbol(rawValue: "staroflife.shield")
+    static var staroflifeShield: SFSymbol { .init(rawValue: "staroflife.shield") }
 
     /// 􁣗
     /// Single Localization, 3 Layersets
@@ -7410,14 +7410,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let staroflifeShieldFill = SFSymbol(rawValue: "staroflife.shield.fill")
+    static var staroflifeShieldFill: SFSymbol { .init(rawValue: "staroflife.shield.fill") }
 
     /// 􁢟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let steeringwheelAndLiquidWave = SFSymbol(rawValue: "steeringwheel.and.liquid.wave")
+    static var steeringwheelAndLiquidWave: SFSymbol { .init(rawValue: "steeringwheel.and.liquid.wave") }
 
     /// 􁖰
     /// Single Localization, 2 Layersets
@@ -7425,7 +7425,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelArrowtriangleLeft = SFSymbol(rawValue: "steeringwheel.arrowtriangle.left")
+    static var steeringwheelArrowtriangleLeft: SFSymbol { .init(rawValue: "steeringwheel.arrowtriangle.left") }
 
     /// 􁖱
     /// Single Localization, 2 Layersets
@@ -7433,7 +7433,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelArrowtriangleRight = SFSymbol(rawValue: "steeringwheel.arrowtriangle.right")
+    static var steeringwheelArrowtriangleRight: SFSymbol { .init(rawValue: "steeringwheel.arrowtriangle.right") }
 
     /// 􁉛
     /// Single Localization, 3 Layersets
@@ -7442,7 +7442,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let steeringwheelBadgeExclamationmark = SFSymbol(rawValue: "steeringwheel.badge.exclamationmark")
+    static var steeringwheelBadgeExclamationmark: SFSymbol { .init(rawValue: "steeringwheel.badge.exclamationmark") }
 
     /// 􁿢
     /// Single Localization, 2 Layersets
@@ -7450,7 +7450,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelCircle = SFSymbol(rawValue: "steeringwheel.circle")
+    static var steeringwheelCircle: SFSymbol { .init(rawValue: "steeringwheel.circle") }
 
     /// 􁿣
     /// Single Localization, 3 Layersets
@@ -7459,7 +7459,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let steeringwheelCircleFill = SFSymbol(rawValue: "steeringwheel.circle.fill")
+    static var steeringwheelCircleFill: SFSymbol { .init(rawValue: "steeringwheel.circle.fill") }
 
     /// 􂈕
     /// Single Localization, 2 Layersets
@@ -7472,14 +7472,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "sterlingsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "sterlingsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "sterlingsignArrowTriangleheadCounterclockwiseRotate90")
-    static let sterlingsignArrowCirclepath = SFSymbol(rawValue: "sterlingsign.arrow.circlepath")
+    static var sterlingsignArrowCirclepath: SFSymbol { .init(rawValue: "sterlingsign.arrow.circlepath") }
 
     /// 􁽇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let storefront = SFSymbol(rawValue: "storefront")
+    static var storefront: SFSymbol { .init(rawValue: "storefront") }
 
     /// 􁽉
     /// Single Localization, 2 Layersets
@@ -7487,7 +7487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let storefrontCircle = SFSymbol(rawValue: "storefront.circle")
+    static var storefrontCircle: SFSymbol { .init(rawValue: "storefront.circle") }
 
     /// 􁽊
     /// Single Localization, 3 Layersets
@@ -7496,14 +7496,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let storefrontCircleFill = SFSymbol(rawValue: "storefront.circle.fill")
+    static var storefrontCircleFill: SFSymbol { .init(rawValue: "storefront.circle.fill") }
 
     /// 􁽈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let storefrontFill = SFSymbol(rawValue: "storefront.fill")
+    static var storefrontFill: SFSymbol { .init(rawValue: "storefront.fill") }
 
     /// 􀻞
     /// Single Localization, 3 Layersets
@@ -7512,7 +7512,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunHorizon = SFSymbol(rawValue: "sun.horizon")
+    static var sunHorizon: SFSymbol { .init(rawValue: "sun.horizon") }
 
     /// 􁛅
     /// Single Localization, 2 Layersets
@@ -7520,7 +7520,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunHorizonCircle = SFSymbol(rawValue: "sun.horizon.circle")
+    static var sunHorizonCircle: SFSymbol { .init(rawValue: "sun.horizon.circle") }
 
     /// 􁛆
     /// Single Localization, 3 Layersets
@@ -7529,7 +7529,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunHorizonCircleFill = SFSymbol(rawValue: "sun.horizon.circle.fill")
+    static var sunHorizonCircleFill: SFSymbol { .init(rawValue: "sun.horizon.circle.fill") }
 
     /// 􀻟
     /// Single Localization, 3 Layersets
@@ -7538,7 +7538,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunHorizonFill = SFSymbol(rawValue: "sun.horizon.fill")
+    static var sunHorizonFill: SFSymbol { .init(rawValue: "sun.horizon.fill") }
 
     /// 􁷌
     /// Single Localization, 2 Layersets
@@ -7546,7 +7546,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunRain = SFSymbol(rawValue: "sun.rain")
+    static var sunRain: SFSymbol { .init(rawValue: "sun.rain") }
 
     /// 􁷎
     /// Single Localization, 2 Layersets
@@ -7554,7 +7554,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunRainCircle = SFSymbol(rawValue: "sun.rain.circle")
+    static var sunRainCircle: SFSymbol { .init(rawValue: "sun.rain.circle") }
 
     /// 􁷏
     /// Single Localization, 3 Layersets
@@ -7563,7 +7563,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunRainCircleFill = SFSymbol(rawValue: "sun.rain.circle.fill")
+    static var sunRainCircleFill: SFSymbol { .init(rawValue: "sun.rain.circle.fill") }
 
     /// 􁷍
     /// Single Localization, 3 Layersets
@@ -7572,7 +7572,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunRainFill = SFSymbol(rawValue: "sun.rain.fill")
+    static var sunRainFill: SFSymbol { .init(rawValue: "sun.rain.fill") }
 
     /// 􁷐
     /// Single Localization, 2 Layersets
@@ -7580,7 +7580,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunSnow = SFSymbol(rawValue: "sun.snow")
+    static var sunSnow: SFSymbol { .init(rawValue: "sun.snow") }
 
     /// 􁷒
     /// Single Localization, 2 Layersets
@@ -7588,7 +7588,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sunSnowCircle = SFSymbol(rawValue: "sun.snow.circle")
+    static var sunSnowCircle: SFSymbol { .init(rawValue: "sun.snow.circle") }
 
     /// 􁷓
     /// Single Localization, 3 Layersets
@@ -7597,7 +7597,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunSnowCircleFill = SFSymbol(rawValue: "sun.snow.circle.fill")
+    static var sunSnowCircleFill: SFSymbol { .init(rawValue: "sun.snow.circle.fill") }
 
     /// 􁷑
     /// Single Localization, 3 Layersets
@@ -7606,7 +7606,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunSnowFill = SFSymbol(rawValue: "sun.snow.fill")
+    static var sunSnowFill: SFSymbol { .init(rawValue: "sun.snow.fill") }
 
     /// 􁻈
     /// Single Localization, 3 Layersets
@@ -7615,28 +7615,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sunglasses = SFSymbol(rawValue: "sunglasses")
+    static var sunglasses: SFSymbol { .init(rawValue: "sunglasses") }
 
     /// 􁻉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunglassesFill = SFSymbol(rawValue: "sunglasses.fill")
+    static var sunglassesFill: SFSymbol { .init(rawValue: "sunglasses.fill") }
 
     /// 􂂯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let surfboard = SFSymbol(rawValue: "surfboard")
+    static var surfboard: SFSymbol { .init(rawValue: "surfboard") }
 
     /// 􂂰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let surfboardFill = SFSymbol(rawValue: "surfboard.fill")
+    static var surfboardFill: SFSymbol { .init(rawValue: "surfboard.fill") }
 
     /// 􁥐
     /// Single Localization, 2 Layersets
@@ -7644,7 +7644,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillDown = SFSymbol(rawValue: "suv.side.hill.down")
+    static var suvSideHillDown: SFSymbol { .init(rawValue: "suv.side.hill.down") }
 
     /// 􁥑
     /// Single Localization, 2 Layersets
@@ -7652,7 +7652,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillDownFill = SFSymbol(rawValue: "suv.side.hill.down.fill")
+    static var suvSideHillDownFill: SFSymbol { .init(rawValue: "suv.side.hill.down.fill") }
 
     /// 􁤏
     /// Single Localization, 2 Layersets
@@ -7660,7 +7660,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillUp = SFSymbol(rawValue: "suv.side.hill.up")
+    static var suvSideHillUp: SFSymbol { .init(rawValue: "suv.side.hill.up") }
 
     /// 􁤐
     /// Single Localization, 2 Layersets
@@ -7668,7 +7668,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillUpFill = SFSymbol(rawValue: "suv.side.hill.up.fill")
+    static var suvSideHillUpFill: SFSymbol { .init(rawValue: "suv.side.hill.up.fill") }
 
     /// 􁤀
     /// Single Localization, 2 Layersets
@@ -7676,7 +7676,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideLock = SFSymbol(rawValue: "suv.side.lock")
+    static var suvSideLock: SFSymbol { .init(rawValue: "suv.side.lock") }
 
     /// 􁤁
     /// Single Localization, 2 Layersets
@@ -7684,7 +7684,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideLockFill = SFSymbol(rawValue: "suv.side.lock.fill")
+    static var suvSideLockFill: SFSymbol { .init(rawValue: "suv.side.lock.fill") }
 
     /// 􁤂
     /// Single Localization, 2 Layersets
@@ -7692,7 +7692,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideLockOpen = SFSymbol(rawValue: "suv.side.lock.open")
+    static var suvSideLockOpen: SFSymbol { .init(rawValue: "suv.side.lock.open") }
 
     /// 􁤃
     /// Single Localization, 2 Layersets
@@ -7700,14 +7700,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideLockOpenFill = SFSymbol(rawValue: "suv.side.lock.open.fill")
+    static var suvSideLockOpenFill: SFSymbol { .init(rawValue: "suv.side.lock.open.fill") }
 
     /// 􁤭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let swedishkronasign = SFSymbol(rawValue: "swedishkronasign")
+    static var swedishkronasign: SFSymbol { .init(rawValue: "swedishkronasign") }
 
     /// 􂈶
     /// Single Localization, 2 Layersets
@@ -7720,7 +7720,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "swedishkronasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "swedishkronasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "swedishkronasignArrowTriangleheadCounterclockwiseRotate90")
-    static let swedishkronasignArrowCirclepath = SFSymbol(rawValue: "swedishkronasign.arrow.circlepath")
+    static var swedishkronasignArrowCirclepath: SFSymbol { .init(rawValue: "swedishkronasign.arrow.circlepath") }
 
     /// 􀮨
     /// Single Localization, 2 Layersets
@@ -7728,7 +7728,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignCircle = SFSymbol(rawValue: "swedishkronasign.circle")
+    static var swedishkronasignCircle: SFSymbol { .init(rawValue: "swedishkronasign.circle") }
 
     /// 􀮩
     /// Single Localization, 3 Layersets
@@ -7737,7 +7737,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let swedishkronasignCircleFill = SFSymbol(rawValue: "swedishkronasign.circle.fill")
+    static var swedishkronasignCircleFill: SFSymbol { .init(rawValue: "swedishkronasign.circle.fill") }
 
     /// 􀮪
     /// Single Localization, 2 Layersets
@@ -7745,7 +7745,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignSquare = SFSymbol(rawValue: "swedishkronasign.square")
+    static var swedishkronasignSquare: SFSymbol { .init(rawValue: "swedishkronasign.square") }
 
     /// 􀮫
     /// Single Localization, 3 Layersets
@@ -7754,7 +7754,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let swedishkronasignSquareFill = SFSymbol(rawValue: "swedishkronasign.square.fill")
+    static var swedishkronasignSquareFill: SFSymbol { .init(rawValue: "swedishkronasign.square.fill") }
 
     /// 􁗫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -7763,21 +7763,21 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s SwiftData.
-    static let swiftdata = SFSymbol(rawValue: "swiftdata")
+    static var swiftdata: SFSymbol { .init(rawValue: "swiftdata") }
 
     /// 􁹢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let swirlCircleRighthalfFilled = SFSymbol(rawValue: "swirl.circle.righthalf.filled")
+    static var swirlCircleRighthalfFilled: SFSymbol { .init(rawValue: "swirl.circle.righthalf.filled") }
 
     /// 􁹪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let swirlCircleRighthalfFilledInverse = SFSymbol(rawValue: "swirl.circle.righthalf.filled.inverse")
+    static var swirlCircleRighthalfFilledInverse: SFSymbol { .init(rawValue: "swirl.circle.righthalf.filled.inverse") }
 
     /// 􂈝
     /// Single Localization, 2 Layersets
@@ -7790,7 +7790,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "tengesignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "tengesignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "tengesignArrowTriangleheadCounterclockwiseRotate90")
-    static let tengesignArrowCirclepath = SFSymbol(rawValue: "tengesign.arrow.circlepath")
+    static var tengesignArrowCirclepath: SFSymbol { .init(rawValue: "tengesign.arrow.circlepath") }
 
     /// 􁷉
     /// Single Localization, 3 Layersets
@@ -7799,7 +7799,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerVariableAndFigure = SFSymbol(rawValue: "thermometer.variable.and.figure")
+    static var thermometerVariableAndFigure: SFSymbol { .init(rawValue: "thermometer.variable.and.figure") }
 
     /// 􁷊
     /// Single Localization, 2 Layersets
@@ -7807,7 +7807,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerVariableAndFigureCircle = SFSymbol(rawValue: "thermometer.variable.and.figure.circle")
+    static var thermometerVariableAndFigureCircle: SFSymbol { .init(rawValue: "thermometer.variable.and.figure.circle") }
 
     /// 􁷋
     /// Single Localization, 3 Layersets
@@ -7816,14 +7816,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerVariableAndFigureCircleFill = SFSymbol(rawValue: "thermometer.variable.and.figure.circle.fill")
+    static var thermometerVariableAndFigureCircleFill: SFSymbol { .init(rawValue: "thermometer.variable.and.figure.circle.fill") }
 
     /// 􁢶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tirepressure = SFSymbol(rawValue: "tirepressure")
+    static var tirepressure: SFSymbol { .init(rawValue: "tirepressure") }
 
     /// 􂀼
     /// Single Localization, 2 Layersets
@@ -7831,7 +7831,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tortoiseCircle = SFSymbol(rawValue: "tortoise.circle")
+    static var tortoiseCircle: SFSymbol { .init(rawValue: "tortoise.circle") }
 
     /// 􂀽
     /// Single Localization, 3 Layersets
@@ -7840,7 +7840,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tortoiseCircleFill = SFSymbol(rawValue: "tortoise.circle.fill")
+    static var tortoiseCircleFill: SFSymbol { .init(rawValue: "tortoise.circle.fill") }
 
     /// 􁢳
     /// Single Localization, 2 Layersets
@@ -7848,7 +7848,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tractionControlTirepressure = SFSymbol(rawValue: "traction.control.tirepressure")
+    static var tractionControlTirepressure: SFSymbol { .init(rawValue: "traction.control.tirepressure") }
 
     /// 􁢵
     /// Single Localization, 2 Layersets
@@ -7856,7 +7856,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tractionControlTirepressureExclamationmark = SFSymbol(rawValue: "traction.control.tirepressure.exclamationmark")
+    static var tractionControlTirepressureExclamationmark: SFSymbol { .init(rawValue: "traction.control.tirepressure.exclamationmark") }
 
     /// 􁢴
     /// Single Localization, 2 Layersets
@@ -7864,28 +7864,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tractionControlTirepressureSlash = SFSymbol(rawValue: "traction.control.tirepressure.slash")
+    static var tractionControlTirepressureSlash: SFSymbol { .init(rawValue: "traction.control.tirepressure.slash") }
 
     /// 􀥰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleshape = SFSymbol(rawValue: "triangleshape")
+    static var triangleshape: SFSymbol { .init(rawValue: "triangleshape") }
 
     /// 􀥱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let triangleshapeFill = SFSymbol(rawValue: "triangleshape.fill")
+    static var triangleshapeFill: SFSymbol { .init(rawValue: "triangleshape.fill") }
 
     /// 􁁾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckBox = SFSymbol(rawValue: "truck.box")
+    static var truckBox: SFSymbol { .init(rawValue: "truck.box") }
 
     /// 􁂀
     /// 2 Localizations, 3 Layersets
@@ -7898,7 +7898,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let truckBoxBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "truck.box.badge.clock")
+    static var truckBoxBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "truck.box.badge.clock") }
 
     /// 􁂁
     /// 2 Localizations, 3 Layersets
@@ -7911,21 +7911,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let truckBoxBadgeClockFill = SymbolWith1Localization<Rtl>(rawValue: "truck.box.badge.clock.fill")
+    static var truckBoxBadgeClockFill: SymbolWith1Localization<Rtl> { .init(rawValue: "truck.box.badge.clock.fill") }
 
     /// 􁁿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckBoxFill = SFSymbol(rawValue: "truck.box.fill")
+    static var truckBoxFill: SFSymbol { .init(rawValue: "truck.box.fill") }
 
     /// 􁥩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckPickupSide = SFSymbol(rawValue: "truck.pickup.side")
+    static var truckPickupSide: SFSymbol { .init(rawValue: "truck.pickup.side") }
 
     /// 􁥭
     /// Single Localization, 2 Layersets
@@ -7933,7 +7933,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideAirCirculate = SFSymbol(rawValue: "truck.pickup.side.air.circulate")
+    static var truckPickupSideAirCirculate: SFSymbol { .init(rawValue: "truck.pickup.side.air.circulate") }
 
     /// 􁥮
     /// Single Localization, 2 Layersets
@@ -7941,7 +7941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideAirCirculateFill = SFSymbol(rawValue: "truck.pickup.side.air.circulate.fill")
+    static var truckPickupSideAirCirculateFill: SFSymbol { .init(rawValue: "truck.pickup.side.air.circulate.fill") }
 
     /// 􁥯
     /// Single Localization, 2 Layersets
@@ -7949,7 +7949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideAirFresh = SFSymbol(rawValue: "truck.pickup.side.air.fresh")
+    static var truckPickupSideAirFresh: SFSymbol { .init(rawValue: "truck.pickup.side.air.fresh") }
 
     /// 􁥰
     /// Single Localization, 2 Layersets
@@ -7957,7 +7957,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideAirFreshFill = SFSymbol(rawValue: "truck.pickup.side.air.fresh.fill")
+    static var truckPickupSideAirFreshFill: SFSymbol { .init(rawValue: "truck.pickup.side.air.fresh.fill") }
 
     /// 􁥱
     /// Single Localization, 3 Layersets
@@ -7966,7 +7966,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let truckPickupSideAndExclamationmark = SFSymbol(rawValue: "truck.pickup.side.and.exclamationmark")
+    static var truckPickupSideAndExclamationmark: SFSymbol { .init(rawValue: "truck.pickup.side.and.exclamationmark") }
 
     /// 􁥲
     /// Single Localization, 3 Layersets
@@ -7975,7 +7975,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let truckPickupSideAndExclamationmarkFill = SFSymbol(rawValue: "truck.pickup.side.and.exclamationmark.fill")
+    static var truckPickupSideAndExclamationmarkFill: SFSymbol { .init(rawValue: "truck.pickup.side.and.exclamationmark.fill") }
 
     /// 􁥷
     /// Single Localization, 2 Layersets
@@ -7983,7 +7983,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleDown = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.down")
+    static var truckPickupSideArrowtriangleDown: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.down") }
 
     /// 􁥸
     /// Single Localization, 2 Layersets
@@ -7991,7 +7991,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleDownFill = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.down.fill")
+    static var truckPickupSideArrowtriangleDownFill: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.down.fill") }
 
     /// 􁥵
     /// Single Localization, 2 Layersets
@@ -7999,7 +7999,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleUp = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.up")
+    static var truckPickupSideArrowtriangleUp: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.up") }
 
     /// 􁥳
     /// Single Localization, 2 Layersets
@@ -8007,7 +8007,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleUpArrowtriangleDown = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.up.arrowtriangle.down")
+    static var truckPickupSideArrowtriangleUpArrowtriangleDown: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.up.arrowtriangle.down") }
 
     /// 􁥴
     /// Single Localization, 2 Layersets
@@ -8015,7 +8015,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleUpArrowtriangleDownFill = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.up.arrowtriangle.down.fill")
+    static var truckPickupSideArrowtriangleUpArrowtriangleDownFill: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.up.arrowtriangle.down.fill") }
 
     /// 􁥶
     /// Single Localization, 2 Layersets
@@ -8023,14 +8023,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowtriangleUpFill = SFSymbol(rawValue: "truck.pickup.side.arrowtriangle.up.fill")
+    static var truckPickupSideArrowtriangleUpFill: SFSymbol { .init(rawValue: "truck.pickup.side.arrowtriangle.up.fill") }
 
     /// 􁥪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckPickupSideFill = SFSymbol(rawValue: "truck.pickup.side.fill")
+    static var truckPickupSideFill: SFSymbol { .init(rawValue: "truck.pickup.side.fill") }
 
     /// 􁥫
     /// Single Localization, 2 Layersets
@@ -8038,7 +8038,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let truckPickupSideFrontOpen = SFSymbol(rawValue: "truck.pickup.side.front.open")
+    static var truckPickupSideFrontOpen: SFSymbol { .init(rawValue: "truck.pickup.side.front.open") }
 
     /// 􁥬
     /// Single Localization, 2 Layersets
@@ -8046,7 +8046,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let truckPickupSideFrontOpenFill = SFSymbol(rawValue: "truck.pickup.side.front.open.fill")
+    static var truckPickupSideFrontOpenFill: SFSymbol { .init(rawValue: "truck.pickup.side.front.open.fill") }
 
     /// 􁦆
     /// Single Localization, 2 Layersets
@@ -8054,7 +8054,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideHillDown = SFSymbol(rawValue: "truck.pickup.side.hill.down")
+    static var truckPickupSideHillDown: SFSymbol { .init(rawValue: "truck.pickup.side.hill.down") }
 
     /// 􁦇
     /// Single Localization, 2 Layersets
@@ -8062,7 +8062,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideHillDownFill = SFSymbol(rawValue: "truck.pickup.side.hill.down.fill")
+    static var truckPickupSideHillDownFill: SFSymbol { .init(rawValue: "truck.pickup.side.hill.down.fill") }
 
     /// 􁠗
     /// Single Localization, 2 Layersets
@@ -8070,7 +8070,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideHillUp = SFSymbol(rawValue: "truck.pickup.side.hill.up")
+    static var truckPickupSideHillUp: SFSymbol { .init(rawValue: "truck.pickup.side.hill.up") }
 
     /// 􁠘
     /// Single Localization, 2 Layersets
@@ -8078,7 +8078,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideHillUpFill = SFSymbol(rawValue: "truck.pickup.side.hill.up.fill")
+    static var truckPickupSideHillUpFill: SFSymbol { .init(rawValue: "truck.pickup.side.hill.up.fill") }
 
     /// 􁥹
     /// Single Localization, 2 Layersets
@@ -8086,7 +8086,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideLock = SFSymbol(rawValue: "truck.pickup.side.lock")
+    static var truckPickupSideLock: SFSymbol { .init(rawValue: "truck.pickup.side.lock") }
 
     /// 􁥺
     /// Single Localization, 2 Layersets
@@ -8094,7 +8094,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideLockFill = SFSymbol(rawValue: "truck.pickup.side.lock.fill")
+    static var truckPickupSideLockFill: SFSymbol { .init(rawValue: "truck.pickup.side.lock.fill") }
 
     /// 􁥻
     /// Single Localization, 2 Layersets
@@ -8102,7 +8102,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideLockOpen = SFSymbol(rawValue: "truck.pickup.side.lock.open")
+    static var truckPickupSideLockOpen: SFSymbol { .init(rawValue: "truck.pickup.side.lock.open") }
 
     /// 􁥼
     /// Single Localization, 2 Layersets
@@ -8110,7 +8110,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideLockOpenFill = SFSymbol(rawValue: "truck.pickup.side.lock.open.fill")
+    static var truckPickupSideLockOpenFill: SFSymbol { .init(rawValue: "truck.pickup.side.lock.open.fill") }
 
     /// 􁽬
     /// Single Localization, 2 Layersets
@@ -8118,7 +8118,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tshirtCircle = SFSymbol(rawValue: "tshirt.circle")
+    static var tshirtCircle: SFSymbol { .init(rawValue: "tshirt.circle") }
 
     /// 􁽭
     /// Single Localization, 3 Layersets
@@ -8127,7 +8127,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tshirtCircleFill = SFSymbol(rawValue: "tshirt.circle.fill")
+    static var tshirtCircleFill: SFSymbol { .init(rawValue: "tshirt.circle.fill") }
 
     /// 􂈪
     /// Single Localization, 2 Layersets
@@ -8140,7 +8140,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "tugriksignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "tugriksignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "tugriksignArrowTriangleheadCounterclockwiseRotate90")
-    static let tugriksignArrowCirclepath = SFSymbol(rawValue: "tugriksign.arrow.circlepath")
+    static var tugriksignArrowCirclepath: SFSymbol { .init(rawValue: "tugriksign.arrow.circlepath") }
 
     /// 􂈘
     /// Single Localization, 2 Layersets
@@ -8153,7 +8153,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "turkishlirasignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "turkishlirasignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "turkishlirasignArrowTriangleheadCounterclockwiseRotate90")
-    static let turkishlirasignArrowCirclepath = SFSymbol(rawValue: "turkishlirasign.arrow.circlepath")
+    static var turkishlirasignArrowCirclepath: SFSymbol { .init(rawValue: "turkishlirasign.arrow.circlepath") }
 
     /// 􂆁
     /// Single Localization, 3 Layersets
@@ -8162,7 +8162,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tvBadgeWifi = SFSymbol(rawValue: "tv.badge.wifi")
+    static var tvBadgeWifi: SFSymbol { .init(rawValue: "tv.badge.wifi") }
 
     /// 􂆂
     /// Single Localization, 3 Layersets
@@ -8171,7 +8171,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tvBadgeWifiFill = SFSymbol(rawValue: "tv.badge.wifi.fill")
+    static var tvBadgeWifiFill: SFSymbol { .init(rawValue: "tv.badge.wifi.fill") }
 
     /// 􁋞
     /// Single Localization, 2 Layersets
@@ -8179,7 +8179,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tvSlash = SFSymbol(rawValue: "tv.slash")
+    static var tvSlash: SFSymbol { .init(rawValue: "tv.slash") }
 
     /// 􁣘
     /// Single Localization, 2 Layersets
@@ -8187,7 +8187,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tvSlashFill = SFSymbol(rawValue: "tv.slash.fill")
+    static var tvSlashFill: SFSymbol { .init(rawValue: "tv.slash.fill") }
 
     /// 􀼅
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8198,7 +8198,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBadgeWaveform = SFSymbol(rawValue: "video.badge.waveform")
+    static var videoBadgeWaveform: SFSymbol { .init(rawValue: "video.badge.waveform") }
 
     /// 􀼆
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8209,7 +8209,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBadgeWaveformFill = SFSymbol(rawValue: "video.badge.waveform.fill")
+    static var videoBadgeWaveformFill: SFSymbol { .init(rawValue: "video.badge.waveform.fill") }
 
     /// 􀱰
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -8223,7 +8223,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBubble = SymbolWith1Localization<Rtl>(rawValue: "video.bubble")
+    static var videoBubble: SymbolWith1Localization<Rtl> { .init(rawValue: "video.bubble") }
 
     /// 􀱱
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -8238,7 +8238,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoBubbleFill = SymbolWith1Localization<Rtl>(rawValue: "video.bubble.fill")
+    static var videoBubbleFill: SymbolWith1Localization<Rtl> { .init(rawValue: "video.bubble.fill") }
 
     /// 􁾄
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8249,7 +8249,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSlashCircle = SFSymbol(rawValue: "video.slash.circle")
+    static var videoSlashCircle: SFSymbol { .init(rawValue: "video.slash.circle") }
 
     /// 􁾅
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8260,14 +8260,14 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
-    static let videoSlashCircleFill = SFSymbol(rawValue: "video.slash.circle.fill")
+    static var videoSlashCircleFill: SFSymbol { .init(rawValue: "video.slash.circle.fill") }
 
     /// 􁹿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let viewfinderRectangular = SFSymbol(rawValue: "viewfinder.rectangular")
+    static var viewfinderRectangular: SFSymbol { .init(rawValue: "viewfinder.rectangular") }
 
     /// 􁣓
     /// Single Localization, 3 Layersets
@@ -8276,7 +8276,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let viewfinderTrianglebadgeExclamationmark = SFSymbol(rawValue: "viewfinder.trianglebadge.exclamationmark")
+    static var viewfinderTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "viewfinder.trianglebadge.exclamationmark") }
 
     /// 􁎖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8291,7 +8291,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionPro")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionPro")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionPro")
-    static let visionpro = SFSymbol(rawValue: "visionpro")
+    static var visionpro: SFSymbol { .init(rawValue: "visionpro") }
 
     /// 􁳔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8306,7 +8306,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProAndArrowForward")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProAndArrowForward")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProAndArrowForward")
-    static let visionproAndArrowForward = SFSymbol(rawValue: "visionpro.and.arrow.forward")
+    static var visionproAndArrowForward: SFSymbol { .init(rawValue: "visionpro.and.arrow.forward") }
 
     /// 􁳕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8321,7 +8321,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProAndArrowForwardFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProAndArrowForwardFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProAndArrowForwardFill")
-    static let visionproAndArrowForwardFill = SFSymbol(rawValue: "visionpro.and.arrow.forward.fill")
+    static var visionproAndArrowForwardFill: SFSymbol { .init(rawValue: "visionpro.and.arrow.forward.fill") }
 
     /// 􁷇
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8337,7 +8337,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProBadgeExclamationmark")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProBadgeExclamationmark")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProBadgeExclamationmark")
-    static let visionproBadgeExclamationmark = SFSymbol(rawValue: "visionpro.badge.exclamationmark")
+    static var visionproBadgeExclamationmark: SFSymbol { .init(rawValue: "visionpro.badge.exclamationmark") }
 
     /// 􁷈
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8353,7 +8353,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProBadgeExclamationmarkFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProBadgeExclamationmarkFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProBadgeExclamationmarkFill")
-    static let visionproBadgeExclamationmarkFill = SFSymbol(rawValue: "visionpro.badge.exclamationmark.fill")
+    static var visionproBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "visionpro.badge.exclamationmark.fill") }
 
     /// 􁼿
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8369,7 +8369,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProBadgePlay")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProBadgePlay")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProBadgePlay")
-    static let visionproBadgePlay = SFSymbol(rawValue: "visionpro.badge.play")
+    static var visionproBadgePlay: SFSymbol { .init(rawValue: "visionpro.badge.play") }
 
     /// 􁽀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8385,7 +8385,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProBadgePlayFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProBadgePlayFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProBadgePlayFill")
-    static let visionproBadgePlayFill = SFSymbol(rawValue: "visionpro.badge.play.fill")
+    static var visionproBadgePlayFill: SFSymbol { .init(rawValue: "visionpro.badge.play.fill") }
 
     /// 􂅿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8400,7 +8400,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProCircle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProCircle")
-    static let visionproCircle = SFSymbol(rawValue: "visionpro.circle")
+    static var visionproCircle: SFSymbol { .init(rawValue: "visionpro.circle") }
 
     /// 􂆀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8416,7 +8416,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProCircleFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProCircleFill")
-    static let visionproCircleFill = SFSymbol(rawValue: "visionpro.circle.fill")
+    static var visionproCircleFill: SFSymbol { .init(rawValue: "visionpro.circle.fill") }
 
     /// 􁎘
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8430,7 +8430,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProFill")
-    static let visionproFill = SFSymbol(rawValue: "visionpro.fill")
+    static var visionproFill: SFSymbol { .init(rawValue: "visionpro.fill") }
 
     /// 􁽃
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8445,7 +8445,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProSlash")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProSlash")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProSlash")
-    static let visionproSlash = SFSymbol(rawValue: "visionpro.slash")
+    static var visionproSlash: SFSymbol { .init(rawValue: "visionpro.slash") }
 
     /// 􂆞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8460,7 +8460,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProSlashCircle")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProSlashCircle")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProSlashCircle")
-    static let visionproSlashCircle = SFSymbol(rawValue: "visionpro.slash.circle")
+    static var visionproSlashCircle: SFSymbol { .init(rawValue: "visionpro.slash.circle") }
 
     /// 􂆟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8476,7 +8476,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProSlashCircleFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProSlashCircleFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProSlashCircleFill")
-    static let visionproSlashCircleFill = SFSymbol(rawValue: "visionpro.slash.circle.fill")
+    static var visionproSlashCircleFill: SFSymbol { .init(rawValue: "visionpro.slash.circle.fill") }
 
     /// 􁽄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8491,7 +8491,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "visionProSlashFill")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "visionProSlashFill")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "visionProSlashFill")
-    static let visionproSlashFill = SFSymbol(rawValue: "visionpro.slash.fill")
+    static var visionproSlashFill: SFSymbol { .init(rawValue: "visionpro.slash.fill") }
 
     /// 􀭻
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8501,7 +8501,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Accessibility features.
-    static let voiceover = SFSymbol(rawValue: "voiceover")
+    static var voiceover: SFSymbol { .init(rawValue: "voiceover") }
 
     /// 􁀬
     /// Single Localization, 2 Layersets
@@ -8509,7 +8509,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let warninglight = SFSymbol(rawValue: "warninglight")
+    static var warninglight: SFSymbol { .init(rawValue: "warninglight") }
 
     /// 􁀭
     /// Single Localization, 2 Layersets
@@ -8517,7 +8517,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let warninglightFill = SFSymbol(rawValue: "warninglight.fill")
+    static var warninglightFill: SFSymbol { .init(rawValue: "warninglight.fill") }
 
     /// 􁿎
     /// Single Localization, 2 Layersets
@@ -8525,7 +8525,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let washerCircle = SFSymbol(rawValue: "washer.circle")
+    static var washerCircle: SFSymbol { .init(rawValue: "washer.circle") }
 
     /// 􁿏
     /// Single Localization, 3 Layersets
@@ -8534,7 +8534,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let washerCircleFill = SFSymbol(rawValue: "washer.circle.fill")
+    static var washerCircleFill: SFSymbol { .init(rawValue: "washer.circle.fill") }
 
     /// 􁞺
     /// Single Localization, 2 Layersets
@@ -8542,21 +8542,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let watchAnalog = SFSymbol(rawValue: "watch.analog")
+    static var watchAnalog: SFSymbol { .init(rawValue: "watch.analog") }
 
     /// 􁻊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waterbottle = SFSymbol(rawValue: "waterbottle")
+    static var waterbottle: SFSymbol { .init(rawValue: "waterbottle") }
 
     /// 􁻋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waterbottleFill = SFSymbol(rawValue: "waterbottle.fill")
+    static var waterbottleFill: SFSymbol { .init(rawValue: "waterbottle.fill") }
 
     /// 􂃓
     /// Single Localization, 2 Layersets
@@ -8564,7 +8564,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waveformAndPersonFilled = SFSymbol(rawValue: "waveform.and.person.filled")
+    static var waveformAndPersonFilled: SFSymbol { .init(rawValue: "waveform.and.person.filled") }
 
     /// 􀻾
     /// Single Localization, 3 Layersets
@@ -8573,7 +8573,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeMagnifyingglass = SFSymbol(rawValue: "waveform.badge.magnifyingglass")
+    static var waveformBadgeMagnifyingglass: SFSymbol { .init(rawValue: "waveform.badge.magnifyingglass") }
 
     /// 􁃨
     /// Single Localization, 3 Layersets
@@ -8587,7 +8587,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "waveformBadgeMicrophone")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "waveformBadgeMicrophone")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "waveformBadgeMicrophone")
-    static let waveformBadgeMic = SFSymbol(rawValue: "waveform.badge.mic")
+    static var waveformBadgeMic: SFSymbol { .init(rawValue: "waveform.badge.mic") }
 
     /// 􂄁
     /// Single Localization, 2 Layersets
@@ -8595,7 +8595,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wifiExclamationmarkCircle = SFSymbol(rawValue: "wifi.exclamationmark.circle")
+    static var wifiExclamationmarkCircle: SFSymbol { .init(rawValue: "wifi.exclamationmark.circle") }
 
     /// 􂄂
     /// Single Localization, 3 Layersets
@@ -8604,7 +8604,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wifiExclamationmarkCircleFill = SFSymbol(rawValue: "wifi.exclamationmark.circle.fill")
+    static var wifiExclamationmarkCircleFill: SFSymbol { .init(rawValue: "wifi.exclamationmark.circle.fill") }
 
     /// 􂈡
     /// Single Localization, 2 Layersets
@@ -8617,7 +8617,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "wonsignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "wonsignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "wonsignArrowTriangleheadCounterclockwiseRotate90")
-    static let wonsignArrowCirclepath = SFSymbol(rawValue: "wonsign.arrow.circlepath")
+    static var wonsignArrowCirclepath: SFSymbol { .init(rawValue: "wonsign.arrow.circlepath") }
 
     /// 􁻇
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8626,7 +8626,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Xserve RAID.
-    static let xserveRaid = SFSymbol(rawValue: "xserve.raid")
+    static var xserveRaid: SFSymbol { .init(rawValue: "xserve.raid") }
 
     /// 􂈔
     /// Single Localization, 2 Layersets
@@ -8639,7 +8639,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 17.0, deprecated: 18.0, renamed: "yensignArrowTriangleheadCounterclockwiseRotate90")
     @available(watchOS, introduced: 10.0, deprecated: 11.0, renamed: "yensignArrowTriangleheadCounterclockwiseRotate90")
     @available(visionOS, introduced: 1.0, deprecated: 2.0, renamed: "yensignArrowTriangleheadCounterclockwiseRotate90")
-    static let yensignArrowCirclepath = SFSymbol(rawValue: "yensign.arrow.circlepath")
+    static var yensignArrowCirclepath: SFSymbol { .init(rawValue: "yensign.arrow.circlepath") }
 
     /// 􁕤
     /// Single Localization, 3 Layersets
@@ -8648,7 +8648,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let yieldsign = SFSymbol(rawValue: "yieldsign")
+    static var yieldsign: SFSymbol { .init(rawValue: "yieldsign") }
 
     /// 􁕥
     /// Single Localization, 3 Layersets
@@ -8657,7 +8657,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let yieldsignFill = SFSymbol(rawValue: "yieldsign.fill")
+    static var yieldsignFill: SFSymbol { .init(rawValue: "yieldsign.fill") }
 
     /// 􀨛
     /// Single Localization, 2 Layersets
@@ -8665,7 +8665,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let zlButtonRoundedtopHorizontal = SFSymbol(rawValue: "zl.button.roundedtop.horizontal")
+    static var zlButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "zl.button.roundedtop.horizontal") }
 
     /// 􀨜
     /// Single Localization, 3 Layersets
@@ -8674,7 +8674,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let zlButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "zl.button.roundedtop.horizontal.fill")
+    static var zlButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "zl.button.roundedtop.horizontal.fill") }
 
     /// 􀨝
     /// Single Localization, 2 Layersets
@@ -8682,7 +8682,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let zrButtonRoundedtopHorizontal = SFSymbol(rawValue: "zr.button.roundedtop.horizontal")
+    static var zrButtonRoundedtopHorizontal: SFSymbol { .init(rawValue: "zr.button.roundedtop.horizontal") }
 
     /// 􀨞
     /// Single Localization, 3 Layersets
@@ -8691,5 +8691,5 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let zrButtonRoundedtopHorizontalFill = SFSymbol(rawValue: "zr.button.roundedtop.horizontal.fill")
+    static var zrButtonRoundedtopHorizontalFill: SFSymbol { .init(rawValue: "zr.button.roundedtop.horizontal.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+5.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+5.1.swift
@@ -8,14 +8,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactBackward = SFSymbol(rawValue: "chevron.compact.backward")
+    static var chevronCompactBackward: SFSymbol { .init(rawValue: "chevron.compact.backward") }
 
     /// 􂉐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactForward = SFSymbol(rawValue: "chevron.compact.forward")
+    static var chevronCompactForward: SFSymbol { .init(rawValue: "chevron.compact.forward") }
 
     /// 􂉚
     /// Single Localization, 2 Layersets
@@ -23,7 +23,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareBadgeCamera = SFSymbol(rawValue: "person.crop.square.badge.camera")
+    static var personCropSquareBadgeCamera: SFSymbol { .init(rawValue: "person.crop.square.badge.camera") }
 
     /// 􂉛
     /// Single Localization, 2 Layersets
@@ -31,7 +31,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareBadgeCameraFill = SFSymbol(rawValue: "person.crop.square.badge.camera.fill")
+    static var personCropSquareBadgeCameraFill: SFSymbol { .init(rawValue: "person.crop.square.badge.camera.fill") }
 
     /// 􂉜
     /// Single Localization, 2 Layersets
@@ -39,7 +39,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareBadgeVideo = SFSymbol(rawValue: "person.crop.square.badge.video")
+    static var personCropSquareBadgeVideo: SFSymbol { .init(rawValue: "person.crop.square.badge.video") }
 
     /// 􂉝
     /// Single Localization, 2 Layersets
@@ -47,5 +47,5 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareBadgeVideoFill = SFSymbol(rawValue: "person.crop.square.badge.video.fill")
+    static var personCropSquareBadgeVideoFill: SFSymbol { .init(rawValue: "person.crop.square.badge.video.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+5.2.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+5.2.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpBadgeClock = SFSymbol(rawValue: "square.and.arrow.up.badge.clock")
+    static var squareAndArrowUpBadgeClock: SFSymbol { .init(rawValue: "square.and.arrow.up.badge.clock") }
 
     /// 􂋏
     /// Single Localization, 3 Layersets
@@ -19,5 +19,5 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpBadgeClockFill = SFSymbol(rawValue: "square.and.arrow.up.badge.clock.fill")
+    static var squareAndArrowUpBadgeClockFill: SFSymbol { .init(rawValue: "square.and.arrow.up.badge.clock.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+5.3.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+5.3.swift
@@ -11,7 +11,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
-    static let appleMeditate = SFSymbol(rawValue: "apple.meditate")
+    static var appleMeditate: SFSymbol { .init(rawValue: "apple.meditate") }
 
     /// 􁟾
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -21,7 +21,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
-    static let appleMeditateSquareStack = SFSymbol(rawValue: "apple.meditate.square.stack")
+    static var appleMeditateSquareStack: SFSymbol { .init(rawValue: "apple.meditate.square.stack") }
 
     /// 􁟿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -31,7 +31,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
-    static let appleMeditateSquareStackFill = SFSymbol(rawValue: "apple.meditate.square.stack.fill")
+    static var appleMeditateSquareStackFill: SFSymbol { .init(rawValue: "apple.meditate.square.stack.fill") }
 
     /// 􂝕
     /// Single Localization, 2 Layersets
@@ -39,7 +39,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let appleTerminalCircle = SFSymbol(rawValue: "apple.terminal.circle")
+    static var appleTerminalCircle: SFSymbol { .init(rawValue: "apple.terminal.circle") }
 
     /// 􂝖
     /// Single Localization, 3 Layersets
@@ -48,7 +48,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appleTerminalCircleFill = SFSymbol(rawValue: "apple.terminal.circle.fill")
+    static var appleTerminalCircleFill: SFSymbol { .init(rawValue: "apple.terminal.circle.fill") }
 
     /// 􂞹
     /// Single Localization, 2 Layersets
@@ -56,7 +56,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownAppDashed = SFSymbol(rawValue: "arrow.down.app.dashed")
+    static var arrowDownAppDashed: SFSymbol { .init(rawValue: "arrow.down.app.dashed") }
 
     /// 􂞺
     /// Single Localization, 3 Layersets
@@ -65,21 +65,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownAppDashedTrianglebadgeExclamationmark = SFSymbol(rawValue: "arrow.down.app.dashed.trianglebadge.exclamationmark")
+    static var arrowDownAppDashedTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "arrow.down.app.dashed.trianglebadge.exclamationmark") }
 
     /// 􂛍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let audioJackMono = SFSymbol(rawValue: "audio.jack.mono")
+    static var audioJackMono: SFSymbol { .init(rawValue: "audio.jack.mono") }
 
     /// 􂛋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let audioJackStereo = SFSymbol(rawValue: "audio.jack.stereo")
+    static var audioJackStereo: SFSymbol { .init(rawValue: "audio.jack.stereo") }
 
     /// 􂕙
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -90,7 +90,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadBadgeExclamationmark = SFSymbol(rawValue: "ipad.badge.exclamationmark")
+    static var ipadBadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.badge.exclamationmark") }
 
     /// 􂕑
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -101,7 +101,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1BadgeExclamationmark = SFSymbol(rawValue: "ipad.gen1.badge.exclamationmark")
+    static var ipadGen1BadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.gen1.badge.exclamationmark") }
 
     /// 􂕓
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -112,7 +112,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1LandscapeBadgeExclamationmark = SFSymbol(rawValue: "ipad.gen1.landscape.badge.exclamationmark")
+    static var ipadGen1LandscapeBadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.gen1.landscape.badge.exclamationmark") }
 
     /// 􂕕
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -123,7 +123,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2BadgeExclamationmark = SFSymbol(rawValue: "ipad.gen2.badge.exclamationmark")
+    static var ipadGen2BadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.gen2.badge.exclamationmark") }
 
     /// 􂕗
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -134,7 +134,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2LandscapeBadgeExclamationmark = SFSymbol(rawValue: "ipad.gen2.landscape.badge.exclamationmark")
+    static var ipadGen2LandscapeBadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.gen2.landscape.badge.exclamationmark") }
 
     /// 􂕛
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -145,7 +145,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadLandscapeBadgeExclamationmark = SFSymbol(rawValue: "ipad.landscape.badge.exclamationmark")
+    static var ipadLandscapeBadgeExclamationmark: SFSymbol { .init(rawValue: "ipad.landscape.badge.exclamationmark") }
 
     /// 􂕏
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -156,7 +156,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneBadgeExclamationmark = SFSymbol(rawValue: "iphone.badge.exclamationmark")
+    static var iphoneBadgeExclamationmark: SFSymbol { .init(rawValue: "iphone.badge.exclamationmark") }
 
     /// 􂓻
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -167,7 +167,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1BadgeExclamationmark = SFSymbol(rawValue: "iphone.gen1.badge.exclamationmark")
+    static var iphoneGen1BadgeExclamationmark: SFSymbol { .init(rawValue: "iphone.gen1.badge.exclamationmark") }
 
     /// 􂕋
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -178,7 +178,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2BadgeExclamationmark = SFSymbol(rawValue: "iphone.gen2.badge.exclamationmark")
+    static var iphoneGen2BadgeExclamationmark: SFSymbol { .init(rawValue: "iphone.gen2.badge.exclamationmark") }
 
     /// 􂕍
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -189,21 +189,21 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3BadgeExclamationmark = SFSymbol(rawValue: "iphone.gen3.badge.exclamationmark")
+    static var iphoneGen3BadgeExclamationmark: SFSymbol { .init(rawValue: "iphone.gen3.badge.exclamationmark") }
 
     /// 􂙣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medalStar = SFSymbol(rawValue: "medal.star")
+    static var medalStar: SFSymbol { .init(rawValue: "medal.star") }
 
     /// 􂙤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let medalStarFill = SFSymbol(rawValue: "medal.star.fill")
+    static var medalStarFill: SFSymbol { .init(rawValue: "medal.star.fill") }
 
     /// 􂞶
     /// Single Localization, 2 Layersets
@@ -211,7 +211,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusCircleDashed = SFSymbol(rawValue: "plus.circle.dashed")
+    static var plusCircleDashed: SFSymbol { .init(rawValue: "plus.circle.dashed") }
 
     /// 􀮙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -221,5 +221,5 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s translation features.
-    static let translate = SFSymbol(rawValue: "translate")
+    static var translate: SFSymbol { .init(rawValue: "translate") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+5.4.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+5.4.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Pill.
-    static let beatsPill = SFSymbol(rawValue: "beats.pill")
+    static var beatsPill: SFSymbol { .init(rawValue: "beats.pill") }
 
     /// 􂟋
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -19,7 +19,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Pill.
-    static let beatsPillFill = SFSymbol(rawValue: "beats.pill.fill")
+    static var beatsPillFill: SFSymbol { .init(rawValue: "beats.pill.fill") }
 
     /// 􂟌
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -29,7 +29,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Solo Buds.
-    static let beatsSolobuds = SFSymbol(rawValue: "beats.solobuds")
+    static var beatsSolobuds: SFSymbol { .init(rawValue: "beats.solobuds") }
 
     /// 􂟏
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -38,7 +38,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Solo Buds case.
-    static let beatsSolobudsChargingcase = SFSymbol(rawValue: "beats.solobuds.chargingcase")
+    static var beatsSolobudsChargingcase: SFSymbol { .init(rawValue: "beats.solobuds.chargingcase") }
 
     /// 􂟐
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -47,7 +47,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Solo Buds case.
-    static let beatsSolobudsChargingcaseFill = SFSymbol(rawValue: "beats.solobuds.chargingcase.fill")
+    static var beatsSolobudsChargingcaseFill: SFSymbol { .init(rawValue: "beats.solobuds.chargingcase.fill") }
 
     /// 􂟎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -57,7 +57,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Solo Buds.
-    static let beatsSolobudsLeft = SFSymbol(rawValue: "beats.solobuds.left")
+    static var beatsSolobudsLeft: SFSymbol { .init(rawValue: "beats.solobuds.left") }
 
     /// 􂟍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -67,5 +67,5 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Solo Buds.
-    static let beatsSolobudsRight = SFSymbol(rawValue: "beats.solobuds.right")
+    static var beatsSolobudsRight: SFSymbol { .init(rawValue: "beats.solobuds.right") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+6.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+6.0.swift
@@ -13,7 +13,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _5ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "5.arrow.trianglehead.clockwise")
+    static var _5ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "5.arrow.trianglehead.clockwise") }
 
     /// 􀶱
     /// 2 Localizations, 2 Layersets
@@ -25,7 +25,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _5ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "5.arrow.trianglehead.counterclockwise")
+    static var _5ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "5.arrow.trianglehead.counterclockwise") }
 
     /// 􀎁
     /// 2 Localizations, 2 Layersets
@@ -37,7 +37,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _10ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "10.arrow.trianglehead.clockwise")
+    static var _10ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "10.arrow.trianglehead.clockwise") }
 
     /// 􀎂
     /// 2 Localizations, 2 Layersets
@@ -49,7 +49,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _10ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "10.arrow.trianglehead.counterclockwise")
+    static var _10ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "10.arrow.trianglehead.counterclockwise") }
 
     /// 􀎃
     /// 2 Localizations, 2 Layersets
@@ -61,7 +61,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _15ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "15.arrow.trianglehead.clockwise")
+    static var _15ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "15.arrow.trianglehead.clockwise") }
 
     /// 􀎄
     /// 2 Localizations, 2 Layersets
@@ -73,7 +73,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _15ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "15.arrow.trianglehead.counterclockwise")
+    static var _15ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "15.arrow.trianglehead.counterclockwise") }
 
     /// 􀎅
     /// 2 Localizations, 2 Layersets
@@ -85,7 +85,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _30ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "30.arrow.trianglehead.clockwise")
+    static var _30ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "30.arrow.trianglehead.clockwise") }
 
     /// 􀎆
     /// 2 Localizations, 2 Layersets
@@ -97,7 +97,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _30ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "30.arrow.trianglehead.counterclockwise")
+    static var _30ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "30.arrow.trianglehead.counterclockwise") }
 
     /// 􀎇
     /// 2 Localizations, 2 Layersets
@@ -109,7 +109,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _45ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "45.arrow.trianglehead.clockwise")
+    static var _45ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "45.arrow.trianglehead.clockwise") }
 
     /// 􀎈
     /// 2 Localizations, 2 Layersets
@@ -121,7 +121,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _45ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "45.arrow.trianglehead.counterclockwise")
+    static var _45ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "45.arrow.trianglehead.counterclockwise") }
 
     /// 􀎉
     /// 2 Localizations, 2 Layersets
@@ -133,7 +133,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _60ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "60.arrow.trianglehead.clockwise")
+    static var _60ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "60.arrow.trianglehead.clockwise") }
 
     /// 􀎊
     /// 2 Localizations, 2 Layersets
@@ -145,7 +145,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _60ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "60.arrow.trianglehead.counterclockwise")
+    static var _60ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "60.arrow.trianglehead.counterclockwise") }
 
     /// 􀘤
     /// 2 Localizations, 2 Layersets
@@ -157,7 +157,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _75ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "75.arrow.trianglehead.clockwise")
+    static var _75ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "75.arrow.trianglehead.clockwise") }
 
     /// 􀘥
     /// 2 Localizations, 2 Layersets
@@ -169,7 +169,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _75ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "75.arrow.trianglehead.counterclockwise")
+    static var _75ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "75.arrow.trianglehead.counterclockwise") }
 
     /// 􀘦
     /// 2 Localizations, 2 Layersets
@@ -181,7 +181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _90ArrowTriangleheadClockwise = SymbolWith1Localization<Hi>(rawValue: "90.arrow.trianglehead.clockwise")
+    static var _90ArrowTriangleheadClockwise: SymbolWith1Localization<Hi> { .init(rawValue: "90.arrow.trianglehead.clockwise") }
 
     /// 􀘧
     /// 2 Localizations, 2 Layersets
@@ -193,7 +193,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let _90ArrowTriangleheadCounterclockwise = SymbolWith1Localization<Hi>(rawValue: "90.arrow.trianglehead.counterclockwise")
+    static var _90ArrowTriangleheadCounterclockwise: SymbolWith1Localization<Hi> { .init(rawValue: "90.arrow.trianglehead.counterclockwise") }
 
     /// 􂥣
     /// Single Localization, 2 Layersets
@@ -201,7 +201,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airCarSide = SFSymbol(rawValue: "air.car.side")
+    static var airCarSide: SFSymbol { .init(rawValue: "air.car.side") }
 
     /// 􂥤
     /// Single Localization, 3 Layersets
@@ -210,7 +210,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airCarSideFill = SFSymbol(rawValue: "air.car.side.fill")
+    static var airCarSideFill: SFSymbol { .init(rawValue: "air.car.side.fill") }
 
     /// 􂥩
     /// Single Localization, 2 Layersets
@@ -218,7 +218,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airConvertibleSide = SFSymbol(rawValue: "air.convertible.side")
+    static var airConvertibleSide: SFSymbol { .init(rawValue: "air.convertible.side") }
 
     /// 􂥪
     /// Single Localization, 3 Layersets
@@ -227,7 +227,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airConvertibleSideFill = SFSymbol(rawValue: "air.convertible.side.fill")
+    static var airConvertibleSideFill: SFSymbol { .init(rawValue: "air.convertible.side.fill") }
 
     /// 􂥧
     /// Single Localization, 2 Layersets
@@ -235,7 +235,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airPickupSide = SFSymbol(rawValue: "air.pickup.side")
+    static var airPickupSide: SFSymbol { .init(rawValue: "air.pickup.side") }
 
     /// 􂥨
     /// Single Localization, 3 Layersets
@@ -244,7 +244,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airPickupSideFill = SFSymbol(rawValue: "air.pickup.side.fill")
+    static var airPickupSideFill: SFSymbol { .init(rawValue: "air.pickup.side.fill") }
 
     /// 􂥥
     /// Single Localization, 2 Layersets
@@ -252,7 +252,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airSuvSide = SFSymbol(rawValue: "air.suv.side")
+    static var airSuvSide: SFSymbol { .init(rawValue: "air.suv.side") }
 
     /// 􂥦
     /// Single Localization, 3 Layersets
@@ -261,7 +261,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airSuvSideFill = SFSymbol(rawValue: "air.suv.side.fill")
+    static var airSuvSideFill: SFSymbol { .init(rawValue: "air.suv.side.fill") }
 
     /// 􀑢
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -272,7 +272,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayAudio = SFSymbol(rawValue: "airplay.audio")
+    static var airplayAudio: SFSymbol { .init(rawValue: "airplay.audio") }
 
     /// 􀱫
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -283,7 +283,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayAudioBadgeExclamationmark = SFSymbol(rawValue: "airplay.audio.badge.exclamationmark")
+    static var airplayAudioBadgeExclamationmark: SFSymbol { .init(rawValue: "airplay.audio.badge.exclamationmark") }
 
     /// 􀾧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -294,7 +294,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayAudioCircle = SFSymbol(rawValue: "airplay.audio.circle")
+    static var airplayAudioCircle: SFSymbol { .init(rawValue: "airplay.audio.circle") }
 
     /// 􀾨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -305,7 +305,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayAudioCircleFill = SFSymbol(rawValue: "airplay.audio.circle.fill")
+    static var airplayAudioCircleFill: SFSymbol { .init(rawValue: "airplay.audio.circle.fill") }
 
     /// 􀑡
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -315,7 +315,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayVideo = SFSymbol(rawValue: "airplay.video")
+    static var airplayVideo: SFSymbol { .init(rawValue: "airplay.video") }
 
     /// 􀱪
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -326,7 +326,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayVideoBadgeExclamationmark = SFSymbol(rawValue: "airplay.video.badge.exclamationmark")
+    static var airplayVideoBadgeExclamationmark: SFSymbol { .init(rawValue: "airplay.video.badge.exclamationmark") }
 
     /// 􀾑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -336,7 +336,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayVideoCircle = SFSymbol(rawValue: "airplay.video.circle")
+    static var airplayVideoCircle: SFSymbol { .init(rawValue: "airplay.video.circle") }
 
     /// 􀾒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -347,7 +347,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
-    static let airplayVideoCircleFill = SFSymbol(rawValue: "airplay.video.circle.fill")
+    static var airplayVideoCircleFill: SFSymbol { .init(rawValue: "airplay.video.circle.fill") }
 
     /// 􀺹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -357,7 +357,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Max.
-    static let airpodsMax = SFSymbol(rawValue: "airpods.max")
+    static var airpodsMax: SFSymbol { .init(rawValue: "airpods.max") }
 
     /// 􀪷
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -367,7 +367,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsPro = SFSymbol(rawValue: "airpods.pro")
+    static var airpodsPro: SFSymbol { .init(rawValue: "airpods.pro") }
 
     /// 􀹫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -376,7 +376,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProChargingcaseWireless = SFSymbol(rawValue: "airpods.pro.chargingcase.wireless")
+    static var airpodsProChargingcaseWireless: SFSymbol { .init(rawValue: "airpods.pro.chargingcase.wireless") }
 
     /// 􀹬
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -385,7 +385,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProChargingcaseWirelessFill = SFSymbol(rawValue: "airpods.pro.chargingcase.wireless.fill")
+    static var airpodsProChargingcaseWirelessFill: SFSymbol { .init(rawValue: "airpods.pro.chargingcase.wireless.fill") }
 
     /// 􁔂
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -395,7 +395,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProChargingcaseWirelessRadiowavesLeftAndRight = SFSymbol(rawValue: "airpods.pro.chargingcase.wireless.radiowaves.left.and.right")
+    static var airpodsProChargingcaseWirelessRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "airpods.pro.chargingcase.wireless.radiowaves.left.and.right") }
 
     /// 􁔃
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -405,7 +405,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill = SFSymbol(rawValue: "airpods.pro.chargingcase.wireless.radiowaves.left.and.right.fill")
+    static var airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "airpods.pro.chargingcase.wireless.radiowaves.left.and.right.fill") }
 
     /// 􀲎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -415,7 +415,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProLeft = SFSymbol(rawValue: "airpods.pro.left")
+    static var airpodsProLeft: SFSymbol { .init(rawValue: "airpods.pro.left") }
 
     /// 􀲍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -425,14 +425,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
-    static let airpodsProRight = SFSymbol(rawValue: "airpods.pro.right")
+    static var airpodsProRight: SFSymbol { .init(rawValue: "airpods.pro.right") }
 
     /// 􁗋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let americanFootball = SFSymbol(rawValue: "american.football")
+    static var americanFootball: SFSymbol { .init(rawValue: "american.football") }
 
     /// 􁚿
     /// Single Localization, 2 Layersets
@@ -440,7 +440,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let americanFootballCircle = SFSymbol(rawValue: "american.football.circle")
+    static var americanFootballCircle: SFSymbol { .init(rawValue: "american.football.circle") }
 
     /// 􁛀
     /// Single Localization, 3 Layersets
@@ -449,21 +449,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let americanFootballCircleFill = SFSymbol(rawValue: "american.football.circle.fill")
+    static var americanFootballCircleFill: SFSymbol { .init(rawValue: "american.football.circle.fill") }
 
     /// 􁗌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let americanFootballFill = SFSymbol(rawValue: "american.football.fill")
+    static var americanFootballFill: SFSymbol { .init(rawValue: "american.football.fill") }
 
     /// 􂎵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let americanFootballProfessional = SFSymbol(rawValue: "american.football.professional")
+    static var americanFootballProfessional: SFSymbol { .init(rawValue: "american.football.professional") }
 
     /// 􂎷
     /// Single Localization, 2 Layersets
@@ -471,7 +471,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let americanFootballProfessionalCircle = SFSymbol(rawValue: "american.football.professional.circle")
+    static var americanFootballProfessionalCircle: SFSymbol { .init(rawValue: "american.football.professional.circle") }
 
     /// 􂎸
     /// Single Localization, 3 Layersets
@@ -480,14 +480,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let americanFootballProfessionalCircleFill = SFSymbol(rawValue: "american.football.professional.circle.fill")
+    static var americanFootballProfessionalCircleFill: SFSymbol { .init(rawValue: "american.football.professional.circle.fill") }
 
     /// 􂎶
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let americanFootballProfessionalFill = SFSymbol(rawValue: "american.football.professional.fill")
+    static var americanFootballProfessionalFill: SFSymbol { .init(rawValue: "american.football.professional.fill") }
 
     /// 􂪻
     /// Single Localization, 2 Layersets
@@ -495,7 +495,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let antennaRadiowavesLeftAndRightSlashCircle = SFSymbol(rawValue: "antenna.radiowaves.left.and.right.slash.circle")
+    static var antennaRadiowavesLeftAndRightSlashCircle: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right.slash.circle") }
 
     /// 􂪽
     /// Single Localization, 3 Layersets
@@ -504,7 +504,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let antennaRadiowavesLeftAndRightSlashCircleFill = SFSymbol(rawValue: "antenna.radiowaves.left.and.right.slash.circle.fill")
+    static var antennaRadiowavesLeftAndRightSlashCircleFill: SFSymbol { .init(rawValue: "antenna.radiowaves.left.and.right.slash.circle.fill") }
 
     /// 􂡆
     /// Single Localization, 3 Layersets
@@ -513,7 +513,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appBadgeClock = SFSymbol(rawValue: "app.badge.clock")
+    static var appBadgeClock: SFSymbol { .init(rawValue: "app.badge.clock") }
 
     /// 􂡇
     /// Single Localization, 3 Layersets
@@ -522,7 +522,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appBadgeClockFill = SFSymbol(rawValue: "app.badge.clock.fill")
+    static var appBadgeClockFill: SFSymbol { .init(rawValue: "app.badge.clock.fill") }
 
     /// 􀉇
     /// 2 Localizations, Single Layerset
@@ -533,7 +533,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let appendPage = SymbolWith1Localization<Rtl>(rawValue: "append.page")
+    static var appendPage: SymbolWith1Localization<Rtl> { .init(rawValue: "append.page") }
 
     /// 􀦋
     /// 2 Localizations, Single Layerset
@@ -544,7 +544,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let appendPageFill = SymbolWith1Localization<Rtl>(rawValue: "append.page.fill")
+    static var appendPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "append.page.fill") }
 
     /// 􂫥
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -555,7 +555,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to music based haptic feedback for software that is compatible with the Core Haptics API.
-    static let appleHapticsAndExclamationmarkTriangle = SFSymbol(rawValue: "apple.haptics.and.exclamationmark.triangle")
+    static var appleHapticsAndExclamationmarkTriangle: SFSymbol { .init(rawValue: "apple.haptics.and.exclamationmark.triangle") }
 
     /// 􂝾
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -565,7 +565,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to music based haptic feedback for software that is compatible with the Core Haptics API.
-    static let appleHapticsAndMusicNote = SFSymbol(rawValue: "apple.haptics.and.music.note")
+    static var appleHapticsAndMusicNote: SFSymbol { .init(rawValue: "apple.haptics.and.music.note") }
 
     /// 􂞀
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -575,7 +575,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to music based haptic feedback for software that is compatible with the Core Haptics API.
-    static let appleHapticsAndMusicNoteSlash = SFSymbol(rawValue: "apple.haptics.and.music.note.slash")
+    static var appleHapticsAndMusicNoteSlash: SFSymbol { .init(rawValue: "apple.haptics.and.music.note.slash") }
 
     /// 􂮕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -585,7 +585,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Image Playground app.
-    static let appleImagePlayground = SFSymbol(rawValue: "apple.image.playground")
+    static var appleImagePlayground: SFSymbol { .init(rawValue: "apple.image.playground") }
 
     /// 􂮖
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -596,7 +596,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Image Playground app.
-    static let appleImagePlaygroundFill = SFSymbol(rawValue: "apple.image.playground.fill")
+    static var appleImagePlaygroundFill: SFSymbol { .init(rawValue: "apple.image.playground.fill") }
 
     /// 􂮢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -606,7 +606,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Intelligence.
-    static let appleIntelligence = SFSymbol(rawValue: "apple.intelligence")
+    static var appleIntelligence: SFSymbol { .init(rawValue: "apple.intelligence") }
 
     /// 􂛑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -616,7 +616,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
-    static let appleMeditateCircle = SFSymbol(rawValue: "apple.meditate.circle")
+    static var appleMeditateCircle: SFSymbol { .init(rawValue: "apple.meditate.circle") }
 
     /// 􂛒
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -627,7 +627,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
-    static let appleMeditateCircleFill = SFSymbol(rawValue: "apple.meditate.circle.fill")
+    static var appleMeditateCircleFill: SFSymbol { .init(rawValue: "apple.meditate.circle.fill") }
 
     /// 􂤀
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -637,7 +637,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilDoubletap = SFSymbol(rawValue: "applepencil.doubletap")
+    static var applepencilDoubletap: SFSymbol { .init(rawValue: "applepencil.doubletap") }
 
     /// 􁤒
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -647,7 +647,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilHover = SFSymbol(rawValue: "applepencil.hover")
+    static var applepencilHover: SFSymbol { .init(rawValue: "applepencil.hover") }
 
     /// 􂣿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -657,7 +657,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Pencil.
-    static let applepencilSqueeze = SFSymbol(rawValue: "applepencil.squeeze")
+    static var applepencilSqueeze: SFSymbol { .init(rawValue: "applepencil.squeeze") }
 
     /// 􂠼
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -667,7 +667,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchCaseSizes = SFSymbol(rawValue: "applewatch.case.sizes")
+    static var applewatchCaseSizes: SFSymbol { .init(rawValue: "applewatch.case.sizes") }
 
     /// 􂁣
     /// Single Localization, 2 Layersets
@@ -675,7 +675,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arcadeStickAndArrowLeftAndArrowRightOutward = SFSymbol(rawValue: "arcade.stick.and.arrow.left.and.arrow.right.outward")
+    static var arcadeStickAndArrowLeftAndArrowRightOutward: SFSymbol { .init(rawValue: "arcade.stick.and.arrow.left.and.arrow.right.outward") }
 
     /// 􂚧
     /// Single Localization, 2 Layersets
@@ -683,7 +683,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowBackwardCircleDotted = SFSymbol(rawValue: "arrow.backward.circle.dotted")
+    static var arrowBackwardCircleDotted: SFSymbol { .init(rawValue: "arrow.backward.circle.dotted") }
 
     /// 􂂥
     /// Single Localization, 2 Layersets
@@ -691,7 +691,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownBackwardAndArrowUpForwardRectangle = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.rectangle")
+    static var arrowDownBackwardAndArrowUpForwardRectangle: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.rectangle") }
 
     /// 􂂦
     /// Single Localization, 3 Layersets
@@ -700,7 +700,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownBackwardAndArrowUpForwardRectangleFill = SFSymbol(rawValue: "arrow.down.backward.and.arrow.up.forward.rectangle.fill")
+    static var arrowDownBackwardAndArrowUpForwardRectangleFill: SFSymbol { .init(rawValue: "arrow.down.backward.and.arrow.up.forward.rectangle.fill") }
 
     /// 􂚰
     /// Single Localization, 2 Layersets
@@ -708,7 +708,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownBackwardCircleDotted = SFSymbol(rawValue: "arrow.down.backward.circle.dotted")
+    static var arrowDownBackwardCircleDotted: SFSymbol { .init(rawValue: "arrow.down.backward.circle.dotted") }
 
     /// 􀈽
     /// Single Localization, 2 Layersets
@@ -716,7 +716,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownDocument = SFSymbol(rawValue: "arrow.down.document")
+    static var arrowDownDocument: SFSymbol { .init(rawValue: "arrow.down.document") }
 
     /// 􀈾
     /// Single Localization, 3 Layersets
@@ -725,7 +725,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownDocumentFill = SFSymbol(rawValue: "arrow.down.document.fill")
+    static var arrowDownDocumentFill: SFSymbol { .init(rawValue: "arrow.down.document.fill") }
 
     /// 􂬞
     /// Single Localization, 2 Layersets
@@ -733,7 +733,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownForwardAndArrowUpBackwardRectangle = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.rectangle")
+    static var arrowDownForwardAndArrowUpBackwardRectangle: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.rectangle") }
 
     /// 􂬟
     /// Single Localization, 3 Layersets
@@ -742,7 +742,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownForwardAndArrowUpBackwardRectangleFill = SFSymbol(rawValue: "arrow.down.forward.and.arrow.up.backward.rectangle.fill")
+    static var arrowDownForwardAndArrowUpBackwardRectangleFill: SFSymbol { .init(rawValue: "arrow.down.forward.and.arrow.up.backward.rectangle.fill") }
 
     /// 􂛴
     /// Single Localization, 2 Layersets
@@ -750,7 +750,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownForwardCircleDotted = SFSymbol(rawValue: "arrow.down.forward.circle.dotted")
+    static var arrowDownForwardCircleDotted: SFSymbol { .init(rawValue: "arrow.down.forward.circle.dotted") }
 
     /// 􂂣
     /// Single Localization, 2 Layersets
@@ -758,7 +758,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftAndArrowUpRightRectangle = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.rectangle")
+    static var arrowDownLeftAndArrowUpRightRectangle: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.rectangle") }
 
     /// 􂂤
     /// Single Localization, 3 Layersets
@@ -767,7 +767,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownLeftAndArrowUpRightRectangleFill = SFSymbol(rawValue: "arrow.down.left.and.arrow.up.right.rectangle.fill")
+    static var arrowDownLeftAndArrowUpRightRectangleFill: SFSymbol { .init(rawValue: "arrow.down.left.and.arrow.up.right.rectangle.fill") }
 
     /// 􂚯
     /// Single Localization, 2 Layersets
@@ -775,7 +775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownLeftCircleDotted = SFSymbol(rawValue: "arrow.down.left.circle.dotted")
+    static var arrowDownLeftCircleDotted: SFSymbol { .init(rawValue: "arrow.down.left.circle.dotted") }
 
     /// 􂬜
     /// Single Localization, 2 Layersets
@@ -783,7 +783,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownRightAndArrowUpLeftRectangle = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.rectangle")
+    static var arrowDownRightAndArrowUpLeftRectangle: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.rectangle") }
 
     /// 􂬝
     /// Single Localization, 3 Layersets
@@ -792,7 +792,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownRightAndArrowUpLeftRectangleFill = SFSymbol(rawValue: "arrow.down.right.and.arrow.up.left.rectangle.fill")
+    static var arrowDownRightAndArrowUpLeftRectangleFill: SFSymbol { .init(rawValue: "arrow.down.right.and.arrow.up.left.rectangle.fill") }
 
     /// 􂛳
     /// Single Localization, 2 Layersets
@@ -800,7 +800,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowDownRightCircleDotted = SFSymbol(rawValue: "arrow.down.right.circle.dotted")
+    static var arrowDownRightCircleDotted: SFSymbol { .init(rawValue: "arrow.down.right.circle.dotted") }
 
     /// 􂚩
     /// Single Localization, 2 Layersets
@@ -808,7 +808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowForwardCircleDotted = SFSymbol(rawValue: "arrow.forward.circle.dotted")
+    static var arrowForwardCircleDotted: SFSymbol { .init(rawValue: "arrow.forward.circle.dotted") }
 
     /// 􂚦
     /// Single Localization, 2 Layersets
@@ -816,7 +816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowLeftCircleDotted = SFSymbol(rawValue: "arrow.left.circle.dotted")
+    static var arrowLeftCircleDotted: SFSymbol { .init(rawValue: "arrow.left.circle.dotted") }
 
     /// 􂚨
     /// Single Localization, 2 Layersets
@@ -824,14 +824,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowRightCircleDotted = SFSymbol(rawValue: "arrow.right.circle.dotted")
+    static var arrowRightCircleDotted: SFSymbol { .init(rawValue: "arrow.right.circle.dotted") }
 
     /// 􂧿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowRightFilledFilterArrowRight = SFSymbol(rawValue: "arrow.right.filled.filter.arrow.right")
+    static var arrowRightFilledFilterArrowRight: SFSymbol { .init(rawValue: "arrow.right.filled.filter.arrow.right") }
 
     /// 􀫵
     /// Single Localization, 3 Layersets
@@ -840,21 +840,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowRightPageOnClipboard = SFSymbol(rawValue: "arrow.right.page.on.clipboard")
+    static var arrowRightPageOnClipboard: SFSymbol { .init(rawValue: "arrow.right.page.on.clipboard") }
 
     /// 􂣼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTrianglehead2Clockwise = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise")
+    static var arrowTrianglehead2Clockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise") }
 
     /// 􀊯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTrianglehead2ClockwiseRotate90 = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90")
+    static var arrowTrianglehead2ClockwiseRotate90: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90") }
 
     /// 􀌢
     /// Single Localization, 2 Layersets
@@ -862,7 +862,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTrianglehead2ClockwiseRotate90Camera = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.camera")
+    static var arrowTrianglehead2ClockwiseRotate90Camera: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.camera") }
 
     /// 􀌣
     /// Single Localization, 3 Layersets
@@ -871,7 +871,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowTrianglehead2ClockwiseRotate90CameraFill = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.camera.fill")
+    static var arrowTrianglehead2ClockwiseRotate90CameraFill: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.camera.fill") }
 
     /// 􀖊
     /// Single Localization, 2 Layersets
@@ -879,7 +879,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTrianglehead2ClockwiseRotate90Circle = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.circle")
+    static var arrowTrianglehead2ClockwiseRotate90Circle: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.circle") }
 
     /// 􀖋
     /// Single Localization, 3 Layersets
@@ -888,7 +888,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowTrianglehead2ClockwiseRotate90CircleFill = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.circle.fill")
+    static var arrowTrianglehead2ClockwiseRotate90CircleFill: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.circle.fill") }
 
     /// 􂆍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -898,7 +898,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTrianglehead2ClockwiseRotate90Icloud = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.icloud")
+    static var arrowTrianglehead2ClockwiseRotate90Icloud: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.icloud") }
 
     /// 􂆎
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -909,7 +909,7 @@ public extension SFSymbol {
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTrianglehead2ClockwiseRotate90IcloudFill = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.icloud.fill")
+    static var arrowTrianglehead2ClockwiseRotate90IcloudFill: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.icloud.fill") }
 
     /// 􀫷
     /// Single Localization, 3 Layersets
@@ -918,42 +918,42 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowTrianglehead2ClockwiseRotate90PageOnClipboard = SFSymbol(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.page.on.clipboard")
+    static var arrowTrianglehead2ClockwiseRotate90PageOnClipboard: SFSymbol { .init(rawValue: "arrow.trianglehead.2.clockwise.rotate.90.page.on.clipboard") }
 
     /// 􂣽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTrianglehead2Counterclockwise = SFSymbol(rawValue: "arrow.trianglehead.2.counterclockwise")
+    static var arrowTrianglehead2Counterclockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.2.counterclockwise") }
 
     /// 􂣾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTrianglehead2CounterclockwiseRotate90 = SFSymbol(rawValue: "arrow.trianglehead.2.counterclockwise.rotate.90")
+    static var arrowTrianglehead2CounterclockwiseRotate90: SFSymbol { .init(rawValue: "arrow.trianglehead.2.counterclockwise.rotate.90") }
 
     /// 􀤗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadBottomleftCapsulepathClockwise = SFSymbol(rawValue: "arrow.trianglehead.bottomleft.capsulepath.clockwise")
+    static var arrowTriangleheadBottomleftCapsulepathClockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.bottomleft.capsulepath.clockwise") }
 
     /// 􀙠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadBranch = SFSymbol(rawValue: "arrow.trianglehead.branch")
+    static var arrowTriangleheadBranch: SFSymbol { .init(rawValue: "arrow.trianglehead.branch") }
 
     /// 􀍿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadClockwise = SFSymbol(rawValue: "arrow.trianglehead.clockwise")
+    static var arrowTriangleheadClockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise") }
 
     /// 􀧡
     /// Single Localization, 2 Layersets
@@ -961,7 +961,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadClockwiseHeart = SFSymbol(rawValue: "arrow.trianglehead.clockwise.heart")
+    static var arrowTriangleheadClockwiseHeart: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise.heart") }
 
     /// 􀧢
     /// Single Localization, 3 Layersets
@@ -970,7 +970,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowTriangleheadClockwiseHeartFill = SFSymbol(rawValue: "arrow.trianglehead.clockwise.heart.fill")
+    static var arrowTriangleheadClockwiseHeartFill: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise.heart.fill") }
 
     /// 􀙷
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -980,7 +980,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTriangleheadClockwiseIcloud = SFSymbol(rawValue: "arrow.trianglehead.clockwise.icloud")
+    static var arrowTriangleheadClockwiseIcloud: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise.icloud") }
 
     /// 􀙸
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -991,21 +991,21 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTriangleheadClockwiseIcloudFill = SFSymbol(rawValue: "arrow.trianglehead.clockwise.icloud.fill")
+    static var arrowTriangleheadClockwiseIcloudFill: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise.icloud.fill") }
 
     /// 􂝔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadClockwiseRotate90 = SFSymbol(rawValue: "arrow.trianglehead.clockwise.rotate.90")
+    static var arrowTriangleheadClockwiseRotate90: SFSymbol { .init(rawValue: "arrow.trianglehead.clockwise.rotate.90") }
 
     /// 􀎀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadCounterclockwise = SFSymbol(rawValue: "arrow.trianglehead.counterclockwise")
+    static var arrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.counterclockwise") }
 
     /// 􀙹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1015,7 +1015,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTriangleheadCounterclockwiseIcloud = SFSymbol(rawValue: "arrow.trianglehead.counterclockwise.icloud")
+    static var arrowTriangleheadCounterclockwiseIcloud: SFSymbol { .init(rawValue: "arrow.trianglehead.counterclockwise.icloud") }
 
     /// 􀙺
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1026,14 +1026,14 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let arrowTriangleheadCounterclockwiseIcloudFill = SFSymbol(rawValue: "arrow.trianglehead.counterclockwise.icloud.fill")
+    static var arrowTriangleheadCounterclockwiseIcloudFill: SFSymbol { .init(rawValue: "arrow.trianglehead.counterclockwise.icloud.fill") }
 
     /// 􁹠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "arrow.trianglehead.counterclockwise.rotate.90")
+    static var arrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􀞒
     /// Single Localization, 2 Layersets
@@ -1041,7 +1041,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRight = SFSymbol(rawValue: "arrow.trianglehead.left.and.right.righttriangle.left.righttriangle.right")
+    static var arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRight: SFSymbol { .init(rawValue: "arrow.trianglehead.left.and.right.righttriangle.left.righttriangle.right") }
 
     /// 􀞓
     /// Single Localization, 2 Layersets
@@ -1049,42 +1049,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill = SFSymbol(rawValue: "arrow.trianglehead.left.and.right.righttriangle.left.righttriangle.right.fill")
+    static var arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill: SFSymbol { .init(rawValue: "arrow.trianglehead.left.and.right.righttriangle.left.righttriangle.right.fill") }
 
     /// 􀖄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadMerge = SFSymbol(rawValue: "arrow.trianglehead.merge")
+    static var arrowTriangleheadMerge: SFSymbol { .init(rawValue: "arrow.trianglehead.merge") }
 
     /// 􀙡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadPull = SFSymbol(rawValue: "arrow.trianglehead.pull")
+    static var arrowTriangleheadPull: SFSymbol { .init(rawValue: "arrow.trianglehead.pull") }
 
     /// 􀣁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadRectanglepath = SFSymbol(rawValue: "arrow.trianglehead.rectanglepath")
+    static var arrowTriangleheadRectanglepath: SFSymbol { .init(rawValue: "arrow.trianglehead.rectanglepath") }
 
     /// 􀖅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadSwap = SFSymbol(rawValue: "arrow.trianglehead.swap")
+    static var arrowTriangleheadSwap: SFSymbol { .init(rawValue: "arrow.trianglehead.swap") }
 
     /// 􀤖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadToprightCapsulepathClockwise = SFSymbol(rawValue: "arrow.trianglehead.topright.capsulepath.clockwise")
+    static var arrowTriangleheadToprightCapsulepathClockwise: SFSymbol { .init(rawValue: "arrow.trianglehead.topright.capsulepath.clockwise") }
 
     /// 􀟷
     /// Single Localization, 3 Layersets
@@ -1093,7 +1093,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let arrowTriangleheadTurnUpRightCircle = SFSymbol(rawValue: "arrow.trianglehead.turn.up.right.circle")
+    static var arrowTriangleheadTurnUpRightCircle: SFSymbol { .init(rawValue: "arrow.trianglehead.turn.up.right.circle") }
 
     /// 􀟸
     /// Single Localization, 3 Layersets
@@ -1102,7 +1102,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let arrowTriangleheadTurnUpRightCircleFill = SFSymbol(rawValue: "arrow.trianglehead.turn.up.right.circle.fill")
+    static var arrowTriangleheadTurnUpRightCircleFill: SFSymbol { .init(rawValue: "arrow.trianglehead.turn.up.right.circle.fill") }
 
     /// 􀙞
     /// Single Localization, 2 Layersets
@@ -1110,7 +1110,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadTurnUpRightDiamond = SFSymbol(rawValue: "arrow.trianglehead.turn.up.right.diamond")
+    static var arrowTriangleheadTurnUpRightDiamond: SFSymbol { .init(rawValue: "arrow.trianglehead.turn.up.right.diamond") }
 
     /// 􀙟
     /// Single Localization, 3 Layersets
@@ -1119,7 +1119,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowTriangleheadTurnUpRightDiamondFill = SFSymbol(rawValue: "arrow.trianglehead.turn.up.right.diamond.fill")
+    static var arrowTriangleheadTurnUpRightDiamondFill: SFSymbol { .init(rawValue: "arrow.trianglehead.turn.up.right.diamond.fill") }
 
     /// 􀟨
     /// Single Localization, 2 Layersets
@@ -1127,7 +1127,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDown = SFSymbol(rawValue: "arrow.trianglehead.up.and.down.righttriangle.up.righttriangle.down")
+    static var arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDown: SFSymbol { .init(rawValue: "arrow.trianglehead.up.and.down.righttriangle.up.righttriangle.down") }
 
     /// 􀟩
     /// Single Localization, 2 Layersets
@@ -1135,7 +1135,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill = SFSymbol(rawValue: "arrow.trianglehead.up.and.down.righttriangle.up.righttriangle.down.fill")
+    static var arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill: SFSymbol { .init(rawValue: "arrow.trianglehead.up.and.down.righttriangle.up.righttriangle.down.fill") }
 
     /// 􂂡
     /// Single Localization, 2 Layersets
@@ -1143,7 +1143,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpBackwardAndArrowDownForwardRectangle = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.rectangle")
+    static var arrowUpBackwardAndArrowDownForwardRectangle: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.rectangle") }
 
     /// 􂂢
     /// Single Localization, 3 Layersets
@@ -1152,7 +1152,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpBackwardAndArrowDownForwardRectangleFill = SFSymbol(rawValue: "arrow.up.backward.and.arrow.down.forward.rectangle.fill")
+    static var arrowUpBackwardAndArrowDownForwardRectangleFill: SFSymbol { .init(rawValue: "arrow.up.backward.and.arrow.down.forward.rectangle.fill") }
 
     /// 􂚬
     /// Single Localization, 2 Layersets
@@ -1160,7 +1160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpBackwardCircleDotted = SFSymbol(rawValue: "arrow.up.backward.circle.dotted")
+    static var arrowUpBackwardCircleDotted: SFSymbol { .init(rawValue: "arrow.up.backward.circle.dotted") }
 
     /// 􂚪
     /// Single Localization, 2 Layersets
@@ -1168,7 +1168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpCircleDotted = SFSymbol(rawValue: "arrow.up.circle.dotted")
+    static var arrowUpCircleDotted: SFSymbol { .init(rawValue: "arrow.up.circle.dotted") }
 
     /// 􀈻
     /// Single Localization, 2 Layersets
@@ -1176,7 +1176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpDocument = SFSymbol(rawValue: "arrow.up.document")
+    static var arrowUpDocument: SFSymbol { .init(rawValue: "arrow.up.document") }
 
     /// 􀈼
     /// Single Localization, 3 Layersets
@@ -1185,7 +1185,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpDocumentFill = SFSymbol(rawValue: "arrow.up.document.fill")
+    static var arrowUpDocumentFill: SFSymbol { .init(rawValue: "arrow.up.document.fill") }
 
     /// 􂬢
     /// Single Localization, 2 Layersets
@@ -1193,7 +1193,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpForwardAndArrowDownBackwardRectangle = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.rectangle")
+    static var arrowUpForwardAndArrowDownBackwardRectangle: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.rectangle") }
 
     /// 􂬣
     /// Single Localization, 3 Layersets
@@ -1202,7 +1202,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpForwardAndArrowDownBackwardRectangleFill = SFSymbol(rawValue: "arrow.up.forward.and.arrow.down.backward.rectangle.fill")
+    static var arrowUpForwardAndArrowDownBackwardRectangleFill: SFSymbol { .init(rawValue: "arrow.up.forward.and.arrow.down.backward.rectangle.fill") }
 
     /// 􂚮
     /// Single Localization, 2 Layersets
@@ -1210,7 +1210,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpForwardCircleDotted = SFSymbol(rawValue: "arrow.up.forward.circle.dotted")
+    static var arrowUpForwardCircleDotted: SFSymbol { .init(rawValue: "arrow.up.forward.circle.dotted") }
 
     /// 􂂟
     /// Single Localization, 2 Layersets
@@ -1218,7 +1218,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftAndArrowDownRightRectangle = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.rectangle")
+    static var arrowUpLeftAndArrowDownRightRectangle: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.rectangle") }
 
     /// 􂂠
     /// Single Localization, 3 Layersets
@@ -1227,7 +1227,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpLeftAndArrowDownRightRectangleFill = SFSymbol(rawValue: "arrow.up.left.and.arrow.down.right.rectangle.fill")
+    static var arrowUpLeftAndArrowDownRightRectangleFill: SFSymbol { .init(rawValue: "arrow.up.left.and.arrow.down.right.rectangle.fill") }
 
     /// 􂚫
     /// Single Localization, 2 Layersets
@@ -1235,7 +1235,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpLeftCircleDotted = SFSymbol(rawValue: "arrow.up.left.circle.dotted")
+    static var arrowUpLeftCircleDotted: SFSymbol { .init(rawValue: "arrow.up.left.circle.dotted") }
 
     /// 􀫶
     /// Single Localization, 3 Layersets
@@ -1244,7 +1244,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpPageOnClipboard = SFSymbol(rawValue: "arrow.up.page.on.clipboard")
+    static var arrowUpPageOnClipboard: SFSymbol { .init(rawValue: "arrow.up.page.on.clipboard") }
 
     /// 􂚭
     /// Single Localization, 2 Layersets
@@ -1252,14 +1252,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpRightCircleDotted = SFSymbol(rawValue: "arrow.up.right.circle.dotted")
+    static var arrowUpRightCircleDotted: SFSymbol { .init(rawValue: "arrow.up.right.circle.dotted") }
 
     /// 􂒲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let australianFootball = SFSymbol(rawValue: "australian.football")
+    static var australianFootball: SFSymbol { .init(rawValue: "australian.football") }
 
     /// 􂒴
     /// Single Localization, 2 Layersets
@@ -1267,7 +1267,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australianFootballCircle = SFSymbol(rawValue: "australian.football.circle")
+    static var australianFootballCircle: SFSymbol { .init(rawValue: "australian.football.circle") }
 
     /// 􂒵
     /// Single Localization, 3 Layersets
@@ -1276,14 +1276,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let australianFootballCircleFill = SFSymbol(rawValue: "australian.football.circle.fill")
+    static var australianFootballCircleFill: SFSymbol { .init(rawValue: "australian.football.circle.fill") }
 
     /// 􂒳
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let australianFootballFill = SFSymbol(rawValue: "australian.football.fill")
+    static var australianFootballFill: SFSymbol { .init(rawValue: "australian.football.fill") }
 
     /// 􂈹
     /// Single Localization, 2 Layersets
@@ -1291,7 +1291,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "australiandollarsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var australiandollarsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "australiandollarsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂕉
     /// Single Localization, 2 Layersets
@@ -1299,7 +1299,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignBankBuilding = SFSymbol(rawValue: "australiandollarsign.bank.building")
+    static var australiandollarsignBankBuilding: SFSymbol { .init(rawValue: "australiandollarsign.bank.building") }
 
     /// 􂕊
     /// Single Localization, 3 Layersets
@@ -1308,7 +1308,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let australiandollarsignBankBuildingFill = SFSymbol(rawValue: "australiandollarsign.bank.building.fill")
+    static var australiandollarsignBankBuildingFill: SFSymbol { .init(rawValue: "australiandollarsign.bank.building.fill") }
 
     /// 􂨼
     /// Single Localization, 2 Layersets
@@ -1316,7 +1316,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "australiandollarsign.gauge.chart.lefthalf.righthalf")
+    static var australiandollarsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "australiandollarsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩦
     /// Single Localization, 2 Layersets
@@ -1324,7 +1324,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "australiandollarsign.gauge.chart.leftthird.topthird.rightthird")
+    static var australiandollarsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "australiandollarsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰌
     /// Single Localization, 2 Layersets
@@ -1332,7 +1332,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignRing = SFSymbol(rawValue: "australiandollarsign.ring")
+    static var australiandollarsignRing: SFSymbol { .init(rawValue: "australiandollarsign.ring") }
 
     /// 􂯢
     /// Single Localization, 2 Layersets
@@ -1340,7 +1340,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australiandollarsignRingDashed = SFSymbol(rawValue: "australiandollarsign.ring.dashed")
+    static var australiandollarsignRingDashed: SFSymbol { .init(rawValue: "australiandollarsign.ring.dashed") }
 
     /// 􂈣
     /// Single Localization, 2 Layersets
@@ -1348,7 +1348,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "australsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var australsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "australsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔝
     /// Single Localization, 2 Layersets
@@ -1356,7 +1356,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignBankBuilding = SFSymbol(rawValue: "australsign.bank.building")
+    static var australsignBankBuilding: SFSymbol { .init(rawValue: "australsign.bank.building") }
 
     /// 􂔞
     /// Single Localization, 3 Layersets
@@ -1365,7 +1365,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let australsignBankBuildingFill = SFSymbol(rawValue: "australsign.bank.building.fill")
+    static var australsignBankBuildingFill: SFSymbol { .init(rawValue: "australsign.bank.building.fill") }
 
     /// 􂨻
     /// Single Localization, 2 Layersets
@@ -1373,7 +1373,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "australsign.gauge.chart.lefthalf.righthalf")
+    static var australsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "australsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩥
     /// Single Localization, 2 Layersets
@@ -1381,7 +1381,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "australsign.gauge.chart.leftthird.topthird.rightthird")
+    static var australsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "australsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰋
     /// Single Localization, 2 Layersets
@@ -1389,7 +1389,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignRing = SFSymbol(rawValue: "australsign.ring")
+    static var australsignRing: SFSymbol { .init(rawValue: "australsign.ring") }
 
     /// 􂯡
     /// Single Localization, 2 Layersets
@@ -1397,7 +1397,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let australsignRingDashed = SFSymbol(rawValue: "australsign.ring.dashed")
+    static var australsignRingDashed: SFSymbol { .init(rawValue: "australsign.ring.dashed") }
 
     /// 􂈯
     /// Single Localization, 2 Layersets
@@ -1405,7 +1405,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "bahtsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var bahtsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "bahtsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔵
     /// Single Localization, 2 Layersets
@@ -1413,7 +1413,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignBankBuilding = SFSymbol(rawValue: "bahtsign.bank.building")
+    static var bahtsignBankBuilding: SFSymbol { .init(rawValue: "bahtsign.bank.building") }
 
     /// 􂔶
     /// Single Localization, 3 Layersets
@@ -1422,7 +1422,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bahtsignBankBuildingFill = SFSymbol(rawValue: "bahtsign.bank.building.fill")
+    static var bahtsignBankBuildingFill: SFSymbol { .init(rawValue: "bahtsign.bank.building.fill") }
 
     /// 􂨽
     /// Single Localization, 2 Layersets
@@ -1430,7 +1430,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "bahtsign.gauge.chart.lefthalf.righthalf")
+    static var bahtsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "bahtsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩧
     /// Single Localization, 2 Layersets
@@ -1438,7 +1438,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "bahtsign.gauge.chart.leftthird.topthird.rightthird")
+    static var bahtsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "bahtsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰍
     /// Single Localization, 2 Layersets
@@ -1446,7 +1446,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignRing = SFSymbol(rawValue: "bahtsign.ring")
+    static var bahtsignRing: SFSymbol { .init(rawValue: "bahtsign.ring") }
 
     /// 􂯣
     /// Single Localization, 2 Layersets
@@ -1454,28 +1454,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bahtsignRingDashed = SFSymbol(rawValue: "bahtsign.ring.dashed")
+    static var bahtsignRingDashed: SFSymbol { .init(rawValue: "bahtsign.ring.dashed") }
 
     /// 􂭎
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let baseUnit = SFSymbol(rawValue: "base.unit")
+    static var baseUnit: SFSymbol { .init(rawValue: "base.unit") }
 
     /// 􂜥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let baseballDiamondBasesOutsIndicator = SFSymbol(rawValue: "baseball.diamond.bases.outs.indicator")
+    static var baseballDiamondBasesOutsIndicator: SFSymbol { .init(rawValue: "baseball.diamond.bases.outs.indicator") }
 
     /// 􂙗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let batteryblockStack = SFSymbol(rawValue: "batteryblock.stack")
+    static var batteryblockStack: SFSymbol { .init(rawValue: "batteryblock.stack") }
 
     /// 􂘙
     /// Single Localization, 2 Layersets
@@ -1483,7 +1483,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let batteryblockStackBadgeSnowflake = SFSymbol(rawValue: "batteryblock.stack.badge.snowflake")
+    static var batteryblockStackBadgeSnowflake: SFSymbol { .init(rawValue: "batteryblock.stack.badge.snowflake") }
 
     /// 􂛯
     /// Single Localization, 2 Layersets
@@ -1491,14 +1491,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let batteryblockStackBadgeSnowflakeFill = SFSymbol(rawValue: "batteryblock.stack.badge.snowflake.fill")
+    static var batteryblockStackBadgeSnowflakeFill: SFSymbol { .init(rawValue: "batteryblock.stack.badge.snowflake.fill") }
 
     /// 􂙘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let batteryblockStackFill = SFSymbol(rawValue: "batteryblock.stack.fill")
+    static var batteryblockStackFill: SFSymbol { .init(rawValue: "batteryblock.stack.fill") }
 
     /// 􂘚
     /// Single Localization, 3 Layersets
@@ -1507,7 +1507,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let batteryblockStackTrianglebadgeExclamationmark = SFSymbol(rawValue: "batteryblock.stack.trianglebadge.exclamationmark")
+    static var batteryblockStackTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "batteryblock.stack.trianglebadge.exclamationmark") }
 
     /// 􂛱
     /// Single Localization, 3 Layersets
@@ -1516,7 +1516,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let batteryblockStackTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "batteryblock.stack.trianglebadge.exclamationmark.fill")
+    static var batteryblockStackTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "batteryblock.stack.trianglebadge.exclamationmark.fill") }
 
     /// 􀹭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1526,7 +1526,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro.
-    static let beatsPowerbeatsPro = SFSymbol(rawValue: "beats.powerbeats.pro")
+    static var beatsPowerbeatsPro: SFSymbol { .init(rawValue: "beats.powerbeats.pro") }
 
     /// 􀹰
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1535,7 +1535,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro case.
-    static let beatsPowerbeatsProChargingcase = SFSymbol(rawValue: "beats.powerbeats.pro.chargingcase")
+    static var beatsPowerbeatsProChargingcase: SFSymbol { .init(rawValue: "beats.powerbeats.pro.chargingcase") }
 
     /// 􀹱
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1544,7 +1544,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro case.
-    static let beatsPowerbeatsProChargingcaseFill = SFSymbol(rawValue: "beats.powerbeats.pro.chargingcase.fill")
+    static var beatsPowerbeatsProChargingcaseFill: SFSymbol { .init(rawValue: "beats.powerbeats.pro.chargingcase.fill") }
 
     /// 􀹯
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1554,7 +1554,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro.
-    static let beatsPowerbeatsProLeft = SFSymbol(rawValue: "beats.powerbeats.pro.left")
+    static var beatsPowerbeatsProLeft: SFSymbol { .init(rawValue: "beats.powerbeats.pro.left") }
 
     /// 􀹮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1564,7 +1564,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro.
-    static let beatsPowerbeatsProRight = SFSymbol(rawValue: "beats.powerbeats.pro.right")
+    static var beatsPowerbeatsProRight: SFSymbol { .init(rawValue: "beats.powerbeats.pro.right") }
 
     /// 􀾣
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1574,7 +1574,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds.
-    static let beatsStudiobudsLeft = SFSymbol(rawValue: "beats.studiobuds.left")
+    static var beatsStudiobudsLeft: SFSymbol { .init(rawValue: "beats.studiobuds.left") }
 
     /// 􁹳
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1584,7 +1584,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds Plus.
-    static let beatsStudiobudsPlus = SFSymbol(rawValue: "beats.studiobuds.plus")
+    static var beatsStudiobudsPlus: SFSymbol { .init(rawValue: "beats.studiobuds.plus") }
 
     /// 􁹶
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1593,7 +1593,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds Plus case.
-    static let beatsStudiobudsPlusChargingcase = SFSymbol(rawValue: "beats.studiobuds.plus.chargingcase")
+    static var beatsStudiobudsPlusChargingcase: SFSymbol { .init(rawValue: "beats.studiobuds.plus.chargingcase") }
 
     /// 􁹷
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1602,7 +1602,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds Plus case.
-    static let beatsStudiobudsPlusChargingcaseFill = SFSymbol(rawValue: "beats.studiobuds.plus.chargingcase.fill")
+    static var beatsStudiobudsPlusChargingcaseFill: SFSymbol { .init(rawValue: "beats.studiobuds.plus.chargingcase.fill") }
 
     /// 􁹴
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1612,7 +1612,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds Plus.
-    static let beatsStudiobudsPlusLeft = SFSymbol(rawValue: "beats.studiobuds.plus.left")
+    static var beatsStudiobudsPlusLeft: SFSymbol { .init(rawValue: "beats.studiobuds.plus.left") }
 
     /// 􁹵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1622,7 +1622,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds Plus.
-    static let beatsStudiobudsPlusRight = SFSymbol(rawValue: "beats.studiobuds.plus.right")
+    static var beatsStudiobudsPlusRight: SFSymbol { .init(rawValue: "beats.studiobuds.plus.right") }
 
     /// 􀾤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1632,14 +1632,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Studio Buds.
-    static let beatsStudiobudsRight = SFSymbol(rawValue: "beats.studiobuds.right")
+    static var beatsStudiobudsRight: SFSymbol { .init(rawValue: "beats.studiobuds.right") }
 
     /// 􀜢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let beziercurve = SFSymbol(rawValue: "beziercurve")
+    static var beziercurve: SFSymbol { .init(rawValue: "beziercurve") }
 
     /// 􂈱
     /// Single Localization, 2 Layersets
@@ -1647,7 +1647,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "bitcoinsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var bitcoinsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "bitcoinsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔹
     /// Single Localization, 2 Layersets
@@ -1655,7 +1655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignBankBuilding = SFSymbol(rawValue: "bitcoinsign.bank.building")
+    static var bitcoinsignBankBuilding: SFSymbol { .init(rawValue: "bitcoinsign.bank.building") }
 
     /// 􂔺
     /// Single Localization, 3 Layersets
@@ -1664,7 +1664,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bitcoinsignBankBuildingFill = SFSymbol(rawValue: "bitcoinsign.bank.building.fill")
+    static var bitcoinsignBankBuildingFill: SFSymbol { .init(rawValue: "bitcoinsign.bank.building.fill") }
 
     /// 􂨾
     /// Single Localization, 2 Layersets
@@ -1672,7 +1672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "bitcoinsign.gauge.chart.lefthalf.righthalf")
+    static var bitcoinsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "bitcoinsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩨
     /// Single Localization, 2 Layersets
@@ -1680,7 +1680,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "bitcoinsign.gauge.chart.leftthird.topthird.rightthird")
+    static var bitcoinsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "bitcoinsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰎
     /// Single Localization, 2 Layersets
@@ -1688,7 +1688,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignRing = SFSymbol(rawValue: "bitcoinsign.ring")
+    static var bitcoinsignRing: SFSymbol { .init(rawValue: "bitcoinsign.ring") }
 
     /// 􂯤
     /// Single Localization, 2 Layersets
@@ -1696,7 +1696,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bitcoinsignRingDashed = SFSymbol(rawValue: "bitcoinsign.ring.dashed")
+    static var bitcoinsignRingDashed: SFSymbol { .init(rawValue: "bitcoinsign.ring.dashed") }
 
     /// 􂈲
     /// Single Localization, 2 Layersets
@@ -1704,7 +1704,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "brazilianrealsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var brazilianrealsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "brazilianrealsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔻
     /// Single Localization, 2 Layersets
@@ -1712,7 +1712,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignBankBuilding = SFSymbol(rawValue: "brazilianrealsign.bank.building")
+    static var brazilianrealsignBankBuilding: SFSymbol { .init(rawValue: "brazilianrealsign.bank.building") }
 
     /// 􂔼
     /// Single Localization, 3 Layersets
@@ -1721,7 +1721,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let brazilianrealsignBankBuildingFill = SFSymbol(rawValue: "brazilianrealsign.bank.building.fill")
+    static var brazilianrealsignBankBuildingFill: SFSymbol { .init(rawValue: "brazilianrealsign.bank.building.fill") }
 
     /// 􂨿
     /// Single Localization, 2 Layersets
@@ -1729,7 +1729,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "brazilianrealsign.gauge.chart.lefthalf.righthalf")
+    static var brazilianrealsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "brazilianrealsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩩
     /// Single Localization, 2 Layersets
@@ -1737,7 +1737,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "brazilianrealsign.gauge.chart.leftthird.topthird.rightthird")
+    static var brazilianrealsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "brazilianrealsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰏
     /// Single Localization, 2 Layersets
@@ -1745,7 +1745,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignRing = SFSymbol(rawValue: "brazilianrealsign.ring")
+    static var brazilianrealsignRing: SFSymbol { .init(rawValue: "brazilianrealsign.ring") }
 
     /// 􂯥
     /// Single Localization, 2 Layersets
@@ -1753,7 +1753,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let brazilianrealsignRingDashed = SFSymbol(rawValue: "brazilianrealsign.ring.dashed")
+    static var brazilianrealsignRingDashed: SFSymbol { .init(rawValue: "brazilianrealsign.ring.dashed") }
 
     /// 􂛥
     /// 2 Localizations, 2 Layersets
@@ -1765,7 +1765,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bubbleAndPencil = SymbolWith1Localization<Rtl>(rawValue: "bubble.and.pencil")
+    static var bubbleAndPencil: SymbolWith1Localization<Rtl> { .init(rawValue: "bubble.and.pencil") }
 
     /// 􂕝
     /// Single Localization, 3 Layersets
@@ -1774,7 +1774,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let calendarAndPerson = SFSymbol(rawValue: "calendar.and.person")
+    static var calendarAndPerson: SFSymbol { .init(rawValue: "calendar.and.person") }
 
     /// 􂏝
     /// Single Localization, 2 Layersets
@@ -1782,7 +1782,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraMacroSlash = SFSymbol(rawValue: "camera.macro.slash")
+    static var cameraMacroSlash: SFSymbol { .init(rawValue: "camera.macro.slash") }
 
     /// 􂏞
     /// Single Localization, 2 Layersets
@@ -1790,7 +1790,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraMacroSlashCircle = SFSymbol(rawValue: "camera.macro.slash.circle")
+    static var cameraMacroSlashCircle: SFSymbol { .init(rawValue: "camera.macro.slash.circle") }
 
     /// 􂏟
     /// Single Localization, 3 Layersets
@@ -1799,7 +1799,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cameraMacroSlashCircleFill = SFSymbol(rawValue: "camera.macro.slash.circle.fill")
+    static var cameraMacroSlashCircleFill: SFSymbol { .init(rawValue: "camera.macro.slash.circle.fill") }
 
     /// 􂘯
     /// Single Localization, 2 Layersets
@@ -1807,7 +1807,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let capsuleOnCapsule = SFSymbol(rawValue: "capsule.on.capsule")
+    static var capsuleOnCapsule: SFSymbol { .init(rawValue: "capsule.on.capsule") }
 
     /// 􂘰
     /// Single Localization, 2 Layersets
@@ -1815,7 +1815,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let capsuleOnCapsuleFill = SFSymbol(rawValue: "capsule.on.capsule.fill")
+    static var capsuleOnCapsuleFill: SFSymbol { .init(rawValue: "capsule.on.capsule.fill") }
 
     /// 􂘱
     /// Single Localization, 2 Layersets
@@ -1823,7 +1823,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let capsuleOnRectangle = SFSymbol(rawValue: "capsule.on.rectangle")
+    static var capsuleOnRectangle: SFSymbol { .init(rawValue: "capsule.on.rectangle") }
 
     /// 􂘲
     /// Single Localization, 2 Layersets
@@ -1831,7 +1831,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let capsuleOnRectangleFill = SFSymbol(rawValue: "capsule.on.rectangle.fill")
+    static var capsuleOnRectangleFill: SFSymbol { .init(rawValue: "capsule.on.rectangle.fill") }
 
     /// 􂤭
     /// Single Localization, 2 Layersets
@@ -1839,7 +1839,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carBadgeGearshape = SFSymbol(rawValue: "car.badge.gearshape")
+    static var carBadgeGearshape: SFSymbol { .init(rawValue: "car.badge.gearshape") }
 
     /// 􂤮
     /// Single Localization, 2 Layersets
@@ -1847,7 +1847,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carBadgeGearshapeFill = SFSymbol(rawValue: "car.badge.gearshape.fill")
+    static var carBadgeGearshapeFill: SFSymbol { .init(rawValue: "car.badge.gearshape.fill") }
 
     /// 􂤻
     /// Single Localization, 2 Layersets
@@ -1855,7 +1855,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carFrontWavesLeftAndRightAndUp = SFSymbol(rawValue: "car.front.waves.left.and.right.and.up")
+    static var carFrontWavesLeftAndRightAndUp: SFSymbol { .init(rawValue: "car.front.waves.left.and.right.and.up") }
 
     /// 􂤼
     /// Single Localization, 2 Layersets
@@ -1863,7 +1863,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carFrontWavesLeftAndRightAndUpFill = SFSymbol(rawValue: "car.front.waves.left.and.right.and.up.fill")
+    static var carFrontWavesLeftAndRightAndUpFill: SFSymbol { .init(rawValue: "car.front.waves.left.and.right.and.up.fill") }
 
     /// 􂊹
     /// Single Localization, 2 Layersets
@@ -1871,7 +1871,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearAndTireMarksOff = SFSymbol(rawValue: "car.rear.and.tire.marks.off")
+    static var carRearAndTireMarksOff: SFSymbol { .init(rawValue: "car.rear.and.tire.marks.off") }
 
     /// 􂉓
     /// Single Localization, 2 Layersets
@@ -1879,7 +1879,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearHazardsign = SFSymbol(rawValue: "car.rear.hazardsign")
+    static var carRearHazardsign: SFSymbol { .init(rawValue: "car.rear.hazardsign") }
 
     /// 􂉔
     /// Single Localization, 3 Layersets
@@ -1888,7 +1888,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let carRearHazardsignFill = SFSymbol(rawValue: "car.rear.hazardsign.fill")
+    static var carRearHazardsignFill: SFSymbol { .init(rawValue: "car.rear.hazardsign.fill") }
 
     /// 􂊺
     /// Single Localization, 2 Layersets
@@ -1896,7 +1896,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance1 = SFSymbol(rawValue: "car.rear.road.lane.distance.1")
+    static var carRearRoadLaneDistance1: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.1") }
 
     /// 􂊿
     /// Single Localization, 2 Layersets
@@ -1904,7 +1904,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance1AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "car.rear.road.lane.distance.1.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var carRearRoadLaneDistance1AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.1.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􂊻
     /// Single Localization, 2 Layersets
@@ -1912,7 +1912,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance2 = SFSymbol(rawValue: "car.rear.road.lane.distance.2")
+    static var carRearRoadLaneDistance2: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.2") }
 
     /// 􂋀
     /// Single Localization, 2 Layersets
@@ -1920,7 +1920,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance2AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "car.rear.road.lane.distance.2.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var carRearRoadLaneDistance2AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.2.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􂊼
     /// Single Localization, 2 Layersets
@@ -1928,7 +1928,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance3 = SFSymbol(rawValue: "car.rear.road.lane.distance.3")
+    static var carRearRoadLaneDistance3: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.3") }
 
     /// 􂋁
     /// Single Localization, 2 Layersets
@@ -1936,7 +1936,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance3AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "car.rear.road.lane.distance.3.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var carRearRoadLaneDistance3AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.3.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􂊽
     /// Single Localization, 2 Layersets
@@ -1944,7 +1944,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance4 = SFSymbol(rawValue: "car.rear.road.lane.distance.4")
+    static var carRearRoadLaneDistance4: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.4") }
 
     /// 􂋂
     /// Single Localization, 2 Layersets
@@ -1952,7 +1952,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance4AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "car.rear.road.lane.distance.4.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var carRearRoadLaneDistance4AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.4.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􂊾
     /// Single Localization, 2 Layersets
@@ -1960,7 +1960,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance5 = SFSymbol(rawValue: "car.rear.road.lane.distance.5")
+    static var carRearRoadLaneDistance5: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.5") }
 
     /// 􂋃
     /// Single Localization, 2 Layersets
@@ -1968,7 +1968,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDistance5AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle = SFSymbol(rawValue: "car.rear.road.lane.distance.5.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle")
+    static var carRearRoadLaneDistance5AndGaugeOpenWithLinesNeedle67percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.rear.road.lane.distance.5.and.gauge.open.with.lines.needle.67percent.and.arrowtriangle") }
 
     /// 􂋌
     /// Single Localization, 2 Layersets
@@ -1976,7 +1976,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneOff = SFSymbol(rawValue: "car.rear.road.lane.off")
+    static var carRearRoadLaneOff: SFSymbol { .init(rawValue: "car.rear.road.lane.off") }
 
     /// 􂤽
     /// Single Localization, 2 Layersets
@@ -1984,7 +1984,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneWaveUp = SFSymbol(rawValue: "car.rear.road.lane.wave.up")
+    static var carRearRoadLaneWaveUp: SFSymbol { .init(rawValue: "car.rear.road.lane.wave.up") }
 
     /// 􂬱
     /// Single Localization, 2 Layersets
@@ -1992,21 +1992,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearTiltRoadLanesCurvedRight = SFSymbol(rawValue: "car.rear.tilt.road.lanes.curved.right")
+    static var carRearTiltRoadLanesCurvedRight: SFSymbol { .init(rawValue: "car.rear.tilt.road.lanes.curved.right") }
 
     /// 􂞒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideFrontOpenCrop = SFSymbol(rawValue: "car.side.front.open.crop")
+    static var carSideFrontOpenCrop: SFSymbol { .init(rawValue: "car.side.front.open.crop") }
 
     /// 􂞓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideFrontOpenCropFill = SFSymbol(rawValue: "car.side.front.open.crop.fill")
+    static var carSideFrontOpenCropFill: SFSymbol { .init(rawValue: "car.side.front.open.crop.fill") }
 
     /// 􂊦
     /// Single Localization, 2 Layersets
@@ -2014,7 +2014,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillDescentControl = SFSymbol(rawValue: "car.side.hill.descent.control")
+    static var carSideHillDescentControl: SFSymbol { .init(rawValue: "car.side.hill.descent.control") }
 
     /// 􂊧
     /// Single Localization, 2 Layersets
@@ -2022,7 +2022,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideHillDescentControlFill = SFSymbol(rawValue: "car.side.hill.descent.control.fill")
+    static var carSideHillDescentControlFill: SFSymbol { .init(rawValue: "car.side.hill.descent.control.fill") }
 
     /// 􂐁
     /// Single Localization, 2 Layersets
@@ -2030,7 +2030,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndExclamationmarkAndCarSideFrontOff = SFSymbol(rawValue: "car.side.rear.and.exclamationmark.and.car.side.front.off")
+    static var carSideRearAndExclamationmarkAndCarSideFrontOff: SFSymbol { .init(rawValue: "car.side.rear.and.exclamationmark.and.car.side.front.off") }
 
     /// 􂬬
     /// Single Localization, 2 Layersets
@@ -2038,7 +2038,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearCropTrunkPartition = SFSymbol(rawValue: "car.side.rear.crop.trunk.partition")
+    static var carSideRearCropTrunkPartition: SFSymbol { .init(rawValue: "car.side.rear.crop.trunk.partition") }
 
     /// 􂬭
     /// Single Localization, 2 Layersets
@@ -2046,35 +2046,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearCropTrunkPartitionFill = SFSymbol(rawValue: "car.side.rear.crop.trunk.partition.fill")
+    static var carSideRearCropTrunkPartitionFill: SFSymbol { .init(rawValue: "car.side.rear.crop.trunk.partition.fill") }
 
     /// 􂞔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideRearOpenCrop = SFSymbol(rawValue: "car.side.rear.open.crop")
+    static var carSideRearOpenCrop: SFSymbol { .init(rawValue: "car.side.rear.open.crop") }
 
     /// 􂞕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideRearOpenCropFill = SFSymbol(rawValue: "car.side.rear.open.crop.fill")
+    static var carSideRearOpenCropFill: SFSymbol { .init(rawValue: "car.side.rear.open.crop.fill") }
 
     /// 􂤗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideRearTowHitch = SFSymbol(rawValue: "car.side.rear.tow.hitch")
+    static var carSideRearTowHitch: SFSymbol { .init(rawValue: "car.side.rear.tow.hitch") }
 
     /// 􂤘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let carSideRearTowHitchFill = SFSymbol(rawValue: "car.side.rear.tow.hitch.fill")
+    static var carSideRearTowHitchFill: SFSymbol { .init(rawValue: "car.side.rear.tow.hitch.fill") }
 
     /// 􂊟
     /// Single Localization, 2 Layersets
@@ -2082,7 +2082,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRoofCargoCarrier = SFSymbol(rawValue: "car.side.roof.cargo.carrier")
+    static var carSideRoofCargoCarrier: SFSymbol { .init(rawValue: "car.side.roof.cargo.carrier") }
 
     /// 􂊠
     /// Single Localization, 2 Layersets
@@ -2090,7 +2090,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRoofCargoCarrierFill = SFSymbol(rawValue: "car.side.roof.cargo.carrier.fill")
+    static var carSideRoofCargoCarrierFill: SFSymbol { .init(rawValue: "car.side.roof.cargo.carrier.fill") }
 
     /// 􂙁
     /// Single Localization, 2 Layersets
@@ -2098,7 +2098,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRoofCargoCarrierSlash = SFSymbol(rawValue: "car.side.roof.cargo.carrier.slash")
+    static var carSideRoofCargoCarrierSlash: SFSymbol { .init(rawValue: "car.side.roof.cargo.carrier.slash") }
 
     /// 􂙃
     /// Single Localization, 2 Layersets
@@ -2106,7 +2106,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRoofCargoCarrierSlashFill = SFSymbol(rawValue: "car.side.roof.cargo.carrier.slash.fill")
+    static var carSideRoofCargoCarrierSlashFill: SFSymbol { .init(rawValue: "car.side.roof.cargo.carrier.slash.fill") }
 
     /// 􂂛
     /// Single Localization, 2 Layersets
@@ -2114,7 +2114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleFrontLeft = SFSymbol(rawValue: "car.top.arrowtriangle.front.left")
+    static var carTopArrowtriangleFrontLeft: SFSymbol { .init(rawValue: "car.top.arrowtriangle.front.left") }
 
     /// 􂂜
     /// Single Localization, 2 Layersets
@@ -2122,7 +2122,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleFrontLeftFill = SFSymbol(rawValue: "car.top.arrowtriangle.front.left.fill")
+    static var carTopArrowtriangleFrontLeftFill: SFSymbol { .init(rawValue: "car.top.arrowtriangle.front.left.fill") }
 
     /// 􂂝
     /// Single Localization, 2 Layersets
@@ -2130,7 +2130,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleFrontRight = SFSymbol(rawValue: "car.top.arrowtriangle.front.right")
+    static var carTopArrowtriangleFrontRight: SFSymbol { .init(rawValue: "car.top.arrowtriangle.front.right") }
 
     /// 􂂞
     /// Single Localization, 2 Layersets
@@ -2138,7 +2138,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleFrontRightFill = SFSymbol(rawValue: "car.top.arrowtriangle.front.right.fill")
+    static var carTopArrowtriangleFrontRightFill: SFSymbol { .init(rawValue: "car.top.arrowtriangle.front.right.fill") }
 
     /// 􂂑
     /// Single Localization, 2 Layersets
@@ -2146,7 +2146,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleRearLeft = SFSymbol(rawValue: "car.top.arrowtriangle.rear.left")
+    static var carTopArrowtriangleRearLeft: SFSymbol { .init(rawValue: "car.top.arrowtriangle.rear.left") }
 
     /// 􂂒
     /// Single Localization, 2 Layersets
@@ -2154,7 +2154,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleRearLeftFill = SFSymbol(rawValue: "car.top.arrowtriangle.rear.left.fill")
+    static var carTopArrowtriangleRearLeftFill: SFSymbol { .init(rawValue: "car.top.arrowtriangle.rear.left.fill") }
 
     /// 􂂓
     /// Single Localization, 2 Layersets
@@ -2162,7 +2162,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleRearRight = SFSymbol(rawValue: "car.top.arrowtriangle.rear.right")
+    static var carTopArrowtriangleRearRight: SFSymbol { .init(rawValue: "car.top.arrowtriangle.rear.right") }
 
     /// 􂂔
     /// Single Localization, 2 Layersets
@@ -2170,7 +2170,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopArrowtriangleRearRightFill = SFSymbol(rawValue: "car.top.arrowtriangle.rear.right.fill")
+    static var carTopArrowtriangleRearRightFill: SFSymbol { .init(rawValue: "car.top.arrowtriangle.rear.right.fill") }
 
     /// 􂨒
     /// Single Localization, 2 Layersets
@@ -2178,7 +2178,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopFrontRadiowavesFrontLeftAndFrontAndFrontRight = SFSymbol(rawValue: "car.top.front.radiowaves.front.left.and.front.and.front.right")
+    static var carTopFrontRadiowavesFrontLeftAndFrontAndFrontRight: SFSymbol { .init(rawValue: "car.top.front.radiowaves.front.left.and.front.and.front.right") }
 
     /// 􂨓
     /// Single Localization, 2 Layersets
@@ -2186,7 +2186,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopFrontRadiowavesFrontLeftAndFrontAndFrontRightFill = SFSymbol(rawValue: "car.top.front.radiowaves.front.left.and.front.and.front.right.fill")
+    static var carTopFrontRadiowavesFrontLeftAndFrontAndFrontRightFill: SFSymbol { .init(rawValue: "car.top.front.radiowaves.front.left.and.front.and.front.right.fill") }
 
     /// 􂤾
     /// Single Localization, 2 Layersets
@@ -2194,7 +2194,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowavesRearLeftCarTopFront = SFSymbol(rawValue: "car.top.radiowaves.rear.left.car.top.front")
+    static var carTopRadiowavesRearLeftCarTopFront: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left.car.top.front") }
 
     /// 􂤿
     /// Single Localization, 2 Layersets
@@ -2202,7 +2202,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowavesRearLeftCarTopFrontFill = SFSymbol(rawValue: "car.top.radiowaves.rear.left.car.top.front.fill")
+    static var carTopRadiowavesRearLeftCarTopFrontFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.left.car.top.front.fill") }
 
     /// 􂥀
     /// Single Localization, 2 Layersets
@@ -2210,7 +2210,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowavesRearRightCarTopFront = SFSymbol(rawValue: "car.top.radiowaves.rear.right.car.top.front")
+    static var carTopRadiowavesRearRightCarTopFront: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.car.top.front") }
 
     /// 􂥁
     /// Single Localization, 2 Layersets
@@ -2218,7 +2218,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowavesRearRightCarTopFrontFill = SFSymbol(rawValue: "car.top.radiowaves.rear.right.car.top.front.fill")
+    static var carTopRadiowavesRearRightCarTopFrontFill: SFSymbol { .init(rawValue: "car.top.radiowaves.rear.right.car.top.front.fill") }
 
     /// 􂨔
     /// Single Localization, 2 Layersets
@@ -2226,7 +2226,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRearRadiowavesRearLeftAndRearAndRearRight = SFSymbol(rawValue: "car.top.rear.radiowaves.rear.left.and.rear.and.rear.right")
+    static var carTopRearRadiowavesRearLeftAndRearAndRearRight: SFSymbol { .init(rawValue: "car.top.rear.radiowaves.rear.left.and.rear.and.rear.right") }
 
     /// 􂨕
     /// Single Localization, 2 Layersets
@@ -2234,7 +2234,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRearRadiowavesRearLeftAndRearAndRearRightFill = SFSymbol(rawValue: "car.top.rear.radiowaves.rear.left.and.rear.and.rear.right.fill")
+    static var carTopRearRadiowavesRearLeftAndRearAndRearRightFill: SFSymbol { .init(rawValue: "car.top.rear.radiowaves.rear.left.and.rear.and.rear.right.fill") }
 
     /// 􂨎
     /// Single Localization, 2 Layersets
@@ -2242,7 +2242,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopVideoRearLeft = SFSymbol(rawValue: "car.top.video.rear.left")
+    static var carTopVideoRearLeft: SFSymbol { .init(rawValue: "car.top.video.rear.left") }
 
     /// 􂨏
     /// Single Localization, 2 Layersets
@@ -2250,7 +2250,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopVideoRearLeftFill = SFSymbol(rawValue: "car.top.video.rear.left.fill")
+    static var carTopVideoRearLeftFill: SFSymbol { .init(rawValue: "car.top.video.rear.left.fill") }
 
     /// 􂨐
     /// Single Localization, 2 Layersets
@@ -2258,7 +2258,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopVideoRearRight = SFSymbol(rawValue: "car.top.video.rear.right")
+    static var carTopVideoRearRight: SFSymbol { .init(rawValue: "car.top.video.rear.right") }
 
     /// 􂨑
     /// Single Localization, 2 Layersets
@@ -2266,7 +2266,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopVideoRearRightFill = SFSymbol(rawValue: "car.top.video.rear.right.fill")
+    static var carTopVideoRearRightFill: SFSymbol { .init(rawValue: "car.top.video.rear.right.fill") }
 
     /// 􂱰
     /// 2 Localizations, 3 Layersets
@@ -2279,7 +2279,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cartBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "cart.badge.clock")
+    static var cartBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "cart.badge.clock") }
 
     /// 􂱲
     /// 2 Localizations, 3 Layersets
@@ -2292,7 +2292,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cartBadgeClockFill = SymbolWith1Localization<Rtl>(rawValue: "cart.badge.clock.fill")
+    static var cartBadgeClockFill: SymbolWith1Localization<Rtl> { .init(rawValue: "cart.badge.clock.fill") }
 
     /// 􂈨
     /// Single Localization, 2 Layersets
@@ -2300,7 +2300,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "cedisign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var cedisignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "cedisign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔧
     /// Single Localization, 2 Layersets
@@ -2308,7 +2308,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignBankBuilding = SFSymbol(rawValue: "cedisign.bank.building")
+    static var cedisignBankBuilding: SFSymbol { .init(rawValue: "cedisign.bank.building") }
 
     /// 􂔨
     /// Single Localization, 3 Layersets
@@ -2317,7 +2317,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cedisignBankBuildingFill = SFSymbol(rawValue: "cedisign.bank.building.fill")
+    static var cedisignBankBuildingFill: SFSymbol { .init(rawValue: "cedisign.bank.building.fill") }
 
     /// 􂩀
     /// Single Localization, 2 Layersets
@@ -2325,7 +2325,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "cedisign.gauge.chart.lefthalf.righthalf")
+    static var cedisignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "cedisign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩪
     /// Single Localization, 2 Layersets
@@ -2333,7 +2333,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "cedisign.gauge.chart.leftthird.topthird.rightthird")
+    static var cedisignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "cedisign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰐
     /// Single Localization, 2 Layersets
@@ -2341,7 +2341,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignRing = SFSymbol(rawValue: "cedisign.ring")
+    static var cedisignRing: SFSymbol { .init(rawValue: "cedisign.ring") }
 
     /// 􂯦
     /// Single Localization, 2 Layersets
@@ -2349,7 +2349,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cedisignRingDashed = SFSymbol(rawValue: "cedisign.ring.dashed")
+    static var cedisignRingDashed: SFSymbol { .init(rawValue: "cedisign.ring.dashed") }
 
     /// 􂈓
     /// Single Localization, 2 Layersets
@@ -2357,7 +2357,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "centsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var centsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "centsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂓽
     /// Single Localization, 2 Layersets
@@ -2365,7 +2365,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignBankBuilding = SFSymbol(rawValue: "centsign.bank.building")
+    static var centsignBankBuilding: SFSymbol { .init(rawValue: "centsign.bank.building") }
 
     /// 􂓾
     /// Single Localization, 3 Layersets
@@ -2374,7 +2374,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let centsignBankBuildingFill = SFSymbol(rawValue: "centsign.bank.building.fill")
+    static var centsignBankBuildingFill: SFSymbol { .init(rawValue: "centsign.bank.building.fill") }
 
     /// 􂩁
     /// Single Localization, 2 Layersets
@@ -2382,7 +2382,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "centsign.gauge.chart.lefthalf.righthalf")
+    static var centsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "centsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩫
     /// Single Localization, 2 Layersets
@@ -2390,7 +2390,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "centsign.gauge.chart.leftthird.topthird.rightthird")
+    static var centsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "centsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰑
     /// Single Localization, 2 Layersets
@@ -2398,7 +2398,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignRing = SFSymbol(rawValue: "centsign.ring")
+    static var centsignRing: SFSymbol { .init(rawValue: "centsign.ring") }
 
     /// 􂯧
     /// Single Localization, 2 Layersets
@@ -2406,7 +2406,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let centsignRingDashed = SFSymbol(rawValue: "centsign.ring.dashed")
+    static var centsignRingDashed: SFSymbol { .init(rawValue: "centsign.ring.dashed") }
 
     /// 􂏽
     /// 20 Localizations, 2 Layersets
@@ -2436,7 +2436,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let characterCircle = SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh>(rawValue: "character.circle")
+    static var characterCircle: SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh> { .init(rawValue: "character.circle") }
 
     /// 􂏾
     /// 20 Localizations, 3 Layersets
@@ -2467,7 +2467,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let characterCircleFill = SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh>(rawValue: "character.circle.fill")
+    static var characterCircleFill: SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh> { .init(rawValue: "character.circle.fill") }
 
     /// 􂏿
     /// 20 Localizations, 2 Layersets
@@ -2497,7 +2497,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let characterSquare = SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh>(rawValue: "character.square")
+    static var characterSquare: SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh> { .init(rawValue: "character.square") }
 
     /// 􂐀
     /// 20 Localizations, 3 Layersets
@@ -2528,7 +2528,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let characterSquareFill = SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh>(rawValue: "character.square.fill")
+    static var characterSquareFill: SymbolWith19Localizations<Ar, Bn_v6_1, Gu_v6_1, He, Hi, Ja, Kn_v6_1, Ko, Ml_v6_1, Mni_v6_1, Mr_v6_1, Or_v6_1, Pa_v6_1, Sat_v6_1, Si_v6_1, Ta_v6_1, Te_v6_1, Th, Zh> { .init(rawValue: "character.square.fill") }
 
     /// 􂐦
     /// 3 Localizations, Single Layerset
@@ -2540,7 +2540,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let charactersLowercase = SymbolWith2Localizations<El, Ru>(rawValue: "characters.lowercase")
+    static var charactersLowercase: SymbolWith2Localizations<El, Ru> { .init(rawValue: "characters.lowercase") }
 
     /// 􀥊
     /// 3 Localizations, Single Layerset
@@ -2552,7 +2552,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let charactersUppercase = SymbolWith2Localizations<El, Ru>(rawValue: "characters.uppercase")
+    static var charactersUppercase: SymbolWith2Localizations<El, Ru> { .init(rawValue: "characters.uppercase") }
 
     /// 􀥜
     /// Single Localization, 3 Layersets
@@ -2561,7 +2561,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartBarHorizontalPage = SFSymbol(rawValue: "chart.bar.horizontal.page")
+    static var chartBarHorizontalPage: SFSymbol { .init(rawValue: "chart.bar.horizontal.page") }
 
     /// 􀦌
     /// Single Localization, 3 Layersets
@@ -2570,7 +2570,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chartBarHorizontalPageFill = SFSymbol(rawValue: "chart.bar.horizontal.page.fill")
+    static var chartBarHorizontalPageFill: SFSymbol { .init(rawValue: "chart.bar.horizontal.page.fill") }
 
     /// 􂯞
     /// Single Localization, 2 Layersets
@@ -2578,7 +2578,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartBarYaxis = SFSymbol(rawValue: "chart.bar.yaxis")
+    static var chartBarYaxis: SFSymbol { .init(rawValue: "chart.bar.yaxis") }
 
     /// 􂮺
     /// Single Localization, 2 Layersets
@@ -2586,7 +2586,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartLineTextClipboard = SFSymbol(rawValue: "chart.line.text.clipboard")
+    static var chartLineTextClipboard: SFSymbol { .init(rawValue: "chart.line.text.clipboard") }
 
     /// 􂮻
     /// Single Localization, 2 Layersets
@@ -2594,7 +2594,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartLineTextClipboardFill = SFSymbol(rawValue: "chart.line.text.clipboard.fill")
+    static var chartLineTextClipboardFill: SFSymbol { .init(rawValue: "chart.line.text.clipboard.fill") }
 
     /// 􁣛
     /// Single Localization, 2 Layersets
@@ -2602,7 +2602,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkArrowTriangleheadCounterclockwise = SFSymbol(rawValue: "checkmark.arrow.trianglehead.counterclockwise")
+    static var checkmarkArrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "checkmark.arrow.trianglehead.counterclockwise") }
 
     /// 􂱅
     /// 2 Localizations, Single Layerset
@@ -2613,7 +2613,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let checkmarkSealTextPage = SymbolWith1Localization<Rtl>(rawValue: "checkmark.seal.text.page")
+    static var checkmarkSealTextPage: SymbolWith1Localization<Rtl> { .init(rawValue: "checkmark.seal.text.page") }
 
     /// 􂱆
     /// 2 Localizations, Single Layerset
@@ -2624,112 +2624,112 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let checkmarkSealTextPageFill = SymbolWith1Localization<Rtl>(rawValue: "checkmark.seal.text.page.fill")
+    static var checkmarkSealTextPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "checkmark.seal.text.page.fill") }
 
     /// 􂨫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronBackwardChevronBackwardDotted = SFSymbol(rawValue: "chevron.backward.chevron.backward.dotted")
+    static var chevronBackwardChevronBackwardDotted: SFSymbol { .init(rawValue: "chevron.backward.chevron.backward.dotted") }
 
     /// 􂦬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactLeftChevronCompactRight = SFSymbol(rawValue: "chevron.compact.left.chevron.compact.right")
+    static var chevronCompactLeftChevronCompactRight: SFSymbol { .init(rawValue: "chevron.compact.left.chevron.compact.right") }
 
     /// 􂦫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactUpChevronCompactDown = SFSymbol(rawValue: "chevron.compact.up.chevron.compact.down")
+    static var chevronCompactUpChevronCompactDown: SFSymbol { .init(rawValue: "chevron.compact.up.chevron.compact.down") }
 
     /// 􂦭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronCompactUpChevronCompactRightChevronCompactDownChevronCompactLeft = SFSymbol(rawValue: "chevron.compact.up.chevron.compact.right.chevron.compact.down.chevron.compact.left")
+    static var chevronCompactUpChevronCompactRightChevronCompactDownChevronCompactLeft: SFSymbol { .init(rawValue: "chevron.compact.up.chevron.compact.right.chevron.compact.down.chevron.compact.left") }
 
     /// 􂪔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDown2 = SFSymbol(rawValue: "chevron.down.2")
+    static var chevronDown2: SFSymbol { .init(rawValue: "chevron.down.2") }
 
     /// 􂨨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDownDotted2 = SFSymbol(rawValue: "chevron.down.dotted.2")
+    static var chevronDownDotted2: SFSymbol { .init(rawValue: "chevron.down.dotted.2") }
 
     /// 􂪘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDownForward2 = SFSymbol(rawValue: "chevron.down.forward.2")
+    static var chevronDownForward2: SFSymbol { .init(rawValue: "chevron.down.forward.2") }
 
     /// 􂪒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDownForwardDotted2 = SFSymbol(rawValue: "chevron.down.forward.dotted.2")
+    static var chevronDownForwardDotted2: SFSymbol { .init(rawValue: "chevron.down.forward.dotted.2") }
 
     /// 􂪗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDownRight2 = SFSymbol(rawValue: "chevron.down.right.2")
+    static var chevronDownRight2: SFSymbol { .init(rawValue: "chevron.down.right.2") }
 
     /// 􂪑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronDownRightDotted2 = SFSymbol(rawValue: "chevron.down.right.dotted.2")
+    static var chevronDownRightDotted2: SFSymbol { .init(rawValue: "chevron.down.right.dotted.2") }
 
     /// 􂨬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronForwardDottedChevronForward = SFSymbol(rawValue: "chevron.forward.dotted.chevron.forward")
+    static var chevronForwardDottedChevronForward: SFSymbol { .init(rawValue: "chevron.forward.dotted.chevron.forward") }
 
     /// 􂨩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeftChevronLeftDotted = SFSymbol(rawValue: "chevron.left.chevron.left.dotted")
+    static var chevronLeftChevronLeftDotted: SFSymbol { .init(rawValue: "chevron.left.chevron.left.dotted") }
 
     /// 􂦩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronLeftChevronRight = SFSymbol(rawValue: "chevron.left.chevron.right")
+    static var chevronLeftChevronRight: SFSymbol { .init(rawValue: "chevron.left.chevron.right") }
 
     /// 􂨪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronRightDottedChevronRight = SFSymbol(rawValue: "chevron.right.dotted.chevron.right")
+    static var chevronRightDottedChevronRight: SFSymbol { .init(rawValue: "chevron.right.dotted.chevron.right") }
 
     /// 􂪓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUp2 = SFSymbol(rawValue: "chevron.up.2")
+    static var chevronUp2: SFSymbol { .init(rawValue: "chevron.up.2") }
 
     /// 􂝒
     /// Single Localization, 2 Layersets
@@ -2737,7 +2737,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chevronUpChevronDownSquare = SFSymbol(rawValue: "chevron.up.chevron.down.square")
+    static var chevronUpChevronDownSquare: SFSymbol { .init(rawValue: "chevron.up.chevron.down.square") }
 
     /// 􂝓
     /// Single Localization, 3 Layersets
@@ -2746,49 +2746,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chevronUpChevronDownSquareFill = SFSymbol(rawValue: "chevron.up.chevron.down.square.fill")
+    static var chevronUpChevronDownSquareFill: SFSymbol { .init(rawValue: "chevron.up.chevron.down.square.fill") }
 
     /// 􂦪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpChevronRightChevronDownChevronLeft = SFSymbol(rawValue: "chevron.up.chevron.right.chevron.down.chevron.left")
+    static var chevronUpChevronRightChevronDownChevronLeft: SFSymbol { .init(rawValue: "chevron.up.chevron.right.chevron.down.chevron.left") }
 
     /// 􂨧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpDotted2 = SFSymbol(rawValue: "chevron.up.dotted.2")
+    static var chevronUpDotted2: SFSymbol { .init(rawValue: "chevron.up.dotted.2") }
 
     /// 􂪖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpForward2 = SFSymbol(rawValue: "chevron.up.forward.2")
+    static var chevronUpForward2: SFSymbol { .init(rawValue: "chevron.up.forward.2") }
 
     /// 􂪐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpForwardDotted2 = SFSymbol(rawValue: "chevron.up.forward.dotted.2")
+    static var chevronUpForwardDotted2: SFSymbol { .init(rawValue: "chevron.up.forward.dotted.2") }
 
     /// 􂪕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpRight2 = SFSymbol(rawValue: "chevron.up.right.2")
+    static var chevronUpRight2: SFSymbol { .init(rawValue: "chevron.up.right.2") }
 
     /// 􂪏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let chevronUpRightDotted2 = SFSymbol(rawValue: "chevron.up.right.dotted.2")
+    static var chevronUpRightDotted2: SFSymbol { .init(rawValue: "chevron.up.right.dotted.2") }
 
     /// 􂈳
     /// Single Localization, 2 Layersets
@@ -2796,7 +2796,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "chineseyuanrenminbisign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔽
     /// Single Localization, 2 Layersets
@@ -2804,7 +2804,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignBankBuilding = SFSymbol(rawValue: "chineseyuanrenminbisign.bank.building")
+    static var chineseyuanrenminbisignBankBuilding: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.bank.building") }
 
     /// 􂔾
     /// Single Localization, 3 Layersets
@@ -2813,7 +2813,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let chineseyuanrenminbisignBankBuildingFill = SFSymbol(rawValue: "chineseyuanrenminbisign.bank.building.fill")
+    static var chineseyuanrenminbisignBankBuildingFill: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.bank.building.fill") }
 
     /// 􂩂
     /// Single Localization, 2 Layersets
@@ -2821,7 +2821,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "chineseyuanrenminbisign.gauge.chart.lefthalf.righthalf")
+    static var chineseyuanrenminbisignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩬
     /// Single Localization, 2 Layersets
@@ -2829,7 +2829,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "chineseyuanrenminbisign.gauge.chart.leftthird.topthird.rightthird")
+    static var chineseyuanrenminbisignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰒
     /// Single Localization, 2 Layersets
@@ -2837,7 +2837,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignRing = SFSymbol(rawValue: "chineseyuanrenminbisign.ring")
+    static var chineseyuanrenminbisignRing: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.ring") }
 
     /// 􂯨
     /// Single Localization, 2 Layersets
@@ -2845,14 +2845,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chineseyuanrenminbisignRingDashed = SFSymbol(rawValue: "chineseyuanrenminbisign.ring.dashed")
+    static var chineseyuanrenminbisignRingDashed: SFSymbol { .init(rawValue: "chineseyuanrenminbisign.ring.dashed") }
 
     /// 􁹨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleBottomrighthalfPatternCheckered = SFSymbol(rawValue: "circle.bottomrighthalf.pattern.checkered")
+    static var circleBottomrighthalfPatternCheckered: SFSymbol { .init(rawValue: "circle.bottomrighthalf.pattern.checkered") }
 
     /// 􀯛
     /// Single Localization, 2 Layersets
@@ -2860,7 +2860,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockArrowTrianglehead2CounterclockwiseRotate90 = SFSymbol(rawValue: "clock.arrow.trianglehead.2.counterclockwise.rotate.90")
+    static var clockArrowTrianglehead2CounterclockwiseRotate90: SFSymbol { .init(rawValue: "clock.arrow.trianglehead.2.counterclockwise.rotate.90") }
 
     /// 􀣔
     /// Single Localization, 2 Layersets
@@ -2868,7 +2868,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+    static var clockArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "clock.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􁷞
     /// Single Localization, 3 Layersets
@@ -2877,7 +2877,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudRainbowCrop = SFSymbol(rawValue: "cloud.rainbow.crop")
+    static var cloudRainbowCrop: SFSymbol { .init(rawValue: "cloud.rainbow.crop") }
 
     /// 􁷠
     /// Single Localization, 3 Layersets
@@ -2886,21 +2886,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cloudRainbowCropFill = SFSymbol(rawValue: "cloud.rainbow.crop.fill")
+    static var cloudRainbowCropFill: SFSymbol { .init(rawValue: "cloud.rainbow.crop.fill") }
 
     /// 􂏣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let coat = SFSymbol(rawValue: "coat")
+    static var coat: SFSymbol { .init(rawValue: "coat") }
 
     /// 􂏤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let coatFill = SFSymbol(rawValue: "coat.fill")
+    static var coatFill: SFSymbol { .init(rawValue: "coat.fill") }
 
     /// 􂈧
     /// Single Localization, 2 Layersets
@@ -2908,7 +2908,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "coloncurrencysign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var coloncurrencysignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "coloncurrencysign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔥
     /// Single Localization, 2 Layersets
@@ -2916,7 +2916,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignBankBuilding = SFSymbol(rawValue: "coloncurrencysign.bank.building")
+    static var coloncurrencysignBankBuilding: SFSymbol { .init(rawValue: "coloncurrencysign.bank.building") }
 
     /// 􂔦
     /// Single Localization, 3 Layersets
@@ -2925,7 +2925,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let coloncurrencysignBankBuildingFill = SFSymbol(rawValue: "coloncurrencysign.bank.building.fill")
+    static var coloncurrencysignBankBuildingFill: SFSymbol { .init(rawValue: "coloncurrencysign.bank.building.fill") }
 
     /// 􂩃
     /// Single Localization, 2 Layersets
@@ -2933,7 +2933,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "coloncurrencysign.gauge.chart.lefthalf.righthalf")
+    static var coloncurrencysignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "coloncurrencysign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩭
     /// Single Localization, 2 Layersets
@@ -2941,7 +2941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "coloncurrencysign.gauge.chart.leftthird.topthird.rightthird")
+    static var coloncurrencysignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "coloncurrencysign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰓
     /// Single Localization, 2 Layersets
@@ -2949,7 +2949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignRing = SFSymbol(rawValue: "coloncurrencysign.ring")
+    static var coloncurrencysignRing: SFSymbol { .init(rawValue: "coloncurrencysign.ring") }
 
     /// 􂯩
     /// Single Localization, 2 Layersets
@@ -2957,14 +2957,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coloncurrencysignRingDashed = SFSymbol(rawValue: "coloncurrencysign.ring.dashed")
+    static var coloncurrencysignRingDashed: SFSymbol { .init(rawValue: "coloncurrencysign.ring.dashed") }
 
     /// 􂥂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSide = SFSymbol(rawValue: "convertible.side")
+    static var convertibleSide: SFSymbol { .init(rawValue: "convertible.side") }
 
     /// 􂥙
     /// Single Localization, 2 Layersets
@@ -2972,7 +2972,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideAirCirculate = SFSymbol(rawValue: "convertible.side.air.circulate")
+    static var convertibleSideAirCirculate: SFSymbol { .init(rawValue: "convertible.side.air.circulate") }
 
     /// 􂥚
     /// Single Localization, 3 Layersets
@@ -2981,7 +2981,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let convertibleSideAirCirculateFill = SFSymbol(rawValue: "convertible.side.air.circulate.fill")
+    static var convertibleSideAirCirculateFill: SFSymbol { .init(rawValue: "convertible.side.air.circulate.fill") }
 
     /// 􂥛
     /// Single Localization, 2 Layersets
@@ -2989,7 +2989,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideAirFresh = SFSymbol(rawValue: "convertible.side.air.fresh")
+    static var convertibleSideAirFresh: SFSymbol { .init(rawValue: "convertible.side.air.fresh") }
 
     /// 􂥜
     /// Single Localization, 2 Layersets
@@ -2997,7 +2997,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideAirFreshFill = SFSymbol(rawValue: "convertible.side.air.fresh.fill")
+    static var convertibleSideAirFreshFill: SFSymbol { .init(rawValue: "convertible.side.air.fresh.fill") }
 
     /// 􂥈
     /// Single Localization, 2 Layersets
@@ -3005,7 +3005,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideAndExclamationmark = SFSymbol(rawValue: "convertible.side.and.exclamationmark")
+    static var convertibleSideAndExclamationmark: SFSymbol { .init(rawValue: "convertible.side.and.exclamationmark") }
 
     /// 􂥉
     /// Single Localization, 2 Layersets
@@ -3013,7 +3013,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideAndExclamationmarkFill = SFSymbol(rawValue: "convertible.side.and.exclamationmark.fill")
+    static var convertibleSideAndExclamationmarkFill: SFSymbol { .init(rawValue: "convertible.side.and.exclamationmark.fill") }
 
     /// 􂬨
     /// Single Localization, 2 Layersets
@@ -3021,7 +3021,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadBackward = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.backward")
+    static var convertibleSideArrowTriangleheadBackward: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.backward") }
 
     /// 􂬩
     /// Single Localization, 2 Layersets
@@ -3029,7 +3029,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadBackwardFill = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.backward.fill")
+    static var convertibleSideArrowTriangleheadBackwardFill: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.backward.fill") }
 
     /// 􂬦
     /// Single Localization, 2 Layersets
@@ -3037,7 +3037,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadForward = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.forward")
+    static var convertibleSideArrowTriangleheadForward: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.forward") }
 
     /// 􂬪
     /// Single Localization, 2 Layersets
@@ -3045,7 +3045,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadForwardAndBackward = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.forward.and.backward")
+    static var convertibleSideArrowTriangleheadForwardAndBackward: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.forward.and.backward") }
 
     /// 􂬫
     /// Single Localization, 2 Layersets
@@ -3053,7 +3053,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadForwardAndBackwardFill = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.forward.and.backward.fill")
+    static var convertibleSideArrowTriangleheadForwardAndBackwardFill: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.forward.and.backward.fill") }
 
     /// 􂬧
     /// Single Localization, 2 Layersets
@@ -3061,7 +3061,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowTriangleheadForwardFill = SFSymbol(rawValue: "convertible.side.arrow.trianglehead.forward.fill")
+    static var convertibleSideArrowTriangleheadForwardFill: SFSymbol { .init(rawValue: "convertible.side.arrow.trianglehead.forward.fill") }
 
     /// 􂥏
     /// Single Localization, 2 Layersets
@@ -3069,7 +3069,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleDown = SFSymbol(rawValue: "convertible.side.arrowtriangle.down")
+    static var convertibleSideArrowtriangleDown: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.down") }
 
     /// 􂥐
     /// Single Localization, 2 Layersets
@@ -3077,7 +3077,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleDownFill = SFSymbol(rawValue: "convertible.side.arrowtriangle.down.fill")
+    static var convertibleSideArrowtriangleDownFill: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.down.fill") }
 
     /// 􂥍
     /// Single Localization, 2 Layersets
@@ -3085,7 +3085,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleUp = SFSymbol(rawValue: "convertible.side.arrowtriangle.up")
+    static var convertibleSideArrowtriangleUp: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.up") }
 
     /// 􂥋
     /// Single Localization, 2 Layersets
@@ -3093,7 +3093,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleUpArrowtriangleDown = SFSymbol(rawValue: "convertible.side.arrowtriangle.up.arrowtriangle.down")
+    static var convertibleSideArrowtriangleUpArrowtriangleDown: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.up.arrowtriangle.down") }
 
     /// 􂥌
     /// Single Localization, 2 Layersets
@@ -3101,7 +3101,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleUpArrowtriangleDownFill = SFSymbol(rawValue: "convertible.side.arrowtriangle.up.arrowtriangle.down.fill")
+    static var convertibleSideArrowtriangleUpArrowtriangleDownFill: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.up.arrowtriangle.down.fill") }
 
     /// 􂥎
     /// Single Localization, 2 Layersets
@@ -3109,42 +3109,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowtriangleUpFill = SFSymbol(rawValue: "convertible.side.arrowtriangle.up.fill")
+    static var convertibleSideArrowtriangleUpFill: SFSymbol { .init(rawValue: "convertible.side.arrowtriangle.up.fill") }
 
     /// 􂥃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSideFill = SFSymbol(rawValue: "convertible.side.fill")
+    static var convertibleSideFill: SFSymbol { .init(rawValue: "convertible.side.fill") }
 
     /// 􂥄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSideFrontOpen = SFSymbol(rawValue: "convertible.side.front.open")
+    static var convertibleSideFrontOpen: SFSymbol { .init(rawValue: "convertible.side.front.open") }
 
     /// 􂥆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSideFrontOpenCrop = SFSymbol(rawValue: "convertible.side.front.open.crop")
+    static var convertibleSideFrontOpenCrop: SFSymbol { .init(rawValue: "convertible.side.front.open.crop") }
 
     /// 􂥇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSideFrontOpenCropFill = SFSymbol(rawValue: "convertible.side.front.open.crop.fill")
+    static var convertibleSideFrontOpenCropFill: SFSymbol { .init(rawValue: "convertible.side.front.open.crop.fill") }
 
     /// 􂥅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let convertibleSideFrontOpenFill = SFSymbol(rawValue: "convertible.side.front.open.fill")
+    static var convertibleSideFrontOpenFill: SFSymbol { .init(rawValue: "convertible.side.front.open.fill") }
 
     /// 􂦆
     /// Single Localization, 2 Layersets
@@ -3152,7 +3152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillDescentControl = SFSymbol(rawValue: "convertible.side.hill.descent.control")
+    static var convertibleSideHillDescentControl: SFSymbol { .init(rawValue: "convertible.side.hill.descent.control") }
 
     /// 􂦇
     /// Single Localization, 2 Layersets
@@ -3160,7 +3160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillDescentControlFill = SFSymbol(rawValue: "convertible.side.hill.descent.control.fill")
+    static var convertibleSideHillDescentControlFill: SFSymbol { .init(rawValue: "convertible.side.hill.descent.control.fill") }
 
     /// 􂦄
     /// Single Localization, 2 Layersets
@@ -3168,7 +3168,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillDown = SFSymbol(rawValue: "convertible.side.hill.down")
+    static var convertibleSideHillDown: SFSymbol { .init(rawValue: "convertible.side.hill.down") }
 
     /// 􂦅
     /// Single Localization, 2 Layersets
@@ -3176,7 +3176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillDownFill = SFSymbol(rawValue: "convertible.side.hill.down.fill")
+    static var convertibleSideHillDownFill: SFSymbol { .init(rawValue: "convertible.side.hill.down.fill") }
 
     /// 􂦂
     /// Single Localization, 2 Layersets
@@ -3184,7 +3184,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillUp = SFSymbol(rawValue: "convertible.side.hill.up")
+    static var convertibleSideHillUp: SFSymbol { .init(rawValue: "convertible.side.hill.up") }
 
     /// 􂦃
     /// Single Localization, 2 Layersets
@@ -3192,7 +3192,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideHillUpFill = SFSymbol(rawValue: "convertible.side.hill.up.fill")
+    static var convertibleSideHillUpFill: SFSymbol { .init(rawValue: "convertible.side.hill.up.fill") }
 
     /// 􂥑
     /// Single Localization, 2 Layersets
@@ -3200,7 +3200,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideLock = SFSymbol(rawValue: "convertible.side.lock")
+    static var convertibleSideLock: SFSymbol { .init(rawValue: "convertible.side.lock") }
 
     /// 􂥒
     /// Single Localization, 2 Layersets
@@ -3208,7 +3208,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideLockFill = SFSymbol(rawValue: "convertible.side.lock.fill")
+    static var convertibleSideLockFill: SFSymbol { .init(rawValue: "convertible.side.lock.fill") }
 
     /// 􂥕
     /// Single Localization, 2 Layersets
@@ -3216,7 +3216,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideLockOpen = SFSymbol(rawValue: "convertible.side.lock.open")
+    static var convertibleSideLockOpen: SFSymbol { .init(rawValue: "convertible.side.lock.open") }
 
     /// 􂥖
     /// Single Localization, 2 Layersets
@@ -3224,7 +3224,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideLockOpenFill = SFSymbol(rawValue: "convertible.side.lock.open.fill")
+    static var convertibleSideLockOpenFill: SFSymbol { .init(rawValue: "convertible.side.lock.open.fill") }
 
     /// 􂈩
     /// Single Localization, 2 Layersets
@@ -3232,7 +3232,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "cruzeirosign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var cruzeirosignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "cruzeirosign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔩
     /// Single Localization, 2 Layersets
@@ -3240,7 +3240,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignBankBuilding = SFSymbol(rawValue: "cruzeirosign.bank.building")
+    static var cruzeirosignBankBuilding: SFSymbol { .init(rawValue: "cruzeirosign.bank.building") }
 
     /// 􂔪
     /// Single Localization, 3 Layersets
@@ -3249,7 +3249,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cruzeirosignBankBuildingFill = SFSymbol(rawValue: "cruzeirosign.bank.building.fill")
+    static var cruzeirosignBankBuildingFill: SFSymbol { .init(rawValue: "cruzeirosign.bank.building.fill") }
 
     /// 􂩄
     /// Single Localization, 2 Layersets
@@ -3257,7 +3257,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "cruzeirosign.gauge.chart.lefthalf.righthalf")
+    static var cruzeirosignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "cruzeirosign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩮
     /// Single Localization, 2 Layersets
@@ -3265,7 +3265,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "cruzeirosign.gauge.chart.leftthird.topthird.rightthird")
+    static var cruzeirosignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "cruzeirosign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰔
     /// Single Localization, 2 Layersets
@@ -3273,7 +3273,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignRing = SFSymbol(rawValue: "cruzeirosign.ring")
+    static var cruzeirosignRing: SFSymbol { .init(rawValue: "cruzeirosign.ring") }
 
     /// 􂯪
     /// Single Localization, 2 Layersets
@@ -3281,7 +3281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cruzeirosignRingDashed = SFSymbol(rawValue: "cruzeirosign.ring.dashed")
+    static var cruzeirosignRingDashed: SFSymbol { .init(rawValue: "cruzeirosign.ring.dashed") }
 
     /// 􂊬
     /// Single Localization, 2 Layersets
@@ -3289,7 +3289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cupAndHeatWaves = SFSymbol(rawValue: "cup.and.heat.waves")
+    static var cupAndHeatWaves: SFSymbol { .init(rawValue: "cup.and.heat.waves") }
 
     /// 􂊭
     /// Single Localization, 2 Layersets
@@ -3297,7 +3297,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cupAndHeatWavesFill = SFSymbol(rawValue: "cup.and.heat.waves.fill")
+    static var cupAndHeatWavesFill: SFSymbol { .init(rawValue: "cup.and.heat.waves.fill") }
 
     /// 􂈷
     /// Single Localization, 2 Layersets
@@ -3305,7 +3305,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "danishkronesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var danishkronesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "danishkronesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂕅
     /// Single Localization, 2 Layersets
@@ -3313,7 +3313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignBankBuilding = SFSymbol(rawValue: "danishkronesign.bank.building")
+    static var danishkronesignBankBuilding: SFSymbol { .init(rawValue: "danishkronesign.bank.building") }
 
     /// 􂕆
     /// Single Localization, 3 Layersets
@@ -3322,7 +3322,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let danishkronesignBankBuildingFill = SFSymbol(rawValue: "danishkronesign.bank.building.fill")
+    static var danishkronesignBankBuildingFill: SFSymbol { .init(rawValue: "danishkronesign.bank.building.fill") }
 
     /// 􂩅
     /// Single Localization, 2 Layersets
@@ -3330,7 +3330,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "danishkronesign.gauge.chart.lefthalf.righthalf")
+    static var danishkronesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "danishkronesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩯
     /// Single Localization, 2 Layersets
@@ -3338,7 +3338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "danishkronesign.gauge.chart.leftthird.topthird.rightthird")
+    static var danishkronesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "danishkronesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰕
     /// Single Localization, 2 Layersets
@@ -3346,7 +3346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignRing = SFSymbol(rawValue: "danishkronesign.ring")
+    static var danishkronesignRing: SFSymbol { .init(rawValue: "danishkronesign.ring") }
 
     /// 􂯫
     /// Single Localization, 2 Layersets
@@ -3354,21 +3354,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let danishkronesignRingDashed = SFSymbol(rawValue: "danishkronesign.ring.dashed")
+    static var danishkronesignRingDashed: SFSymbol { .init(rawValue: "danishkronesign.ring.dashed") }
 
     /// 􂧤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let degreesignCelsius = SFSymbol(rawValue: "degreesign.celsius")
+    static var degreesignCelsius: SFSymbol { .init(rawValue: "degreesign.celsius") }
 
     /// 􂧣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let degreesignFahrenheit = SFSymbol(rawValue: "degreesign.fahrenheit")
+    static var degreesignFahrenheit: SFSymbol { .init(rawValue: "degreesign.fahrenheit") }
 
     /// 􂤓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3378,7 +3378,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let desktopcomputerAndMacbook = SFSymbol(rawValue: "desktopcomputer.and.macbook")
+    static var desktopcomputerAndMacbook: SFSymbol { .init(rawValue: "desktopcomputer.and.macbook") }
 
     /// 􂠹
     /// Single Localization, 2 Layersets
@@ -3386,7 +3386,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontal = SFSymbol(rawValue: "distribute.horizontal")
+    static var distributeHorizontal: SFSymbol { .init(rawValue: "distribute.horizontal") }
 
     /// 􂠺
     /// Single Localization, 2 Layersets
@@ -3394,7 +3394,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeHorizontalFill = SFSymbol(rawValue: "distribute.horizontal.fill")
+    static var distributeHorizontalFill: SFSymbol { .init(rawValue: "distribute.horizontal.fill") }
 
     /// 􂠷
     /// Single Localization, 2 Layersets
@@ -3402,7 +3402,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVertical = SFSymbol(rawValue: "distribute.vertical")
+    static var distributeVertical: SFSymbol { .init(rawValue: "distribute.vertical") }
 
     /// 􂠸
     /// Single Localization, 2 Layersets
@@ -3410,14 +3410,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let distributeVerticalFill = SFSymbol(rawValue: "distribute.vertical.fill")
+    static var distributeVerticalFill: SFSymbol { .init(rawValue: "distribute.vertical.fill") }
 
     /// 􀈷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let document = SFSymbol(rawValue: "document")
+    static var document: SFSymbol { .init(rawValue: "document") }
 
     /// 􁙡
     /// Single Localization, 3 Layersets
@@ -3426,7 +3426,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeArrowUp = SFSymbol(rawValue: "document.badge.arrow.up")
+    static var documentBadgeArrowUp: SFSymbol { .init(rawValue: "document.badge.arrow.up") }
 
     /// 􁙢
     /// Single Localization, 3 Layersets
@@ -3435,7 +3435,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeArrowUpFill = SFSymbol(rawValue: "document.badge.arrow.up.fill")
+    static var documentBadgeArrowUpFill: SFSymbol { .init(rawValue: "document.badge.arrow.up.fill") }
 
     /// 􀫾
     /// Single Localization, 3 Layersets
@@ -3444,7 +3444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeClock = SFSymbol(rawValue: "document.badge.clock")
+    static var documentBadgeClock: SFSymbol { .init(rawValue: "document.badge.clock") }
 
     /// 􀫿
     /// Single Localization, 3 Layersets
@@ -3453,7 +3453,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeClockFill = SFSymbol(rawValue: "document.badge.clock.fill")
+    static var documentBadgeClockFill: SFSymbol { .init(rawValue: "document.badge.clock.fill") }
 
     /// 􀩴
     /// Single Localization, 3 Layersets
@@ -3462,7 +3462,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeEllipsis = SFSymbol(rawValue: "document.badge.ellipsis")
+    static var documentBadgeEllipsis: SFSymbol { .init(rawValue: "document.badge.ellipsis") }
 
     /// 􀩵
     /// Single Localization, 3 Layersets
@@ -3471,7 +3471,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentBadgeEllipsisFill = SFSymbol(rawValue: "document.badge.ellipsis.fill")
+    static var documentBadgeEllipsisFill: SFSymbol { .init(rawValue: "document.badge.ellipsis.fill") }
 
     /// 􀩚
     /// Single Localization, 2 Layersets
@@ -3479,7 +3479,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentBadgeGearshape = SFSymbol(rawValue: "document.badge.gearshape")
+    static var documentBadgeGearshape: SFSymbol { .init(rawValue: "document.badge.gearshape") }
 
     /// 􀩛
     /// Single Localization, 2 Layersets
@@ -3487,7 +3487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentBadgeGearshapeFill = SFSymbol(rawValue: "document.badge.gearshape.fill")
+    static var documentBadgeGearshapeFill: SFSymbol { .init(rawValue: "document.badge.gearshape.fill") }
 
     /// 􀣗
     /// Single Localization, 3 Layersets
@@ -3496,7 +3496,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let documentBadgePlus = SFSymbol(rawValue: "document.badge.plus")
+    static var documentBadgePlus: SFSymbol { .init(rawValue: "document.badge.plus") }
 
     /// 􀣘
     /// Single Localization, 3 Layersets
@@ -3505,7 +3505,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let documentBadgePlusFill = SFSymbol(rawValue: "document.badge.plus.fill")
+    static var documentBadgePlusFill: SFSymbol { .init(rawValue: "document.badge.plus.fill") }
 
     /// 􀈹
     /// Single Localization, 2 Layersets
@@ -3513,7 +3513,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentCircle = SFSymbol(rawValue: "document.circle")
+    static var documentCircle: SFSymbol { .init(rawValue: "document.circle") }
 
     /// 􀈺
     /// Single Localization, 3 Layersets
@@ -3522,14 +3522,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentCircleFill = SFSymbol(rawValue: "document.circle.fill")
+    static var documentCircleFill: SFSymbol { .init(rawValue: "document.circle.fill") }
 
     /// 􀈸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let documentFill = SFSymbol(rawValue: "document.fill")
+    static var documentFill: SFSymbol { .init(rawValue: "document.fill") }
 
     /// 􀉃
     /// Single Localization, 3 Layersets
@@ -3538,7 +3538,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentOnClipboard = SFSymbol(rawValue: "document.on.clipboard")
+    static var documentOnClipboard: SFSymbol { .init(rawValue: "document.on.clipboard") }
 
     /// 􀉄
     /// Single Localization, 2 Layersets
@@ -3546,7 +3546,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentOnClipboardFill = SFSymbol(rawValue: "document.on.clipboard.fill")
+    static var documentOnClipboardFill: SFSymbol { .init(rawValue: "document.on.clipboard.fill") }
 
     /// 􀉁
     /// Single Localization, 3 Layersets
@@ -3555,7 +3555,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let documentOnDocument = SFSymbol(rawValue: "document.on.document")
+    static var documentOnDocument: SFSymbol { .init(rawValue: "document.on.document") }
 
     /// 􀉂
     /// Single Localization, 2 Layersets
@@ -3563,7 +3563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentOnDocumentFill = SFSymbol(rawValue: "document.on.document.fill")
+    static var documentOnDocumentFill: SFSymbol { .init(rawValue: "document.on.document.fill") }
 
     /// 􀎾
     /// Single Localization, 2 Layersets
@@ -3571,7 +3571,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentViewfinder = SFSymbol(rawValue: "document.viewfinder")
+    static var documentViewfinder: SFSymbol { .init(rawValue: "document.viewfinder") }
 
     /// 􀡢
     /// Single Localization, 2 Layersets
@@ -3579,7 +3579,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentViewfinderFill = SFSymbol(rawValue: "document.viewfinder.fill")
+    static var documentViewfinderFill: SFSymbol { .init(rawValue: "document.viewfinder.fill") }
 
     /// 􁎣
     /// Single Localization, 2 Layersets
@@ -3587,7 +3587,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "dollarsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var dollarsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "dollarsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂓲
     /// Single Localization, 2 Layersets
@@ -3595,7 +3595,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignBankBuilding = SFSymbol(rawValue: "dollarsign.bank.building")
+    static var dollarsignBankBuilding: SFSymbol { .init(rawValue: "dollarsign.bank.building") }
 
     /// 􂓳
     /// Single Localization, 3 Layersets
@@ -3604,7 +3604,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dollarsignBankBuildingFill = SFSymbol(rawValue: "dollarsign.bank.building.fill")
+    static var dollarsignBankBuildingFill: SFSymbol { .init(rawValue: "dollarsign.bank.building.fill") }
 
     /// 􂧈
     /// Single Localization, 2 Layersets
@@ -3612,7 +3612,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "dollarsign.gauge.chart.lefthalf.righthalf")
+    static var dollarsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "dollarsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂧉
     /// Single Localization, 2 Layersets
@@ -3620,7 +3620,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "dollarsign.gauge.chart.leftthird.topthird.rightthird")
+    static var dollarsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "dollarsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂮈
     /// Single Localization, 2 Layersets
@@ -3628,7 +3628,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignRing = SFSymbol(rawValue: "dollarsign.ring")
+    static var dollarsignRing: SFSymbol { .init(rawValue: "dollarsign.ring") }
 
     /// 􂮇
     /// Single Localization, 2 Layersets
@@ -3636,7 +3636,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dollarsignRingDashed = SFSymbol(rawValue: "dollarsign.ring.dashed")
+    static var dollarsignRingDashed: SFSymbol { .init(rawValue: "dollarsign.ring.dashed") }
 
     /// 􂈛
     /// Single Localization, 2 Layersets
@@ -3644,7 +3644,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "dongsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var dongsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "dongsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔍
     /// Single Localization, 2 Layersets
@@ -3652,7 +3652,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignBankBuilding = SFSymbol(rawValue: "dongsign.bank.building")
+    static var dongsignBankBuilding: SFSymbol { .init(rawValue: "dongsign.bank.building") }
 
     /// 􂔎
     /// Single Localization, 3 Layersets
@@ -3661,7 +3661,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let dongsignBankBuildingFill = SFSymbol(rawValue: "dongsign.bank.building.fill")
+    static var dongsignBankBuildingFill: SFSymbol { .init(rawValue: "dongsign.bank.building.fill") }
 
     /// 􂩆
     /// Single Localization, 2 Layersets
@@ -3669,7 +3669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "dongsign.gauge.chart.lefthalf.righthalf")
+    static var dongsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "dongsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩰
     /// Single Localization, 2 Layersets
@@ -3677,7 +3677,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "dongsign.gauge.chart.leftthird.topthird.rightthird")
+    static var dongsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "dongsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰖
     /// Single Localization, 2 Layersets
@@ -3685,7 +3685,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignRing = SFSymbol(rawValue: "dongsign.ring")
+    static var dongsignRing: SFSymbol { .init(rawValue: "dongsign.ring") }
 
     /// 􂯬
     /// Single Localization, 2 Layersets
@@ -3693,35 +3693,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dongsignRingDashed = SFSymbol(rawValue: "dongsign.ring.dashed")
+    static var dongsignRingDashed: SFSymbol { .init(rawValue: "dongsign.ring.dashed") }
 
     /// 􂖛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let drone = SFSymbol(rawValue: "drone")
+    static var drone: SFSymbol { .init(rawValue: "drone") }
 
     /// 􂖜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let droneFill = SFSymbol(rawValue: "drone.fill")
+    static var droneFill: SFSymbol { .init(rawValue: "drone.fill") }
 
     /// 􂂱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let duffleBag = SFSymbol(rawValue: "duffle.bag")
+    static var duffleBag: SFSymbol { .init(rawValue: "duffle.bag") }
 
     /// 􂂲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let duffleBagFill = SFSymbol(rawValue: "duffle.bag.fill")
+    static var duffleBagFill: SFSymbol { .init(rawValue: "duffle.bag.fill") }
 
     /// 􀳼
     /// 2 Localizations, 2 Layersets
@@ -3738,7 +3738,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 18.0, deprecated: 18.1, renamed: "waveformPathEcgTextPage")
     @available(watchOS, introduced: 11.0, deprecated: 11.1, renamed: "waveformPathEcgTextPage")
     @available(visionOS, introduced: 2.0, deprecated: 2.1, renamed: "waveformPathEcgTextPage")
-    static let ecgTextPage = SymbolWith1Localization<Rtl>(rawValue: "ecg.text.page")
+    static var ecgTextPage: SymbolWith1Localization<Rtl> { .init(rawValue: "ecg.text.page") }
 
     /// 􀳽
     /// 2 Localizations, Single Layerset
@@ -3754,7 +3754,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 18.0, deprecated: 18.1, renamed: "waveformPathEcgTextPageFill")
     @available(watchOS, introduced: 11.0, deprecated: 11.1, renamed: "waveformPathEcgTextPageFill")
     @available(visionOS, introduced: 2.0, deprecated: 2.1, renamed: "waveformPathEcgTextPageFill")
-    static let ecgTextPageFill = SymbolWith1Localization<Rtl>(rawValue: "ecg.text.page.fill")
+    static var ecgTextPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "ecg.text.page.fill") }
 
     /// 􂥟
     /// Single Localization, 2 Layersets
@@ -3762,7 +3762,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let engineEmissionAndExclamationmark = SFSymbol(rawValue: "engine.emission.and.exclamationmark")
+    static var engineEmissionAndExclamationmark: SFSymbol { .init(rawValue: "engine.emission.and.exclamationmark") }
 
     /// 􂋋
     /// Single Localization, 2 Layersets
@@ -3770,7 +3770,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let engineEmissionAndFilter = SFSymbol(rawValue: "engine.emission.and.filter")
+    static var engineEmissionAndFilter: SFSymbol { .init(rawValue: "engine.emission.and.filter") }
 
     /// 􀦗
     /// Single Localization, 2 Layersets
@@ -3778,7 +3778,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndArrowTriangleheadBranch = SFSymbol(rawValue: "envelope.and.arrow.trianglehead.branch")
+    static var envelopeAndArrowTriangleheadBranch: SFSymbol { .init(rawValue: "envelope.and.arrow.trianglehead.branch") }
 
     /// 􀦘
     /// Single Localization, 2 Layersets
@@ -3786,7 +3786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndArrowTriangleheadBranchFill = SFSymbol(rawValue: "envelope.and.arrow.trianglehead.branch.fill")
+    static var envelopeAndArrowTriangleheadBranchFill: SFSymbol { .init(rawValue: "envelope.and.arrow.trianglehead.branch.fill") }
 
     /// 􂙡
     /// 2 Localizations, Single Layerset
@@ -3797,7 +3797,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeFront = SymbolWith1Localization<Rtl>(rawValue: "envelope.front")
+    static var envelopeFront: SymbolWith1Localization<Rtl> { .init(rawValue: "envelope.front") }
 
     /// 􂙢
     /// 2 Localizations, 2 Layersets
@@ -3809,7 +3809,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let envelopeFrontFill = SymbolWith1Localization<Rtl>(rawValue: "envelope.front.fill")
+    static var envelopeFrontFill: SymbolWith1Localization<Rtl> { .init(rawValue: "envelope.front.fill") }
 
     /// 􂈚
     /// Single Localization, 2 Layersets
@@ -3817,7 +3817,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "eurosign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var eurosignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "eurosign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔋
     /// Single Localization, 2 Layersets
@@ -3825,7 +3825,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignBankBuilding = SFSymbol(rawValue: "eurosign.bank.building")
+    static var eurosignBankBuilding: SFSymbol { .init(rawValue: "eurosign.bank.building") }
 
     /// 􂔌
     /// Single Localization, 3 Layersets
@@ -3834,7 +3834,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eurosignBankBuildingFill = SFSymbol(rawValue: "eurosign.bank.building.fill")
+    static var eurosignBankBuildingFill: SFSymbol { .init(rawValue: "eurosign.bank.building.fill") }
 
     /// 􂩇
     /// Single Localization, 2 Layersets
@@ -3842,7 +3842,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "eurosign.gauge.chart.lefthalf.righthalf")
+    static var eurosignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "eurosign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩱
     /// Single Localization, 2 Layersets
@@ -3850,7 +3850,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "eurosign.gauge.chart.leftthird.topthird.rightthird")
+    static var eurosignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "eurosign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰗
     /// Single Localization, 2 Layersets
@@ -3858,7 +3858,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignRing = SFSymbol(rawValue: "eurosign.ring")
+    static var eurosignRing: SFSymbol { .init(rawValue: "eurosign.ring") }
 
     /// 􂯭
     /// Single Localization, 2 Layersets
@@ -3866,7 +3866,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurosignRingDashed = SFSymbol(rawValue: "eurosign.ring.dashed")
+    static var eurosignRingDashed: SFSymbol { .init(rawValue: "eurosign.ring.dashed") }
 
     /// 􂈸
     /// Single Localization, 2 Layersets
@@ -3874,7 +3874,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "eurozonesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var eurozonesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "eurozonesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂕇
     /// Single Localization, 2 Layersets
@@ -3882,7 +3882,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignBankBuilding = SFSymbol(rawValue: "eurozonesign.bank.building")
+    static var eurozonesignBankBuilding: SFSymbol { .init(rawValue: "eurozonesign.bank.building") }
 
     /// 􂕈
     /// Single Localization, 3 Layersets
@@ -3891,7 +3891,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eurozonesignBankBuildingFill = SFSymbol(rawValue: "eurozonesign.bank.building.fill")
+    static var eurozonesignBankBuildingFill: SFSymbol { .init(rawValue: "eurozonesign.bank.building.fill") }
 
     /// 􂩈
     /// Single Localization, 2 Layersets
@@ -3899,7 +3899,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "eurozonesign.gauge.chart.lefthalf.righthalf")
+    static var eurozonesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "eurozonesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩲
     /// Single Localization, 2 Layersets
@@ -3907,7 +3907,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "eurozonesign.gauge.chart.leftthird.topthird.rightthird")
+    static var eurozonesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "eurozonesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰘
     /// Single Localization, 2 Layersets
@@ -3915,7 +3915,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignRing = SFSymbol(rawValue: "eurozonesign.ring")
+    static var eurozonesignRing: SFSymbol { .init(rawValue: "eurozonesign.ring") }
 
     /// 􂯮
     /// Single Localization, 2 Layersets
@@ -3923,7 +3923,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eurozonesignRingDashed = SFSymbol(rawValue: "eurozonesign.ring.dashed")
+    static var eurozonesignRingDashed: SFSymbol { .init(rawValue: "eurozonesign.ring.dashed") }
 
     /// 􀢤
     /// Single Localization, 2 Layersets
@@ -3931,7 +3931,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let exclamationmarkArrowTrianglehead2ClockwiseRotate90 = SFSymbol(rawValue: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90")
+    static var exclamationmarkArrowTrianglehead2ClockwiseRotate90: SFSymbol { .init(rawValue: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90") }
 
     /// 􀱨
     /// Single Localization, 2 Layersets
@@ -3939,21 +3939,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let exclamationmarkArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90")
+    static var exclamationmarkArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂝗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure2LeftHoldinghands = SFSymbol(rawValue: "figure.2.left.holdinghands")
+    static var figure2LeftHoldinghands: SFSymbol { .init(rawValue: "figure.2.left.holdinghands") }
 
     /// 􂜺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figure2RightHoldinghands = SFSymbol(rawValue: "figure.2.right.holdinghands")
+    static var figure2RightHoldinghands: SFSymbol { .init(rawValue: "figure.2.right.holdinghands") }
 
     /// 􂛽
     /// Single Localization, 2 Layersets
@@ -3961,7 +3961,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureAmericanFootballCircle = SFSymbol(rawValue: "figure.american.football.circle")
+    static var figureAmericanFootballCircle: SFSymbol { .init(rawValue: "figure.american.football.circle") }
 
     /// 􂛾
     /// Single Localization, 3 Layersets
@@ -3970,7 +3970,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureAmericanFootballCircleFill = SFSymbol(rawValue: "figure.american.football.circle.fill")
+    static var figureAmericanFootballCircleFill: SFSymbol { .init(rawValue: "figure.american.football.circle.fill") }
 
     /// 􂛿
     /// Single Localization, 2 Layersets
@@ -3978,7 +3978,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureArcheryCircle = SFSymbol(rawValue: "figure.archery.circle")
+    static var figureArcheryCircle: SFSymbol { .init(rawValue: "figure.archery.circle") }
 
     /// 􂜀
     /// Single Localization, 3 Layersets
@@ -3987,7 +3987,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureArcheryCircleFill = SFSymbol(rawValue: "figure.archery.circle.fill")
+    static var figureArcheryCircleFill: SFSymbol { .init(rawValue: "figure.archery.circle.fill") }
 
     /// 􂜁
     /// Single Localization, 2 Layersets
@@ -3995,7 +3995,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureAustralianFootballCircle = SFSymbol(rawValue: "figure.australian.football.circle")
+    static var figureAustralianFootballCircle: SFSymbol { .init(rawValue: "figure.australian.football.circle") }
 
     /// 􂜂
     /// Single Localization, 3 Layersets
@@ -4004,7 +4004,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureAustralianFootballCircleFill = SFSymbol(rawValue: "figure.australian.football.circle.fill")
+    static var figureAustralianFootballCircleFill: SFSymbol { .init(rawValue: "figure.australian.football.circle.fill") }
 
     /// 􂜃
     /// Single Localization, 2 Layersets
@@ -4012,7 +4012,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBadmintonCircle = SFSymbol(rawValue: "figure.badminton.circle")
+    static var figureBadmintonCircle: SFSymbol { .init(rawValue: "figure.badminton.circle") }
 
     /// 􂜄
     /// Single Localization, 3 Layersets
@@ -4021,7 +4021,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBadmintonCircleFill = SFSymbol(rawValue: "figure.badminton.circle.fill")
+    static var figureBadmintonCircleFill: SFSymbol { .init(rawValue: "figure.badminton.circle.fill") }
 
     /// 􂜅
     /// Single Localization, 2 Layersets
@@ -4029,7 +4029,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBarreCircle = SFSymbol(rawValue: "figure.barre.circle")
+    static var figureBarreCircle: SFSymbol { .init(rawValue: "figure.barre.circle") }
 
     /// 􂜆
     /// Single Localization, 3 Layersets
@@ -4038,7 +4038,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBarreCircleFill = SFSymbol(rawValue: "figure.barre.circle.fill")
+    static var figureBarreCircleFill: SFSymbol { .init(rawValue: "figure.barre.circle.fill") }
 
     /// 􂜇
     /// Single Localization, 2 Layersets
@@ -4046,7 +4046,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBaseballCircle = SFSymbol(rawValue: "figure.baseball.circle")
+    static var figureBaseballCircle: SFSymbol { .init(rawValue: "figure.baseball.circle") }
 
     /// 􂜈
     /// Single Localization, 3 Layersets
@@ -4055,7 +4055,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBaseballCircleFill = SFSymbol(rawValue: "figure.baseball.circle.fill")
+    static var figureBaseballCircleFill: SFSymbol { .init(rawValue: "figure.baseball.circle.fill") }
 
     /// 􂜉
     /// Single Localization, 2 Layersets
@@ -4063,7 +4063,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBasketballCircle = SFSymbol(rawValue: "figure.basketball.circle")
+    static var figureBasketballCircle: SFSymbol { .init(rawValue: "figure.basketball.circle") }
 
     /// 􂜊
     /// Single Localization, 3 Layersets
@@ -4072,7 +4072,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBasketballCircleFill = SFSymbol(rawValue: "figure.basketball.circle.fill")
+    static var figureBasketballCircleFill: SFSymbol { .init(rawValue: "figure.basketball.circle.fill") }
 
     /// 􂜋
     /// Single Localization, 2 Layersets
@@ -4080,7 +4080,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBowlingCircle = SFSymbol(rawValue: "figure.bowling.circle")
+    static var figureBowlingCircle: SFSymbol { .init(rawValue: "figure.bowling.circle") }
 
     /// 􂜌
     /// Single Localization, 3 Layersets
@@ -4089,7 +4089,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBowlingCircleFill = SFSymbol(rawValue: "figure.bowling.circle.fill")
+    static var figureBowlingCircleFill: SFSymbol { .init(rawValue: "figure.bowling.circle.fill") }
 
     /// 􂜍
     /// Single Localization, 2 Layersets
@@ -4097,7 +4097,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureBoxingCircle = SFSymbol(rawValue: "figure.boxing.circle")
+    static var figureBoxingCircle: SFSymbol { .init(rawValue: "figure.boxing.circle") }
 
     /// 􂜎
     /// Single Localization, 3 Layersets
@@ -4106,7 +4106,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureBoxingCircleFill = SFSymbol(rawValue: "figure.boxing.circle.fill")
+    static var figureBoxingCircleFill: SFSymbol { .init(rawValue: "figure.boxing.circle.fill") }
 
     /// 􂚝
     /// Single Localization, 2 Layersets
@@ -4114,7 +4114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureClimbingCircle = SFSymbol(rawValue: "figure.climbing.circle")
+    static var figureClimbingCircle: SFSymbol { .init(rawValue: "figure.climbing.circle") }
 
     /// 􂚞
     /// Single Localization, 3 Layersets
@@ -4123,7 +4123,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureClimbingCircleFill = SFSymbol(rawValue: "figure.climbing.circle.fill")
+    static var figureClimbingCircleFill: SFSymbol { .init(rawValue: "figure.climbing.circle.fill") }
 
     /// 􂜏
     /// Single Localization, 2 Layersets
@@ -4131,7 +4131,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureCooldownCircle = SFSymbol(rawValue: "figure.cooldown.circle")
+    static var figureCooldownCircle: SFSymbol { .init(rawValue: "figure.cooldown.circle") }
 
     /// 􂜐
     /// Single Localization, 3 Layersets
@@ -4140,7 +4140,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureCooldownCircleFill = SFSymbol(rawValue: "figure.cooldown.circle.fill")
+    static var figureCooldownCircleFill: SFSymbol { .init(rawValue: "figure.cooldown.circle.fill") }
 
     /// 􂚃
     /// Single Localization, 2 Layersets
@@ -4148,7 +4148,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureCoreTrainingCircle = SFSymbol(rawValue: "figure.core.training.circle")
+    static var figureCoreTrainingCircle: SFSymbol { .init(rawValue: "figure.core.training.circle") }
 
     /// 􂚄
     /// Single Localization, 3 Layersets
@@ -4157,7 +4157,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureCoreTrainingCircleFill = SFSymbol(rawValue: "figure.core.training.circle.fill")
+    static var figureCoreTrainingCircleFill: SFSymbol { .init(rawValue: "figure.core.training.circle.fill") }
 
     /// 􂜑
     /// Single Localization, 2 Layersets
@@ -4165,7 +4165,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureCricketCircle = SFSymbol(rawValue: "figure.cricket.circle")
+    static var figureCricketCircle: SFSymbol { .init(rawValue: "figure.cricket.circle") }
 
     /// 􂜒
     /// Single Localization, 3 Layersets
@@ -4174,7 +4174,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureCricketCircleFill = SFSymbol(rawValue: "figure.cricket.circle.fill")
+    static var figureCricketCircleFill: SFSymbol { .init(rawValue: "figure.cricket.circle.fill") }
 
     /// 􂜓
     /// Single Localization, 2 Layersets
@@ -4182,7 +4182,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureCrossTrainingCircle = SFSymbol(rawValue: "figure.cross.training.circle")
+    static var figureCrossTrainingCircle: SFSymbol { .init(rawValue: "figure.cross.training.circle") }
 
     /// 􂜔
     /// Single Localization, 3 Layersets
@@ -4191,7 +4191,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureCrossTrainingCircleFill = SFSymbol(rawValue: "figure.cross.training.circle.fill")
+    static var figureCrossTrainingCircleFill: SFSymbol { .init(rawValue: "figure.cross.training.circle.fill") }
 
     /// 􂜕
     /// Single Localization, 2 Layersets
@@ -4199,7 +4199,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureCurlingCircle = SFSymbol(rawValue: "figure.curling.circle")
+    static var figureCurlingCircle: SFSymbol { .init(rawValue: "figure.curling.circle") }
 
     /// 􂜖
     /// Single Localization, 3 Layersets
@@ -4208,7 +4208,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureCurlingCircleFill = SFSymbol(rawValue: "figure.curling.circle.fill")
+    static var figureCurlingCircleFill: SFSymbol { .init(rawValue: "figure.curling.circle.fill") }
 
     /// 􂜗
     /// Single Localization, 2 Layersets
@@ -4216,7 +4216,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureDanceCircle = SFSymbol(rawValue: "figure.dance.circle")
+    static var figureDanceCircle: SFSymbol { .init(rawValue: "figure.dance.circle") }
 
     /// 􂜘
     /// Single Localization, 3 Layersets
@@ -4225,7 +4225,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureDanceCircleFill = SFSymbol(rawValue: "figure.dance.circle.fill")
+    static var figureDanceCircleFill: SFSymbol { .init(rawValue: "figure.dance.circle.fill") }
 
     /// 􂚅
     /// Single Localization, 2 Layersets
@@ -4233,7 +4233,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureDiscSportsCircle = SFSymbol(rawValue: "figure.disc.sports.circle")
+    static var figureDiscSportsCircle: SFSymbol { .init(rawValue: "figure.disc.sports.circle") }
 
     /// 􂚥
     /// Single Localization, 3 Layersets
@@ -4242,7 +4242,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureDiscSportsCircleFill = SFSymbol(rawValue: "figure.disc.sports.circle.fill")
+    static var figureDiscSportsCircleFill: SFSymbol { .init(rawValue: "figure.disc.sports.circle.fill") }
 
     /// 􂜜
     /// Single Localization, 2 Layersets
@@ -4250,7 +4250,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureEllipticalCircle = SFSymbol(rawValue: "figure.elliptical.circle")
+    static var figureEllipticalCircle: SFSymbol { .init(rawValue: "figure.elliptical.circle") }
 
     /// 􂜝
     /// Single Localization, 3 Layersets
@@ -4259,7 +4259,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureEllipticalCircleFill = SFSymbol(rawValue: "figure.elliptical.circle.fill")
+    static var figureEllipticalCircleFill: SFSymbol { .init(rawValue: "figure.elliptical.circle.fill") }
 
     /// 􂜞
     /// Single Localization, 2 Layersets
@@ -4267,7 +4267,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureEquestrianSportsCircle = SFSymbol(rawValue: "figure.equestrian.sports.circle")
+    static var figureEquestrianSportsCircle: SFSymbol { .init(rawValue: "figure.equestrian.sports.circle") }
 
     /// 􂜟
     /// Single Localization, 3 Layersets
@@ -4276,7 +4276,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureEquestrianSportsCircleFill = SFSymbol(rawValue: "figure.equestrian.sports.circle.fill")
+    static var figureEquestrianSportsCircleFill: SFSymbol { .init(rawValue: "figure.equestrian.sports.circle.fill") }
 
     /// 􂜠
     /// Single Localization, 2 Layersets
@@ -4284,7 +4284,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureFencingCircle = SFSymbol(rawValue: "figure.fencing.circle")
+    static var figureFencingCircle: SFSymbol { .init(rawValue: "figure.fencing.circle") }
 
     /// 􂜡
     /// Single Localization, 3 Layersets
@@ -4293,14 +4293,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureFencingCircleFill = SFSymbol(rawValue: "figure.fencing.circle.fill")
+    static var figureFencingCircleFill: SFSymbol { .init(rawValue: "figure.fencing.circle.fill") }
 
     /// 􂞣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureFieldHockey = SFSymbol(rawValue: "figure.field.hockey")
+    static var figureFieldHockey: SFSymbol { .init(rawValue: "figure.field.hockey") }
 
     /// 􂞤
     /// Single Localization, 2 Layersets
@@ -4308,7 +4308,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureFieldHockeyCircle = SFSymbol(rawValue: "figure.field.hockey.circle")
+    static var figureFieldHockeyCircle: SFSymbol { .init(rawValue: "figure.field.hockey.circle") }
 
     /// 􂞿
     /// Single Localization, 3 Layersets
@@ -4317,7 +4317,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureFieldHockeyCircleFill = SFSymbol(rawValue: "figure.field.hockey.circle.fill")
+    static var figureFieldHockeyCircleFill: SFSymbol { .init(rawValue: "figure.field.hockey.circle.fill") }
 
     /// 􂚣
     /// Single Localization, 2 Layersets
@@ -4325,7 +4325,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureFishingCircle = SFSymbol(rawValue: "figure.fishing.circle")
+    static var figureFishingCircle: SFSymbol { .init(rawValue: "figure.fishing.circle") }
 
     /// 􂚤
     /// Single Localization, 3 Layersets
@@ -4334,7 +4334,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureFishingCircleFill = SFSymbol(rawValue: "figure.fishing.circle.fill")
+    static var figureFishingCircleFill: SFSymbol { .init(rawValue: "figure.fishing.circle.fill") }
 
     /// 􂜚
     /// Single Localization, 2 Layersets
@@ -4342,7 +4342,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureFlexibilityCircle = SFSymbol(rawValue: "figure.flexibility.circle")
+    static var figureFlexibilityCircle: SFSymbol { .init(rawValue: "figure.flexibility.circle") }
 
     /// 􂜛
     /// Single Localization, 3 Layersets
@@ -4351,7 +4351,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureFlexibilityCircleFill = SFSymbol(rawValue: "figure.flexibility.circle.fill")
+    static var figureFlexibilityCircleFill: SFSymbol { .init(rawValue: "figure.flexibility.circle.fill") }
 
     /// 􂜨
     /// Single Localization, 2 Layersets
@@ -4359,7 +4359,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureGolfCircle = SFSymbol(rawValue: "figure.golf.circle")
+    static var figureGolfCircle: SFSymbol { .init(rawValue: "figure.golf.circle") }
 
     /// 􂜩
     /// Single Localization, 3 Layersets
@@ -4368,7 +4368,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureGolfCircleFill = SFSymbol(rawValue: "figure.golf.circle.fill")
+    static var figureGolfCircleFill: SFSymbol { .init(rawValue: "figure.golf.circle.fill") }
 
     /// 􂜪
     /// Single Localization, 2 Layersets
@@ -4376,7 +4376,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureGymnasticsCircle = SFSymbol(rawValue: "figure.gymnastics.circle")
+    static var figureGymnasticsCircle: SFSymbol { .init(rawValue: "figure.gymnastics.circle") }
 
     /// 􂜫
     /// Single Localization, 3 Layersets
@@ -4385,7 +4385,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureGymnasticsCircleFill = SFSymbol(rawValue: "figure.gymnastics.circle.fill")
+    static var figureGymnasticsCircleFill: SFSymbol { .init(rawValue: "figure.gymnastics.circle.fill") }
 
     /// 􂜬
     /// Single Localization, 2 Layersets
@@ -4393,7 +4393,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHandCyclingCircle = SFSymbol(rawValue: "figure.hand.cycling.circle")
+    static var figureHandCyclingCircle: SFSymbol { .init(rawValue: "figure.hand.cycling.circle") }
 
     /// 􂜭
     /// Single Localization, 3 Layersets
@@ -4402,7 +4402,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHandCyclingCircleFill = SFSymbol(rawValue: "figure.hand.cycling.circle.fill")
+    static var figureHandCyclingCircleFill: SFSymbol { .init(rawValue: "figure.hand.cycling.circle.fill") }
 
     /// 􂛇
     /// Single Localization, 2 Layersets
@@ -4410,7 +4410,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHandballCircle = SFSymbol(rawValue: "figure.handball.circle")
+    static var figureHandballCircle: SFSymbol { .init(rawValue: "figure.handball.circle") }
 
     /// 􂛈
     /// Single Localization, 3 Layersets
@@ -4419,7 +4419,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHandballCircleFill = SFSymbol(rawValue: "figure.handball.circle.fill")
+    static var figureHandballCircleFill: SFSymbol { .init(rawValue: "figure.handball.circle.fill") }
 
     /// 􂐿
     /// Single Localization, 2 Layersets
@@ -4427,7 +4427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHighintensityIntervaltrainingCircle = SFSymbol(rawValue: "figure.highintensity.intervaltraining.circle")
+    static var figureHighintensityIntervaltrainingCircle: SFSymbol { .init(rawValue: "figure.highintensity.intervaltraining.circle") }
 
     /// 􂑀
     /// Single Localization, 3 Layersets
@@ -4436,7 +4436,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHighintensityIntervaltrainingCircleFill = SFSymbol(rawValue: "figure.highintensity.intervaltraining.circle.fill")
+    static var figureHighintensityIntervaltrainingCircleFill: SFSymbol { .init(rawValue: "figure.highintensity.intervaltraining.circle.fill") }
 
     /// 􂕟
     /// Single Localization, 2 Layersets
@@ -4444,7 +4444,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHikingCircle = SFSymbol(rawValue: "figure.hiking.circle")
+    static var figureHikingCircle: SFSymbol { .init(rawValue: "figure.hiking.circle") }
 
     /// 􂕠
     /// Single Localization, 3 Layersets
@@ -4453,7 +4453,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHikingCircleFill = SFSymbol(rawValue: "figure.hiking.circle.fill")
+    static var figureHikingCircleFill: SFSymbol { .init(rawValue: "figure.hiking.circle.fill") }
 
     /// 􂕡
     /// Single Localization, 2 Layersets
@@ -4461,7 +4461,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHockeyCircle = SFSymbol(rawValue: "figure.hockey.circle")
+    static var figureHockeyCircle: SFSymbol { .init(rawValue: "figure.hockey.circle") }
 
     /// 􂕢
     /// Single Localization, 3 Layersets
@@ -4470,7 +4470,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHockeyCircleFill = SFSymbol(rawValue: "figure.hockey.circle.fill")
+    static var figureHockeyCircleFill: SFSymbol { .init(rawValue: "figure.hockey.circle.fill") }
 
     /// 􂕣
     /// Single Localization, 2 Layersets
@@ -4478,7 +4478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureHuntingCircle = SFSymbol(rawValue: "figure.hunting.circle")
+    static var figureHuntingCircle: SFSymbol { .init(rawValue: "figure.hunting.circle") }
 
     /// 􂕤
     /// Single Localization, 3 Layersets
@@ -4487,14 +4487,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureHuntingCircleFill = SFSymbol(rawValue: "figure.hunting.circle.fill")
+    static var figureHuntingCircleFill: SFSymbol { .init(rawValue: "figure.hunting.circle.fill") }
 
     /// 􂟇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureIceHockey = SFSymbol(rawValue: "figure.ice.hockey")
+    static var figureIceHockey: SFSymbol { .init(rawValue: "figure.ice.hockey") }
 
     /// 􂟈
     /// Single Localization, 2 Layersets
@@ -4502,7 +4502,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureIceHockeyCircle = SFSymbol(rawValue: "figure.ice.hockey.circle")
+    static var figureIceHockeyCircle: SFSymbol { .init(rawValue: "figure.ice.hockey.circle") }
 
     /// 􂟉
     /// Single Localization, 3 Layersets
@@ -4511,14 +4511,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureIceHockeyCircleFill = SFSymbol(rawValue: "figure.ice.hockey.circle.fill")
+    static var figureIceHockeyCircleFill: SFSymbol { .init(rawValue: "figure.ice.hockey.circle.fill") }
 
     /// 􂟀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureIceSkating = SFSymbol(rawValue: "figure.ice.skating")
+    static var figureIceSkating: SFSymbol { .init(rawValue: "figure.ice.skating") }
 
     /// 􂟁
     /// Single Localization, 2 Layersets
@@ -4526,7 +4526,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureIceSkatingCircle = SFSymbol(rawValue: "figure.ice.skating.circle")
+    static var figureIceSkatingCircle: SFSymbol { .init(rawValue: "figure.ice.skating.circle") }
 
     /// 􂟂
     /// Single Localization, 3 Layersets
@@ -4535,7 +4535,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureIceSkatingCircleFill = SFSymbol(rawValue: "figure.ice.skating.circle.fill")
+    static var figureIceSkatingCircleFill: SFSymbol { .init(rawValue: "figure.ice.skating.circle.fill") }
 
     /// 􂕥
     /// Single Localization, 2 Layersets
@@ -4543,7 +4543,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureIndoorCycleCircle = SFSymbol(rawValue: "figure.indoor.cycle.circle")
+    static var figureIndoorCycleCircle: SFSymbol { .init(rawValue: "figure.indoor.cycle.circle") }
 
     /// 􂕦
     /// Single Localization, 3 Layersets
@@ -4552,14 +4552,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureIndoorCycleCircleFill = SFSymbol(rawValue: "figure.indoor.cycle.circle.fill")
+    static var figureIndoorCycleCircleFill: SFSymbol { .init(rawValue: "figure.indoor.cycle.circle.fill") }
 
     /// 􁌋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureIndoorRowing = SFSymbol(rawValue: "figure.indoor.rowing")
+    static var figureIndoorRowing: SFSymbol { .init(rawValue: "figure.indoor.rowing") }
 
     /// 􂖁
     /// Single Localization, 2 Layersets
@@ -4567,7 +4567,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureIndoorRowingCircle = SFSymbol(rawValue: "figure.indoor.rowing.circle")
+    static var figureIndoorRowingCircle: SFSymbol { .init(rawValue: "figure.indoor.rowing.circle") }
 
     /// 􂖂
     /// Single Localization, 3 Layersets
@@ -4576,14 +4576,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureIndoorRowingCircleFill = SFSymbol(rawValue: "figure.indoor.rowing.circle.fill")
+    static var figureIndoorRowingCircleFill: SFSymbol { .init(rawValue: "figure.indoor.rowing.circle.fill") }
 
     /// 􁔿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureIndoorSoccer = SFSymbol(rawValue: "figure.indoor.soccer")
+    static var figureIndoorSoccer: SFSymbol { .init(rawValue: "figure.indoor.soccer") }
 
     /// 􂖉
     /// Single Localization, 2 Layersets
@@ -4591,7 +4591,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureIndoorSoccerCircle = SFSymbol(rawValue: "figure.indoor.soccer.circle")
+    static var figureIndoorSoccerCircle: SFSymbol { .init(rawValue: "figure.indoor.soccer.circle") }
 
     /// 􂖊
     /// Single Localization, 3 Layersets
@@ -4600,7 +4600,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureIndoorSoccerCircleFill = SFSymbol(rawValue: "figure.indoor.soccer.circle.fill")
+    static var figureIndoorSoccerCircleFill: SFSymbol { .init(rawValue: "figure.indoor.soccer.circle.fill") }
 
     /// 􂙽
     /// Single Localization, 2 Layersets
@@ -4608,7 +4608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureJumpropeCircle = SFSymbol(rawValue: "figure.jumprope.circle")
+    static var figureJumpropeCircle: SFSymbol { .init(rawValue: "figure.jumprope.circle") }
 
     /// 􂙾
     /// Single Localization, 3 Layersets
@@ -4617,7 +4617,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureJumpropeCircleFill = SFSymbol(rawValue: "figure.jumprope.circle.fill")
+    static var figureJumpropeCircleFill: SFSymbol { .init(rawValue: "figure.jumprope.circle.fill") }
 
     /// 􂕧
     /// Single Localization, 2 Layersets
@@ -4625,7 +4625,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureKickboxingCircle = SFSymbol(rawValue: "figure.kickboxing.circle")
+    static var figureKickboxingCircle: SFSymbol { .init(rawValue: "figure.kickboxing.circle") }
 
     /// 􂕨
     /// Single Localization, 3 Layersets
@@ -4634,7 +4634,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureKickboxingCircleFill = SFSymbol(rawValue: "figure.kickboxing.circle.fill")
+    static var figureKickboxingCircleFill: SFSymbol { .init(rawValue: "figure.kickboxing.circle.fill") }
 
     /// 􂕩
     /// Single Localization, 2 Layersets
@@ -4642,7 +4642,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureLacrosseCircle = SFSymbol(rawValue: "figure.lacrosse.circle")
+    static var figureLacrosseCircle: SFSymbol { .init(rawValue: "figure.lacrosse.circle") }
 
     /// 􂕪
     /// Single Localization, 3 Layersets
@@ -4651,7 +4651,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureLacrosseCircleFill = SFSymbol(rawValue: "figure.lacrosse.circle.fill")
+    static var figureLacrosseCircleFill: SFSymbol { .init(rawValue: "figure.lacrosse.circle.fill") }
 
     /// 􂕫
     /// Single Localization, 2 Layersets
@@ -4659,7 +4659,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureMartialArtsCircle = SFSymbol(rawValue: "figure.martial.arts.circle")
+    static var figureMartialArtsCircle: SFSymbol { .init(rawValue: "figure.martial.arts.circle") }
 
     /// 􂕬
     /// Single Localization, 3 Layersets
@@ -4668,7 +4668,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureMartialArtsCircleFill = SFSymbol(rawValue: "figure.martial.arts.circle.fill")
+    static var figureMartialArtsCircleFill: SFSymbol { .init(rawValue: "figure.martial.arts.circle.fill") }
 
     /// 􂕭
     /// Single Localization, 2 Layersets
@@ -4676,7 +4676,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureMindAndBodyCircle = SFSymbol(rawValue: "figure.mind.and.body.circle")
+    static var figureMindAndBodyCircle: SFSymbol { .init(rawValue: "figure.mind.and.body.circle") }
 
     /// 􂕮
     /// Single Localization, 3 Layersets
@@ -4685,7 +4685,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureMindAndBodyCircleFill = SFSymbol(rawValue: "figure.mind.and.body.circle.fill")
+    static var figureMindAndBodyCircleFill: SFSymbol { .init(rawValue: "figure.mind.and.body.circle.fill") }
 
     /// 􂕯
     /// Single Localization, 2 Layersets
@@ -4693,7 +4693,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureMixedCardioCircle = SFSymbol(rawValue: "figure.mixed.cardio.circle")
+    static var figureMixedCardioCircle: SFSymbol { .init(rawValue: "figure.mixed.cardio.circle") }
 
     /// 􂕰
     /// Single Localization, 3 Layersets
@@ -4702,7 +4702,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureMixedCardioCircleFill = SFSymbol(rawValue: "figure.mixed.cardio.circle.fill")
+    static var figureMixedCardioCircleFill: SFSymbol { .init(rawValue: "figure.mixed.cardio.circle.fill") }
 
     /// 􂕱
     /// Single Localization, 2 Layersets
@@ -4710,7 +4710,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureOpenWaterSwimCircle = SFSymbol(rawValue: "figure.open.water.swim.circle")
+    static var figureOpenWaterSwimCircle: SFSymbol { .init(rawValue: "figure.open.water.swim.circle") }
 
     /// 􂕲
     /// Single Localization, 3 Layersets
@@ -4719,7 +4719,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureOpenWaterSwimCircleFill = SFSymbol(rawValue: "figure.open.water.swim.circle.fill")
+    static var figureOpenWaterSwimCircleFill: SFSymbol { .init(rawValue: "figure.open.water.swim.circle.fill") }
 
     /// 􂛉
     /// Single Localization, 2 Layersets
@@ -4727,7 +4727,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureOutdoorCycleCircle = SFSymbol(rawValue: "figure.outdoor.cycle.circle")
+    static var figureOutdoorCycleCircle: SFSymbol { .init(rawValue: "figure.outdoor.cycle.circle") }
 
     /// 􂛊
     /// Single Localization, 3 Layersets
@@ -4736,14 +4736,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureOutdoorCycleCircleFill = SFSymbol(rawValue: "figure.outdoor.cycle.circle.fill")
+    static var figureOutdoorCycleCircleFill: SFSymbol { .init(rawValue: "figure.outdoor.cycle.circle.fill") }
 
     /// 􂞼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureOutdoorRowing = SFSymbol(rawValue: "figure.outdoor.rowing")
+    static var figureOutdoorRowing: SFSymbol { .init(rawValue: "figure.outdoor.rowing") }
 
     /// 􂞽
     /// Single Localization, 2 Layersets
@@ -4751,7 +4751,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureOutdoorRowingCircle = SFSymbol(rawValue: "figure.outdoor.rowing.circle")
+    static var figureOutdoorRowingCircle: SFSymbol { .init(rawValue: "figure.outdoor.rowing.circle") }
 
     /// 􂞾
     /// Single Localization, 3 Layersets
@@ -4760,14 +4760,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureOutdoorRowingCircleFill = SFSymbol(rawValue: "figure.outdoor.rowing.circle.fill")
+    static var figureOutdoorRowingCircleFill: SFSymbol { .init(rawValue: "figure.outdoor.rowing.circle.fill") }
 
     /// 􂟄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureOutdoorSoccer = SFSymbol(rawValue: "figure.outdoor.soccer")
+    static var figureOutdoorSoccer: SFSymbol { .init(rawValue: "figure.outdoor.soccer") }
 
     /// 􂟅
     /// Single Localization, 2 Layersets
@@ -4775,7 +4775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureOutdoorSoccerCircle = SFSymbol(rawValue: "figure.outdoor.soccer.circle")
+    static var figureOutdoorSoccerCircle: SFSymbol { .init(rawValue: "figure.outdoor.soccer.circle") }
 
     /// 􂟆
     /// Single Localization, 3 Layersets
@@ -4784,7 +4784,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureOutdoorSoccerCircleFill = SFSymbol(rawValue: "figure.outdoor.soccer.circle.fill")
+    static var figureOutdoorSoccerCircleFill: SFSymbol { .init(rawValue: "figure.outdoor.soccer.circle.fill") }
 
     /// 􂕵
     /// Single Localization, 2 Layersets
@@ -4792,7 +4792,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figurePickleballCircle = SFSymbol(rawValue: "figure.pickleball.circle")
+    static var figurePickleballCircle: SFSymbol { .init(rawValue: "figure.pickleball.circle") }
 
     /// 􂕶
     /// Single Localization, 3 Layersets
@@ -4801,7 +4801,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figurePickleballCircleFill = SFSymbol(rawValue: "figure.pickleball.circle.fill")
+    static var figurePickleballCircleFill: SFSymbol { .init(rawValue: "figure.pickleball.circle.fill") }
 
     /// 􂕷
     /// Single Localization, 2 Layersets
@@ -4809,7 +4809,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figurePilatesCircle = SFSymbol(rawValue: "figure.pilates.circle")
+    static var figurePilatesCircle: SFSymbol { .init(rawValue: "figure.pilates.circle") }
 
     /// 􂕸
     /// Single Localization, 3 Layersets
@@ -4818,7 +4818,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figurePilatesCircleFill = SFSymbol(rawValue: "figure.pilates.circle.fill")
+    static var figurePilatesCircleFill: SFSymbol { .init(rawValue: "figure.pilates.circle.fill") }
 
     /// 􂕹
     /// Single Localization, 2 Layersets
@@ -4826,7 +4826,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figurePlayCircle = SFSymbol(rawValue: "figure.play.circle")
+    static var figurePlayCircle: SFSymbol { .init(rawValue: "figure.play.circle") }
 
     /// 􂕺
     /// Single Localization, 3 Layersets
@@ -4835,7 +4835,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figurePlayCircleFill = SFSymbol(rawValue: "figure.play.circle.fill")
+    static var figurePlayCircleFill: SFSymbol { .init(rawValue: "figure.play.circle.fill") }
 
     /// 􂕻
     /// Single Localization, 2 Layersets
@@ -4843,7 +4843,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figurePoolSwimCircle = SFSymbol(rawValue: "figure.pool.swim.circle")
+    static var figurePoolSwimCircle: SFSymbol { .init(rawValue: "figure.pool.swim.circle") }
 
     /// 􂕼
     /// Single Localization, 3 Layersets
@@ -4852,7 +4852,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figurePoolSwimCircleFill = SFSymbol(rawValue: "figure.pool.swim.circle.fill")
+    static var figurePoolSwimCircleFill: SFSymbol { .init(rawValue: "figure.pool.swim.circle.fill") }
 
     /// 􂕽
     /// Single Localization, 2 Layersets
@@ -4860,7 +4860,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRacquetballCircle = SFSymbol(rawValue: "figure.racquetball.circle")
+    static var figureRacquetballCircle: SFSymbol { .init(rawValue: "figure.racquetball.circle") }
 
     /// 􂕾
     /// Single Localization, 3 Layersets
@@ -4869,7 +4869,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRacquetballCircleFill = SFSymbol(rawValue: "figure.racquetball.circle.fill")
+    static var figureRacquetballCircleFill: SFSymbol { .init(rawValue: "figure.racquetball.circle.fill") }
 
     /// 􂛹
     /// Single Localization, 2 Layersets
@@ -4877,7 +4877,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRollCircle = SFSymbol(rawValue: "figure.roll.circle")
+    static var figureRollCircle: SFSymbol { .init(rawValue: "figure.roll.circle") }
 
     /// 􂛺
     /// Single Localization, 3 Layersets
@@ -4886,7 +4886,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRollCircleFill = SFSymbol(rawValue: "figure.roll.circle.fill")
+    static var figureRollCircleFill: SFSymbol { .init(rawValue: "figure.roll.circle.fill") }
 
     /// 􂛻
     /// Single Localization, 2 Layersets
@@ -4894,7 +4894,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRollRunningpaceCircle = SFSymbol(rawValue: "figure.roll.runningpace.circle")
+    static var figureRollRunningpaceCircle: SFSymbol { .init(rawValue: "figure.roll.runningpace.circle") }
 
     /// 􂛼
     /// Single Localization, 3 Layersets
@@ -4903,7 +4903,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRollRunningpaceCircleFill = SFSymbol(rawValue: "figure.roll.runningpace.circle.fill")
+    static var figureRollRunningpaceCircleFill: SFSymbol { .init(rawValue: "figure.roll.runningpace.circle.fill") }
 
     /// 􂕿
     /// Single Localization, 2 Layersets
@@ -4911,7 +4911,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRollingCircle = SFSymbol(rawValue: "figure.rolling.circle")
+    static var figureRollingCircle: SFSymbol { .init(rawValue: "figure.rolling.circle") }
 
     /// 􂖀
     /// Single Localization, 3 Layersets
@@ -4920,7 +4920,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRollingCircleFill = SFSymbol(rawValue: "figure.rolling.circle.fill")
+    static var figureRollingCircleFill: SFSymbol { .init(rawValue: "figure.rolling.circle.fill") }
 
     /// 􂖃
     /// Single Localization, 2 Layersets
@@ -4928,7 +4928,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRugbyCircle = SFSymbol(rawValue: "figure.rugby.circle")
+    static var figureRugbyCircle: SFSymbol { .init(rawValue: "figure.rugby.circle") }
 
     /// 􂖄
     /// Single Localization, 3 Layersets
@@ -4937,14 +4937,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRugbyCircleFill = SFSymbol(rawValue: "figure.rugby.circle.fill")
+    static var figureRugbyCircleFill: SFSymbol { .init(rawValue: "figure.rugby.circle.fill") }
 
     /// 􂛅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureRunTreadmill = SFSymbol(rawValue: "figure.run.treadmill")
+    static var figureRunTreadmill: SFSymbol { .init(rawValue: "figure.run.treadmill") }
 
     /// 􂛵
     /// Single Localization, 2 Layersets
@@ -4952,7 +4952,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureRunTreadmillCircle = SFSymbol(rawValue: "figure.run.treadmill.circle")
+    static var figureRunTreadmillCircle: SFSymbol { .init(rawValue: "figure.run.treadmill.circle") }
 
     /// 􂛶
     /// Single Localization, 3 Layersets
@@ -4961,7 +4961,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureRunTreadmillCircleFill = SFSymbol(rawValue: "figure.run.treadmill.circle.fill")
+    static var figureRunTreadmillCircleFill: SFSymbol { .init(rawValue: "figure.run.treadmill.circle.fill") }
 
     /// 􂙻
     /// Single Localization, 2 Layersets
@@ -4969,7 +4969,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSailingCircle = SFSymbol(rawValue: "figure.sailing.circle")
+    static var figureSailingCircle: SFSymbol { .init(rawValue: "figure.sailing.circle") }
 
     /// 􂙼
     /// Single Localization, 3 Layersets
@@ -4978,196 +4978,196 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSailingCircleFill = SFSymbol(rawValue: "figure.sailing.circle.fill")
+    static var figureSailingCircleFill: SFSymbol { .init(rawValue: "figure.sailing.circle.fill") }
 
     /// 􂒭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats1 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1")
+    static var figureSeatedSeatbeltLeftDriveSeats1: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1") }
 
     /// 􂒪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats11 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1.1")
+    static var figureSeatedSeatbeltLeftDriveSeats11: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1.1") }
 
     /// 􂒃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats11Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1.1.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats11Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1.1.fill") }
 
     /// 􂒩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats12 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1.2")
+    static var figureSeatedSeatbeltLeftDriveSeats12: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1.2") }
 
     /// 􂒂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats12Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1.2.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats12Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1.2.fill") }
 
     /// 􂒆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats1Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.1.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats1Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.1.fill") }
 
     /// 􂒬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats2 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2")
+    static var figureSeatedSeatbeltLeftDriveSeats2: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2") }
 
     /// 􂒨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats22 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2")
+    static var figureSeatedSeatbeltLeftDriveSeats22: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2") }
 
     /// 􂒤
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats222 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.2")
+    static var figureSeatedSeatbeltLeftDriveSeats222: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.2") }
 
     /// 􂑾
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats222Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.2.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats222Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.2.fill") }
 
     /// 􂒥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats223 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.3")
+    static var figureSeatedSeatbeltLeftDriveSeats223: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.3") }
 
     /// 􂒠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats223Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats223Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.3.fill") }
 
     /// 􂒁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats22Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats22Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.2.fill") }
 
     /// 􂒧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats23 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3")
+    static var figureSeatedSeatbeltLeftDriveSeats23: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3") }
 
     /// 􂒣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats232 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.2")
+    static var figureSeatedSeatbeltLeftDriveSeats232: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.2") }
 
     /// 􂑽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats232Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.2.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats232Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.2.fill") }
 
     /// 􂒢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats233 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.3")
+    static var figureSeatedSeatbeltLeftDriveSeats233: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.3") }
 
     /// 􂑼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats233Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats233Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.3.fill") }
 
     /// 􂒀
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats23Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats23Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.3.fill") }
 
     /// 􂒅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats2Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.2.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats2Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.2.fill") }
 
     /// 􂒫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats3 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3")
+    static var figureSeatedSeatbeltLeftDriveSeats3: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3") }
 
     /// 􂒦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats33 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3")
+    static var figureSeatedSeatbeltLeftDriveSeats33: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3") }
 
     /// 􂒡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats333 = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.3")
+    static var figureSeatedSeatbeltLeftDriveSeats333: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.3") }
 
     /// 􂑻
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats333Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats333Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.3.fill") }
 
     /// 􂑿
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats33Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats33Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3.3.fill") }
 
     /// 􂒄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSeatbeltLeftDriveSeats3Fill = SFSymbol(rawValue: "figure.seated.seatbelt.left.drive.seats.3.fill")
+    static var figureSeatedSeatbeltLeftDriveSeats3Fill: SFSymbol { .init(rawValue: "figure.seated.seatbelt.left.drive.seats.3.fill") }
 
     /// 􁺼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSideLeft = SFSymbol(rawValue: "figure.seated.side.left")
+    static var figureSeatedSideLeft: SFSymbol { .init(rawValue: "figure.seated.side.left") }
 
     /// 􁁶
     /// Single Localization, 2 Layersets
@@ -5175,7 +5175,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.lower")
+    static var figureSeatedSideLeftAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.lower") }
 
     /// 􁁵
     /// Single Localization, 2 Layersets
@@ -5183,7 +5183,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.middle")
+    static var figureSeatedSideLeftAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.middle") }
 
     /// 􁁸
     /// Single Localization, 2 Layersets
@@ -5191,7 +5191,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.middle.and.lower")
+    static var figureSeatedSideLeftAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.middle.and.lower") }
 
     /// 􁻀
     /// Single Localization, 2 Layersets
@@ -5199,7 +5199,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.middle.and.lower.angled")
+    static var figureSeatedSideLeftAirDistributionMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.middle.and.lower.angled") }
 
     /// 􁁷
     /// Single Localization, 2 Layersets
@@ -5207,7 +5207,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper")
+    static var figureSeatedSideLeftAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper") }
 
     /// 􁺿
     /// Single Localization, 2 Layersets
@@ -5215,7 +5215,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpperAngledAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.lower.angled")
+    static var figureSeatedSideLeftAirDistributionUpperAngledAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.lower.angled") }
 
     /// 􁺾
     /// Single Localization, 2 Layersets
@@ -5223,7 +5223,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpperAngledAndMiddle = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.middle")
+    static var figureSeatedSideLeftAirDistributionUpperAngledAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.middle") }
 
     /// 􁺽
     /// Single Localization, 2 Layersets
@@ -5231,7 +5231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpperAngledAndMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.middle.and.lower.angled")
+    static var figureSeatedSideLeftAirDistributionUpperAngledAndMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.middle.and.lower.angled") }
 
     /// 􁊍
     /// Single Localization, 3 Layersets
@@ -5240,7 +5240,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideLeftAirbagOff = SFSymbol(rawValue: "figure.seated.side.left.airbag.off")
+    static var figureSeatedSideLeftAirbagOff: SFSymbol { .init(rawValue: "figure.seated.side.left.airbag.off") }
 
     /// 􁉻
     /// Single Localization, 3 Layersets
@@ -5249,7 +5249,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideLeftAirbagOff2 = SFSymbol(rawValue: "figure.seated.side.left.airbag.off.2")
+    static var figureSeatedSideLeftAirbagOff2: SFSymbol { .init(rawValue: "figure.seated.side.left.airbag.off.2") }
 
     /// 􀿧
     /// Single Localization, 3 Layersets
@@ -5258,7 +5258,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideLeftAirbagOn = SFSymbol(rawValue: "figure.seated.side.left.airbag.on")
+    static var figureSeatedSideLeftAirbagOn: SFSymbol { .init(rawValue: "figure.seated.side.left.airbag.on") }
 
     /// 􁞚
     /// Single Localization, 3 Layersets
@@ -5267,7 +5267,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideLeftAirbagOn2 = SFSymbol(rawValue: "figure.seated.side.left.airbag.on.2")
+    static var figureSeatedSideLeftAirbagOn2: SFSymbol { .init(rawValue: "figure.seated.side.left.airbag.on.2") }
 
     /// 􁲍
     /// Single Localization, 2 Layersets
@@ -5275,7 +5275,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAutomatic = SFSymbol(rawValue: "figure.seated.side.left.automatic")
+    static var figureSeatedSideLeftAutomatic: SFSymbol { .init(rawValue: "figure.seated.side.left.automatic") }
 
     /// 􂟃
     /// Single Localization, 2 Layersets
@@ -5283,7 +5283,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftFan = SFSymbol(rawValue: "figure.seated.side.left.fan")
+    static var figureSeatedSideLeftFan: SFSymbol { .init(rawValue: "figure.seated.side.left.fan") }
 
     /// 􁦂
     /// Single Localization, 2 Layersets
@@ -5291,7 +5291,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftSteeringwheel = SFSymbol(rawValue: "figure.seated.side.left.steeringwheel")
+    static var figureSeatedSideLeftSteeringwheel: SFSymbol { .init(rawValue: "figure.seated.side.left.steeringwheel") }
 
     /// 􁁹
     /// Single Localization, 2 Layersets
@@ -5299,7 +5299,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWaves = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWaves: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves") }
 
     /// 􁻒
     /// Single Localization, 2 Layersets
@@ -5307,7 +5307,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.lower")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.lower") }
 
     /// 􁻑
     /// Single Localization, 2 Layersets
@@ -5315,7 +5315,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.middle")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.middle") }
 
     /// 􁻍
     /// Single Localization, 2 Layersets
@@ -5323,7 +5323,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.middle.and.lower")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.middle.and.lower") }
 
     /// 􁻐
     /// Single Localization, 2 Layersets
@@ -5331,7 +5331,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper") }
 
     /// 􁻏
     /// Single Localization, 2 Layersets
@@ -5339,7 +5339,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndLower = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.lower")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndLower: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.lower") }
 
     /// 􁻎
     /// Single Localization, 2 Layersets
@@ -5347,7 +5347,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.middle")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.middle") }
 
     /// 􁻌
     /// Single Localization, 2 Layersets
@@ -5355,14 +5355,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower")
+    static var figureSeatedSideLeftWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.left.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower") }
 
     /// 􂧏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSideRight = SFSymbol(rawValue: "figure.seated.side.right")
+    static var figureSeatedSideRight: SFSymbol { .init(rawValue: "figure.seated.side.right") }
 
     /// 􂧑
     /// Single Localization, 2 Layersets
@@ -5370,7 +5370,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.lower")
+    static var figureSeatedSideRightAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.lower") }
 
     /// 􂧒
     /// Single Localization, 2 Layersets
@@ -5378,7 +5378,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.middle")
+    static var figureSeatedSideRightAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.middle") }
 
     /// 􂧓
     /// Single Localization, 2 Layersets
@@ -5386,7 +5386,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.middle.and.lower")
+    static var figureSeatedSideRightAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.middle.and.lower") }
 
     /// 􂧗
     /// Single Localization, 2 Layersets
@@ -5394,7 +5394,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.middle.and.lower.angled")
+    static var figureSeatedSideRightAirDistributionMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.middle.and.lower.angled") }
 
     /// 􂧐
     /// Single Localization, 2 Layersets
@@ -5402,7 +5402,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper")
+    static var figureSeatedSideRightAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper") }
 
     /// 􂧖
     /// Single Localization, 2 Layersets
@@ -5410,7 +5410,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpperAngledAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.lower.angled")
+    static var figureSeatedSideRightAirDistributionUpperAngledAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.lower.angled") }
 
     /// 􂧕
     /// Single Localization, 2 Layersets
@@ -5418,7 +5418,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpperAngledAndMiddle = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.middle")
+    static var figureSeatedSideRightAirDistributionUpperAngledAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.middle") }
 
     /// 􂧔
     /// Single Localization, 2 Layersets
@@ -5426,7 +5426,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpperAngledAndMiddleAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.middle.and.lower.angled")
+    static var figureSeatedSideRightAirDistributionUpperAngledAndMiddleAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.middle.and.lower.angled") }
 
     /// 􂧌
     /// Single Localization, 3 Layersets
@@ -5435,7 +5435,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideRightAirbagOff = SFSymbol(rawValue: "figure.seated.side.right.airbag.off")
+    static var figureSeatedSideRightAirbagOff: SFSymbol { .init(rawValue: "figure.seated.side.right.airbag.off") }
 
     /// 􂧎
     /// Single Localization, 3 Layersets
@@ -5444,7 +5444,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideRightAirbagOff2 = SFSymbol(rawValue: "figure.seated.side.right.airbag.off.2")
+    static var figureSeatedSideRightAirbagOff2: SFSymbol { .init(rawValue: "figure.seated.side.right.airbag.off.2") }
 
     /// 􂧋
     /// Single Localization, 3 Layersets
@@ -5453,7 +5453,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideRightAirbagOn = SFSymbol(rawValue: "figure.seated.side.right.airbag.on")
+    static var figureSeatedSideRightAirbagOn: SFSymbol { .init(rawValue: "figure.seated.side.right.airbag.on") }
 
     /// 􂧍
     /// Single Localization, 3 Layersets
@@ -5462,7 +5462,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSeatedSideRightAirbagOn2 = SFSymbol(rawValue: "figure.seated.side.right.airbag.on.2")
+    static var figureSeatedSideRightAirbagOn2: SFSymbol { .init(rawValue: "figure.seated.side.right.airbag.on.2") }
 
     /// 􂧡
     /// Single Localization, 2 Layersets
@@ -5470,7 +5470,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAutomatic = SFSymbol(rawValue: "figure.seated.side.right.automatic")
+    static var figureSeatedSideRightAutomatic: SFSymbol { .init(rawValue: "figure.seated.side.right.automatic") }
 
     /// 􂧢
     /// Single Localization, 2 Layersets
@@ -5478,7 +5478,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightFan = SFSymbol(rawValue: "figure.seated.side.right.fan")
+    static var figureSeatedSideRightFan: SFSymbol { .init(rawValue: "figure.seated.side.right.fan") }
 
     /// 􂧠
     /// Single Localization, 2 Layersets
@@ -5486,7 +5486,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightSteeringwheel = SFSymbol(rawValue: "figure.seated.side.right.steeringwheel")
+    static var figureSeatedSideRightSteeringwheel: SFSymbol { .init(rawValue: "figure.seated.side.right.steeringwheel") }
 
     /// 􂧘
     /// Single Localization, 2 Layersets
@@ -5494,7 +5494,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWaves = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWaves: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves") }
 
     /// 􂧞
     /// Single Localization, 2 Layersets
@@ -5502,7 +5502,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionLower = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.lower")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionLower: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.lower") }
 
     /// 􂧟
     /// Single Localization, 2 Layersets
@@ -5510,7 +5510,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionMiddle = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.middle")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionMiddle: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.middle") }
 
     /// 􂧚
     /// Single Localization, 2 Layersets
@@ -5518,7 +5518,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.middle.and.lower")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.middle.and.lower") }
 
     /// 􂧝
     /// Single Localization, 2 Layersets
@@ -5526,7 +5526,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpper = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpper: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper") }
 
     /// 􂧜
     /// Single Localization, 2 Layersets
@@ -5534,7 +5534,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndLower = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.lower")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndLower: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.lower") }
 
     /// 􂧛
     /// Single Localization, 2 Layersets
@@ -5542,7 +5542,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.middle")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddle: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.middle") }
 
     /// 􂧙
     /// Single Localization, 2 Layersets
@@ -5550,14 +5550,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower")
+    static var figureSeatedSideRightWindshieldFrontAndHeatWavesAirDistributionUpperAndMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.right.windshield.front.and.heat.waves.air.distribution.upper.and.middle.and.lower") }
 
     /// 􁔽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSkateboarding = SFSymbol(rawValue: "figure.skateboarding")
+    static var figureSkateboarding: SFSymbol { .init(rawValue: "figure.skateboarding") }
 
     /// 􂖅
     /// Single Localization, 2 Layersets
@@ -5565,7 +5565,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSkateboardingCircle = SFSymbol(rawValue: "figure.skateboarding.circle")
+    static var figureSkateboardingCircle: SFSymbol { .init(rawValue: "figure.skateboarding.circle") }
 
     /// 􂖆
     /// Single Localization, 3 Layersets
@@ -5574,7 +5574,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSkateboardingCircleFill = SFSymbol(rawValue: "figure.skateboarding.circle.fill")
+    static var figureSkateboardingCircleFill: SFSymbol { .init(rawValue: "figure.skateboarding.circle.fill") }
 
     /// 􂚁
     /// Single Localization, 2 Layersets
@@ -5582,7 +5582,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSkiingCrosscountryCircle = SFSymbol(rawValue: "figure.skiing.crosscountry.circle")
+    static var figureSkiingCrosscountryCircle: SFSymbol { .init(rawValue: "figure.skiing.crosscountry.circle") }
 
     /// 􂚂
     /// Single Localization, 3 Layersets
@@ -5591,7 +5591,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSkiingCrosscountryCircleFill = SFSymbol(rawValue: "figure.skiing.crosscountry.circle.fill")
+    static var figureSkiingCrosscountryCircleFill: SFSymbol { .init(rawValue: "figure.skiing.crosscountry.circle.fill") }
 
     /// 􂙿
     /// Single Localization, 2 Layersets
@@ -5599,7 +5599,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSkiingDownhillCircle = SFSymbol(rawValue: "figure.skiing.downhill.circle")
+    static var figureSkiingDownhillCircle: SFSymbol { .init(rawValue: "figure.skiing.downhill.circle") }
 
     /// 􂚀
     /// Single Localization, 3 Layersets
@@ -5608,7 +5608,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSkiingDownhillCircleFill = SFSymbol(rawValue: "figure.skiing.downhill.circle.fill")
+    static var figureSkiingDownhillCircleFill: SFSymbol { .init(rawValue: "figure.skiing.downhill.circle.fill") }
 
     /// 􂖇
     /// Single Localization, 2 Layersets
@@ -5616,7 +5616,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSnowboardingCircle = SFSymbol(rawValue: "figure.snowboarding.circle")
+    static var figureSnowboardingCircle: SFSymbol { .init(rawValue: "figure.snowboarding.circle") }
 
     /// 􂖈
     /// Single Localization, 3 Layersets
@@ -5625,7 +5625,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSnowboardingCircleFill = SFSymbol(rawValue: "figure.snowboarding.circle.fill")
+    static var figureSnowboardingCircleFill: SFSymbol { .init(rawValue: "figure.snowboarding.circle.fill") }
 
     /// 􂙹
     /// Single Localization, 2 Layersets
@@ -5633,7 +5633,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSocialdanceCircle = SFSymbol(rawValue: "figure.socialdance.circle")
+    static var figureSocialdanceCircle: SFSymbol { .init(rawValue: "figure.socialdance.circle") }
 
     /// 􂙺
     /// Single Localization, 3 Layersets
@@ -5642,7 +5642,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSocialdanceCircleFill = SFSymbol(rawValue: "figure.socialdance.circle.fill")
+    static var figureSocialdanceCircleFill: SFSymbol { .init(rawValue: "figure.socialdance.circle.fill") }
 
     /// 􂖋
     /// Single Localization, 2 Layersets
@@ -5650,7 +5650,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSoftballCircle = SFSymbol(rawValue: "figure.softball.circle")
+    static var figureSoftballCircle: SFSymbol { .init(rawValue: "figure.softball.circle") }
 
     /// 􂖌
     /// Single Localization, 3 Layersets
@@ -5659,7 +5659,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSoftballCircleFill = SFSymbol(rawValue: "figure.softball.circle.fill")
+    static var figureSoftballCircleFill: SFSymbol { .init(rawValue: "figure.softball.circle.fill") }
 
     /// 􂖍
     /// Single Localization, 2 Layersets
@@ -5667,7 +5667,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSquashCircle = SFSymbol(rawValue: "figure.squash.circle")
+    static var figureSquashCircle: SFSymbol { .init(rawValue: "figure.squash.circle") }
 
     /// 􂖎
     /// Single Localization, 3 Layersets
@@ -5676,7 +5676,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSquashCircleFill = SFSymbol(rawValue: "figure.squash.circle.fill")
+    static var figureSquashCircleFill: SFSymbol { .init(rawValue: "figure.squash.circle.fill") }
 
     /// 􂖏
     /// Single Localization, 2 Layersets
@@ -5684,7 +5684,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStairStepperCircle = SFSymbol(rawValue: "figure.stair.stepper.circle")
+    static var figureStairStepperCircle: SFSymbol { .init(rawValue: "figure.stair.stepper.circle") }
 
     /// 􂖐
     /// Single Localization, 3 Layersets
@@ -5693,7 +5693,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureStairStepperCircleFill = SFSymbol(rawValue: "figure.stair.stepper.circle.fill")
+    static var figureStairStepperCircleFill: SFSymbol { .init(rawValue: "figure.stair.stepper.circle.fill") }
 
     /// 􂖑
     /// Single Localization, 2 Layersets
@@ -5701,7 +5701,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStairsCircle = SFSymbol(rawValue: "figure.stairs.circle")
+    static var figureStairsCircle: SFSymbol { .init(rawValue: "figure.stairs.circle") }
 
     /// 􂖒
     /// Single Localization, 3 Layersets
@@ -5710,14 +5710,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureStairsCircleFill = SFSymbol(rawValue: "figure.stairs.circle.fill")
+    static var figureStairsCircleFill: SFSymbol { .init(rawValue: "figure.stairs.circle.fill") }
 
     /// 􂡩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureStandDress = SFSymbol(rawValue: "figure.stand.dress")
+    static var figureStandDress: SFSymbol { .init(rawValue: "figure.stand.dress") }
 
     /// 􁙂
     /// Single Localization, 2 Layersets
@@ -5725,7 +5725,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStandDressLineVerticalFigure = SFSymbol(rawValue: "figure.stand.dress.line.vertical.figure")
+    static var figureStandDressLineVerticalFigure: SFSymbol { .init(rawValue: "figure.stand.dress.line.vertical.figure") }
 
     /// 􂖓
     /// Single Localization, 2 Layersets
@@ -5733,7 +5733,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStepTrainingCircle = SFSymbol(rawValue: "figure.step.training.circle")
+    static var figureStepTrainingCircle: SFSymbol { .init(rawValue: "figure.step.training.circle") }
 
     /// 􂖔
     /// Single Localization, 3 Layersets
@@ -5742,7 +5742,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureStepTrainingCircleFill = SFSymbol(rawValue: "figure.step.training.circle.fill")
+    static var figureStepTrainingCircleFill: SFSymbol { .init(rawValue: "figure.step.training.circle.fill") }
 
     /// 􂜦
     /// Single Localization, 2 Layersets
@@ -5750,7 +5750,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStrengthtrainingFunctionalCircle = SFSymbol(rawValue: "figure.strengthtraining.functional.circle")
+    static var figureStrengthtrainingFunctionalCircle: SFSymbol { .init(rawValue: "figure.strengthtraining.functional.circle") }
 
     /// 􂜧
     /// Single Localization, 3 Layersets
@@ -5759,7 +5759,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureStrengthtrainingFunctionalCircleFill = SFSymbol(rawValue: "figure.strengthtraining.functional.circle.fill")
+    static var figureStrengthtrainingFunctionalCircleFill: SFSymbol { .init(rawValue: "figure.strengthtraining.functional.circle.fill") }
 
     /// 􂜾
     /// Single Localization, 2 Layersets
@@ -5767,7 +5767,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureStrengthtrainingTraditionalCircle = SFSymbol(rawValue: "figure.strengthtraining.traditional.circle")
+    static var figureStrengthtrainingTraditionalCircle: SFSymbol { .init(rawValue: "figure.strengthtraining.traditional.circle") }
 
     /// 􂜿
     /// Single Localization, 3 Layersets
@@ -5776,7 +5776,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureStrengthtrainingTraditionalCircleFill = SFSymbol(rawValue: "figure.strengthtraining.traditional.circle.fill")
+    static var figureStrengthtrainingTraditionalCircleFill: SFSymbol { .init(rawValue: "figure.strengthtraining.traditional.circle.fill") }
 
     /// 􂖕
     /// Single Localization, 2 Layersets
@@ -5784,7 +5784,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSurfingCircle = SFSymbol(rawValue: "figure.surfing.circle")
+    static var figureSurfingCircle: SFSymbol { .init(rawValue: "figure.surfing.circle") }
 
     /// 􂖖
     /// Single Localization, 3 Layersets
@@ -5793,7 +5793,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureSurfingCircleFill = SFSymbol(rawValue: "figure.surfing.circle.fill")
+    static var figureSurfingCircleFill: SFSymbol { .init(rawValue: "figure.surfing.circle.fill") }
 
     /// 􂖗
     /// Single Localization, 2 Layersets
@@ -5801,7 +5801,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureTableTennisCircle = SFSymbol(rawValue: "figure.table.tennis.circle")
+    static var figureTableTennisCircle: SFSymbol { .init(rawValue: "figure.table.tennis.circle") }
 
     /// 􂖘
     /// Single Localization, 3 Layersets
@@ -5810,7 +5810,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureTableTennisCircleFill = SFSymbol(rawValue: "figure.table.tennis.circle.fill")
+    static var figureTableTennisCircleFill: SFSymbol { .init(rawValue: "figure.table.tennis.circle.fill") }
 
     /// 􂚉
     /// Single Localization, 2 Layersets
@@ -5818,7 +5818,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureTaichiCircle = SFSymbol(rawValue: "figure.taichi.circle")
+    static var figureTaichiCircle: SFSymbol { .init(rawValue: "figure.taichi.circle") }
 
     /// 􂚊
     /// Single Localization, 3 Layersets
@@ -5827,7 +5827,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureTaichiCircleFill = SFSymbol(rawValue: "figure.taichi.circle.fill")
+    static var figureTaichiCircleFill: SFSymbol { .init(rawValue: "figure.taichi.circle.fill") }
 
     /// 􂜼
     /// Single Localization, 2 Layersets
@@ -5835,7 +5835,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureTennisCircle = SFSymbol(rawValue: "figure.tennis.circle")
+    static var figureTennisCircle: SFSymbol { .init(rawValue: "figure.tennis.circle") }
 
     /// 􂜽
     /// Single Localization, 3 Layersets
@@ -5844,7 +5844,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureTennisCircleFill = SFSymbol(rawValue: "figure.tennis.circle.fill")
+    static var figureTennisCircleFill: SFSymbol { .init(rawValue: "figure.tennis.circle.fill") }
 
     /// 􂙷
     /// Single Localization, 2 Layersets
@@ -5852,7 +5852,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureTrackAndFieldCircle = SFSymbol(rawValue: "figure.track.and.field.circle")
+    static var figureTrackAndFieldCircle: SFSymbol { .init(rawValue: "figure.track.and.field.circle") }
 
     /// 􂙸
     /// Single Localization, 3 Layersets
@@ -5861,7 +5861,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureTrackAndFieldCircleFill = SFSymbol(rawValue: "figure.track.and.field.circle.fill")
+    static var figureTrackAndFieldCircleFill: SFSymbol { .init(rawValue: "figure.track.and.field.circle.fill") }
 
     /// 􂝀
     /// Single Localization, 2 Layersets
@@ -5869,7 +5869,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureVolleyballCircle = SFSymbol(rawValue: "figure.volleyball.circle")
+    static var figureVolleyballCircle: SFSymbol { .init(rawValue: "figure.volleyball.circle") }
 
     /// 􂝁
     /// Single Localization, 3 Layersets
@@ -5878,14 +5878,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureVolleyballCircleFill = SFSymbol(rawValue: "figure.volleyball.circle.fill")
+    static var figureVolleyballCircleFill: SFSymbol { .init(rawValue: "figure.volleyball.circle.fill") }
 
     /// 􂛆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWalkTreadmill = SFSymbol(rawValue: "figure.walk.treadmill")
+    static var figureWalkTreadmill: SFSymbol { .init(rawValue: "figure.walk.treadmill") }
 
     /// 􂛷
     /// Single Localization, 2 Layersets
@@ -5893,7 +5893,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkTreadmillCircle = SFSymbol(rawValue: "figure.walk.treadmill.circle")
+    static var figureWalkTreadmillCircle: SFSymbol { .init(rawValue: "figure.walk.treadmill.circle") }
 
     /// 􂛸
     /// Single Localization, 3 Layersets
@@ -5902,7 +5902,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWalkTreadmillCircleFill = SFSymbol(rawValue: "figure.walk.treadmill.circle.fill")
+    static var figureWalkTreadmillCircleFill: SFSymbol { .init(rawValue: "figure.walk.treadmill.circle.fill") }
 
     /// 􁓚
     /// Single Localization, 2 Layersets
@@ -5910,7 +5910,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkTriangle = SFSymbol(rawValue: "figure.walk.triangle")
+    static var figureWalkTriangle: SFSymbol { .init(rawValue: "figure.walk.triangle") }
 
     /// 􁓛
     /// Single Localization, 3 Layersets
@@ -5919,7 +5919,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWalkTriangleFill = SFSymbol(rawValue: "figure.walk.triangle.fill")
+    static var figureWalkTriangleFill: SFSymbol { .init(rawValue: "figure.walk.triangle.fill") }
 
     /// 􂙵
     /// Single Localization, 2 Layersets
@@ -5927,7 +5927,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWaterFitnessCircle = SFSymbol(rawValue: "figure.water.fitness.circle")
+    static var figureWaterFitnessCircle: SFSymbol { .init(rawValue: "figure.water.fitness.circle") }
 
     /// 􂙶
     /// Single Localization, 3 Layersets
@@ -5936,7 +5936,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWaterFitnessCircleFill = SFSymbol(rawValue: "figure.water.fitness.circle.fill")
+    static var figureWaterFitnessCircleFill: SFSymbol { .init(rawValue: "figure.water.fitness.circle.fill") }
 
     /// 􂝂
     /// Single Localization, 2 Layersets
@@ -5944,7 +5944,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWaterpoloCircle = SFSymbol(rawValue: "figure.waterpolo.circle")
+    static var figureWaterpoloCircle: SFSymbol { .init(rawValue: "figure.waterpolo.circle") }
 
     /// 􂝃
     /// Single Localization, 3 Layersets
@@ -5953,7 +5953,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWaterpoloCircleFill = SFSymbol(rawValue: "figure.waterpolo.circle.fill")
+    static var figureWaterpoloCircleFill: SFSymbol { .init(rawValue: "figure.waterpolo.circle.fill") }
 
     /// 􂝄
     /// Single Localization, 2 Layersets
@@ -5961,7 +5961,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWrestlingCircle = SFSymbol(rawValue: "figure.wrestling.circle")
+    static var figureWrestlingCircle: SFSymbol { .init(rawValue: "figure.wrestling.circle") }
 
     /// 􂝅
     /// Single Localization, 3 Layersets
@@ -5970,7 +5970,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWrestlingCircleFill = SFSymbol(rawValue: "figure.wrestling.circle.fill")
+    static var figureWrestlingCircleFill: SFSymbol { .init(rawValue: "figure.wrestling.circle.fill") }
 
     /// 􂝆
     /// Single Localization, 2 Layersets
@@ -5978,7 +5978,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureYogaCircle = SFSymbol(rawValue: "figure.yoga.circle")
+    static var figureYogaCircle: SFSymbol { .init(rawValue: "figure.yoga.circle") }
 
     /// 􂝇
     /// Single Localization, 3 Layersets
@@ -5987,28 +5987,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureYogaCircleFill = SFSymbol(rawValue: "figure.yoga.circle.fill")
+    static var figureYogaCircleFill: SFSymbol { .init(rawValue: "figure.yoga.circle.fill") }
 
     /// 􂦈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fireExtinguisher = SFSymbol(rawValue: "fire.extinguisher")
+    static var fireExtinguisher: SFSymbol { .init(rawValue: "fire.extinguisher") }
 
     /// 􂦉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fireExtinguisherFill = SFSymbol(rawValue: "fire.extinguisher.fill")
+    static var fireExtinguisherFill: SFSymbol { .init(rawValue: "fire.extinguisher.fill") }
 
     /// 􁙌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flagPatternCheckered = SFSymbol(rawValue: "flag.pattern.checkered")
+    static var flagPatternCheckered: SFSymbol { .init(rawValue: "flag.pattern.checkered") }
 
     /// 􁜔
     /// Single Localization, 2 Layersets
@@ -6016,7 +6016,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flagPatternCheckered2Crossed = SFSymbol(rawValue: "flag.pattern.checkered.2.crossed")
+    static var flagPatternCheckered2Crossed: SFSymbol { .init(rawValue: "flag.pattern.checkered.2.crossed") }
 
     /// 􁝼
     /// Single Localization, 2 Layersets
@@ -6024,7 +6024,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flagPatternCheckeredCircle = SFSymbol(rawValue: "flag.pattern.checkered.circle")
+    static var flagPatternCheckeredCircle: SFSymbol { .init(rawValue: "flag.pattern.checkered.circle") }
 
     /// 􁝽
     /// Single Localization, 3 Layersets
@@ -6033,7 +6033,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let flagPatternCheckeredCircleFill = SFSymbol(rawValue: "flag.pattern.checkered.circle.fill")
+    static var flagPatternCheckeredCircleFill: SFSymbol { .init(rawValue: "flag.pattern.checkered.circle.fill") }
 
     /// 􂈗
     /// Single Localization, 2 Layersets
@@ -6041,7 +6041,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "florinsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var florinsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "florinsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔅
     /// Single Localization, 2 Layersets
@@ -6049,7 +6049,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignBankBuilding = SFSymbol(rawValue: "florinsign.bank.building")
+    static var florinsignBankBuilding: SFSymbol { .init(rawValue: "florinsign.bank.building") }
 
     /// 􂔆
     /// Single Localization, 3 Layersets
@@ -6058,7 +6058,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let florinsignBankBuildingFill = SFSymbol(rawValue: "florinsign.bank.building.fill")
+    static var florinsignBankBuildingFill: SFSymbol { .init(rawValue: "florinsign.bank.building.fill") }
 
     /// 􂩉
     /// Single Localization, 2 Layersets
@@ -6066,7 +6066,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "florinsign.gauge.chart.lefthalf.righthalf")
+    static var florinsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "florinsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩳
     /// Single Localization, 2 Layersets
@@ -6074,7 +6074,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "florinsign.gauge.chart.leftthird.topthird.rightthird")
+    static var florinsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "florinsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰙
     /// Single Localization, 2 Layersets
@@ -6082,7 +6082,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignRing = SFSymbol(rawValue: "florinsign.ring")
+    static var florinsignRing: SFSymbol { .init(rawValue: "florinsign.ring") }
 
     /// 􂯯
     /// Single Localization, 2 Layersets
@@ -6090,35 +6090,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let florinsignRingDashed = SFSymbol(rawValue: "florinsign.ring.dashed")
+    static var florinsignRingDashed: SFSymbol { .init(rawValue: "florinsign.ring.dashed") }
 
     /// 􂥢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fluidBatteryblock = SFSymbol(rawValue: "fluid.batteryblock")
+    static var fluidBatteryblock: SFSymbol { .init(rawValue: "fluid.batteryblock") }
 
     /// 􂮔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fluidCoolant = SFSymbol(rawValue: "fluid.coolant")
+    static var fluidCoolant: SFSymbol { .init(rawValue: "fluid.coolant") }
 
     /// 􂞈
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let formfittingGamecontroller = SFSymbol(rawValue: "formfitting.gamecontroller")
+    static var formfittingGamecontroller: SFSymbol { .init(rawValue: "formfitting.gamecontroller") }
 
     /// 􂞉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let formfittingGamecontrollerFill = SFSymbol(rawValue: "formfitting.gamecontroller.fill")
+    static var formfittingGamecontrollerFill: SFSymbol { .init(rawValue: "formfitting.gamecontroller.fill") }
 
     /// 􂈖
     /// Single Localization, 2 Layersets
@@ -6126,7 +6126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "francsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var francsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "francsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔃
     /// Single Localization, 2 Layersets
@@ -6134,7 +6134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignBankBuilding = SFSymbol(rawValue: "francsign.bank.building")
+    static var francsignBankBuilding: SFSymbol { .init(rawValue: "francsign.bank.building") }
 
     /// 􂔄
     /// Single Localization, 3 Layersets
@@ -6143,7 +6143,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let francsignBankBuildingFill = SFSymbol(rawValue: "francsign.bank.building.fill")
+    static var francsignBankBuildingFill: SFSymbol { .init(rawValue: "francsign.bank.building.fill") }
 
     /// 􂩊
     /// Single Localization, 2 Layersets
@@ -6151,7 +6151,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "francsign.gauge.chart.lefthalf.righthalf")
+    static var francsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "francsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩴
     /// Single Localization, 2 Layersets
@@ -6159,7 +6159,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "francsign.gauge.chart.leftthird.topthird.rightthird")
+    static var francsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "francsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰚
     /// Single Localization, 2 Layersets
@@ -6167,7 +6167,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignRing = SFSymbol(rawValue: "francsign.ring")
+    static var francsignRing: SFSymbol { .init(rawValue: "francsign.ring") }
 
     /// 􂯰
     /// Single Localization, 2 Layersets
@@ -6175,14 +6175,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let francsignRingDashed = SFSymbol(rawValue: "francsign.ring.dashed")
+    static var francsignRingDashed: SFSymbol { .init(rawValue: "francsign.ring.dashed") }
 
     /// 􂥫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelpumpAndFilter = SFSymbol(rawValue: "fuelpump.and.filter")
+    static var fuelpumpAndFilter: SFSymbol { .init(rawValue: "fuelpump.and.filter") }
 
     /// 􂝈
     /// Single Localization, 2 Layersets
@@ -6190,7 +6190,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gamecontrollerCircle = SFSymbol(rawValue: "gamecontroller.circle")
+    static var gamecontrollerCircle: SFSymbol { .init(rawValue: "gamecontroller.circle") }
 
     /// 􂝉
     /// Single Localization, 3 Layersets
@@ -6199,7 +6199,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let gamecontrollerCircleFill = SFSymbol(rawValue: "gamecontroller.circle.fill")
+    static var gamecontrollerCircleFill: SFSymbol { .init(rawValue: "gamecontroller.circle.fill") }
 
     /// 􁊐
     /// Single Localization, 2 Layersets
@@ -6207,7 +6207,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenWithLinesNeedle33percentAndArrowTriangleheadFrom0percentTo50percent = SFSymbol(rawValue: "gauge.open.with.lines.needle.33percent.and.arrow.trianglehead.from.0percent.to.50percent")
+    static var gaugeOpenWithLinesNeedle33percentAndArrowTriangleheadFrom0percentTo50percent: SFSymbol { .init(rawValue: "gauge.open.with.lines.needle.33percent.and.arrow.trianglehead.from.0percent.to.50percent") }
 
     /// 􁐂
     /// Single Localization, 2 Layersets
@@ -6215,14 +6215,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gearshapeArrowTrianglehead2ClockwiseRotate90 = SFSymbol(rawValue: "gearshape.arrow.trianglehead.2.clockwise.rotate.90")
+    static var gearshapeArrowTrianglehead2ClockwiseRotate90: SFSymbol { .init(rawValue: "gearshape.arrow.trianglehead.2.clockwise.rotate.90") }
 
     /// 􂪱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let greaterthanorequalto = SFSymbol(rawValue: "greaterthanorequalto")
+    static var greaterthanorequalto: SFSymbol { .init(rawValue: "greaterthanorequalto") }
 
     /// 􂫋
     /// Single Localization, 2 Layersets
@@ -6230,7 +6230,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let greaterthanorequaltoCircle = SFSymbol(rawValue: "greaterthanorequalto.circle")
+    static var greaterthanorequaltoCircle: SFSymbol { .init(rawValue: "greaterthanorequalto.circle") }
 
     /// 􂫌
     /// Single Localization, 3 Layersets
@@ -6239,7 +6239,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let greaterthanorequaltoCircleFill = SFSymbol(rawValue: "greaterthanorequalto.circle.fill")
+    static var greaterthanorequaltoCircleFill: SFSymbol { .init(rawValue: "greaterthanorequalto.circle.fill") }
 
     /// 􂫍
     /// Single Localization, 2 Layersets
@@ -6247,7 +6247,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let greaterthanorequaltoSquare = SFSymbol(rawValue: "greaterthanorequalto.square")
+    static var greaterthanorequaltoSquare: SFSymbol { .init(rawValue: "greaterthanorequalto.square") }
 
     /// 􂫎
     /// Single Localization, 3 Layersets
@@ -6256,7 +6256,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let greaterthanorequaltoSquareFill = SFSymbol(rawValue: "greaterthanorequalto.square.fill")
+    static var greaterthanorequaltoSquareFill: SFSymbol { .init(rawValue: "greaterthanorequalto.square.fill") }
 
     /// 􂈦
     /// Single Localization, 2 Layersets
@@ -6264,7 +6264,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "guaranisign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var guaranisignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "guaranisign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔣
     /// Single Localization, 2 Layersets
@@ -6272,7 +6272,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignBankBuilding = SFSymbol(rawValue: "guaranisign.bank.building")
+    static var guaranisignBankBuilding: SFSymbol { .init(rawValue: "guaranisign.bank.building") }
 
     /// 􂔤
     /// Single Localization, 3 Layersets
@@ -6281,7 +6281,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let guaranisignBankBuildingFill = SFSymbol(rawValue: "guaranisign.bank.building.fill")
+    static var guaranisignBankBuildingFill: SFSymbol { .init(rawValue: "guaranisign.bank.building.fill") }
 
     /// 􂩋
     /// Single Localization, 2 Layersets
@@ -6289,7 +6289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "guaranisign.gauge.chart.lefthalf.righthalf")
+    static var guaranisignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "guaranisign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩵
     /// Single Localization, 2 Layersets
@@ -6297,7 +6297,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "guaranisign.gauge.chart.leftthird.topthird.rightthird")
+    static var guaranisignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "guaranisign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰛
     /// Single Localization, 2 Layersets
@@ -6305,7 +6305,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignRing = SFSymbol(rawValue: "guaranisign.ring")
+    static var guaranisignRing: SFSymbol { .init(rawValue: "guaranisign.ring") }
 
     /// 􂯱
     /// Single Localization, 2 Layersets
@@ -6313,7 +6313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guaranisignRingDashed = SFSymbol(rawValue: "guaranisign.ring.dashed")
+    static var guaranisignRingDashed: SFSymbol { .init(rawValue: "guaranisign.ring.dashed") }
 
     /// 􂚖
     /// Single Localization, 3 Layersets
@@ -6322,7 +6322,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handDrawBadgeEllipsis = SFSymbol(rawValue: "hand.draw.badge.ellipsis")
+    static var handDrawBadgeEllipsis: SFSymbol { .init(rawValue: "hand.draw.badge.ellipsis") }
 
     /// 􂚗
     /// Single Localization, 3 Layersets
@@ -6331,21 +6331,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handDrawBadgeEllipsisFill = SFSymbol(rawValue: "hand.draw.badge.ellipsis.fill")
+    static var handDrawBadgeEllipsisFill: SFSymbol { .init(rawValue: "hand.draw.badge.ellipsis.fill") }
 
     /// 􂤃
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPalmFacing = SFSymbol(rawValue: "hand.palm.facing")
+    static var handPalmFacing: SFSymbol { .init(rawValue: "hand.palm.facing") }
 
     /// 􂤄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handPalmFacingFill = SFSymbol(rawValue: "hand.palm.facing.fill")
+    static var handPalmFacingFill: SFSymbol { .init(rawValue: "hand.palm.facing.fill") }
 
     /// 􁟱
     /// Single Localization, 2 Layersets
@@ -6353,7 +6353,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handPinch = SFSymbol(rawValue: "hand.pinch")
+    static var handPinch: SFSymbol { .init(rawValue: "hand.pinch") }
 
     /// 􁟲
     /// Single Localization, 2 Layersets
@@ -6361,7 +6361,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handPinchFill = SFSymbol(rawValue: "hand.pinch.fill")
+    static var handPinchFill: SFSymbol { .init(rawValue: "hand.pinch.fill") }
 
     /// 􂠆
     /// Single Localization, 3 Layersets
@@ -6370,7 +6370,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handPointUpBrailleBadgeEllipsis = SFSymbol(rawValue: "hand.point.up.braille.badge.ellipsis")
+    static var handPointUpBrailleBadgeEllipsis: SFSymbol { .init(rawValue: "hand.point.up.braille.badge.ellipsis") }
 
     /// 􂠇
     /// Single Localization, 3 Layersets
@@ -6379,21 +6379,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handPointUpBrailleBadgeEllipsisFill = SFSymbol(rawValue: "hand.point.up.braille.badge.ellipsis.fill")
+    static var handPointUpBrailleBadgeEllipsisFill: SFSymbol { .init(rawValue: "hand.point.up.braille.badge.ellipsis.fill") }
 
     /// 􂤁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handRaisedPalmFacing = SFSymbol(rawValue: "hand.raised.palm.facing")
+    static var handRaisedPalmFacing: SFSymbol { .init(rawValue: "hand.raised.palm.facing") }
 
     /// 􂤂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handRaisedPalmFacingFill = SFSymbol(rawValue: "hand.raised.palm.facing.fill")
+    static var handRaisedPalmFacingFill: SFSymbol { .init(rawValue: "hand.raised.palm.facing.fill") }
 
     /// 􂲤
     /// Single Localization, 2 Layersets
@@ -6401,7 +6401,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handRays = SFSymbol(rawValue: "hand.rays")
+    static var handRays: SFSymbol { .init(rawValue: "hand.rays") }
 
     /// 􂲥
     /// Single Localization, 2 Layersets
@@ -6409,35 +6409,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handRaysFill = SFSymbol(rawValue: "hand.rays.fill")
+    static var handRaysFill: SFSymbol { .init(rawValue: "hand.rays.fill") }
 
     /// 􂏨
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hatCap = SFSymbol(rawValue: "hat.cap")
+    static var hatCap: SFSymbol { .init(rawValue: "hat.cap") }
 
     /// 􂏩
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hatCapFill = SFSymbol(rawValue: "hat.cap.fill")
+    static var hatCapFill: SFSymbol { .init(rawValue: "hat.cap.fill") }
 
     /// 􂏦
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hatWidebrim = SFSymbol(rawValue: "hat.widebrim")
+    static var hatWidebrim: SFSymbol { .init(rawValue: "hat.widebrim") }
 
     /// 􂏧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hatWidebrimFill = SFSymbol(rawValue: "hat.widebrim.fill")
+    static var hatWidebrimFill: SFSymbol { .init(rawValue: "hat.widebrim.fill") }
 
     /// 􁟹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6447,7 +6447,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let headProfileArrowForwardAndVisionPro = SFSymbol(rawValue: "head.profile.arrow.forward.and.vision.pro")
+    static var headProfileArrowForwardAndVisionPro: SFSymbol { .init(rawValue: "head.profile.arrow.forward.and.vision.pro") }
 
     /// 􂬂
     /// Single Localization, 2 Layersets
@@ -6455,14 +6455,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let headphonesSlash = SFSymbol(rawValue: "headphones.slash")
+    static var headphonesSlash: SFSymbol { .init(rawValue: "headphones.slash") }
 
     /// 􂣵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let headset = SFSymbol(rawValue: "headset")
+    static var headset: SFSymbol { .init(rawValue: "headset") }
 
     /// 􂣶
     /// Single Localization, 2 Layersets
@@ -6470,7 +6470,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let headsetCircle = SFSymbol(rawValue: "headset.circle")
+    static var headsetCircle: SFSymbol { .init(rawValue: "headset.circle") }
 
     /// 􂣷
     /// Single Localization, 3 Layersets
@@ -6479,7 +6479,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let headsetCircleFill = SFSymbol(rawValue: "headset.circle.fill")
+    static var headsetCircleFill: SFSymbol { .init(rawValue: "headset.circle.fill") }
 
     /// 􂤇
     /// Single Localization, 3 Layersets
@@ -6488,7 +6488,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heartTextClipboard = SFSymbol(rawValue: "heart.text.clipboard")
+    static var heartTextClipboard: SFSymbol { .init(rawValue: "heart.text.clipboard") }
 
     /// 􂤈
     /// Single Localization, 3 Layersets
@@ -6497,7 +6497,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let heartTextClipboardFill = SFSymbol(rawValue: "heart.text.clipboard.fill")
+    static var heartTextClipboardFill: SFSymbol { .init(rawValue: "heart.text.clipboard.fill") }
 
     /// 􂬤
     /// Single Localization, 2 Layersets
@@ -6505,21 +6505,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heatWavesAndFan = SFSymbol(rawValue: "heat.waves.and.fan")
+    static var heatWavesAndFan: SFSymbol { .init(rawValue: "heat.waves.and.fan") }
 
     /// 􂞌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let helmet = SFSymbol(rawValue: "helmet")
+    static var helmet: SFSymbol { .init(rawValue: "helmet") }
 
     /// 􂞍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let helmetFill = SFSymbol(rawValue: "helmet.fill")
+    static var helmetFill: SFSymbol { .init(rawValue: "helmet.fill") }
 
     /// 􂡔
     /// Single Localization, 3 Layersets
@@ -6528,7 +6528,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeaker2BadgeMinus = SFSymbol(rawValue: "hifispeaker.2.badge.minus")
+    static var hifispeaker2BadgeMinus: SFSymbol { .init(rawValue: "hifispeaker.2.badge.minus") }
 
     /// 􂡕
     /// Single Localization, 3 Layersets
@@ -6537,7 +6537,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeaker2BadgeMinusFill = SFSymbol(rawValue: "hifispeaker.2.badge.minus.fill")
+    static var hifispeaker2BadgeMinusFill: SFSymbol { .init(rawValue: "hifispeaker.2.badge.minus.fill") }
 
     /// 􂡒
     /// Single Localization, 3 Layersets
@@ -6546,7 +6546,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeaker2BadgePlus = SFSymbol(rawValue: "hifispeaker.2.badge.plus")
+    static var hifispeaker2BadgePlus: SFSymbol { .init(rawValue: "hifispeaker.2.badge.plus") }
 
     /// 􂡓
     /// Single Localization, 3 Layersets
@@ -6555,7 +6555,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeaker2BadgePlusFill = SFSymbol(rawValue: "hifispeaker.2.badge.plus.fill")
+    static var hifispeaker2BadgePlusFill: SFSymbol { .init(rawValue: "hifispeaker.2.badge.plus.fill") }
 
     /// 􂡌
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6566,7 +6566,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepodBadgeMinus = SFSymbol(rawValue: "hifispeaker.and.homepod.badge.minus")
+    static var hifispeakerAndHomepodBadgeMinus: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.badge.minus") }
 
     /// 􂡍
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6577,7 +6577,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepodBadgeMinusFill = SFSymbol(rawValue: "hifispeaker.and.homepod.badge.minus.fill")
+    static var hifispeakerAndHomepodBadgeMinusFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.badge.minus.fill") }
 
     /// 􂡊
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6588,7 +6588,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepodBadgePlus = SFSymbol(rawValue: "hifispeaker.and.homepod.badge.plus")
+    static var hifispeakerAndHomepodBadgePlus: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.badge.plus") }
 
     /// 􂡋
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6599,7 +6599,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let hifispeakerAndHomepodBadgePlusFill = SFSymbol(rawValue: "hifispeaker.and.homepod.badge.plus.fill")
+    static var hifispeakerAndHomepodBadgePlusFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.badge.plus.fill") }
 
     /// 􀷭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6609,7 +6609,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMini = SFSymbol(rawValue: "hifispeaker.and.homepod.mini")
+    static var hifispeakerAndHomepodMini: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini") }
 
     /// 􂠯
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6620,7 +6620,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMiniBadgeMinus = SFSymbol(rawValue: "hifispeaker.and.homepod.mini.badge.minus")
+    static var hifispeakerAndHomepodMiniBadgeMinus: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini.badge.minus") }
 
     /// 􂠰
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6631,7 +6631,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMiniBadgeMinusFill = SFSymbol(rawValue: "hifispeaker.and.homepod.mini.badge.minus.fill")
+    static var hifispeakerAndHomepodMiniBadgeMinusFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini.badge.minus.fill") }
 
     /// 􂠭
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6642,7 +6642,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMiniBadgePlus = SFSymbol(rawValue: "hifispeaker.and.homepod.mini.badge.plus")
+    static var hifispeakerAndHomepodMiniBadgePlus: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini.badge.plus") }
 
     /// 􂠮
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6653,7 +6653,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMiniBadgePlusFill = SFSymbol(rawValue: "hifispeaker.and.homepod.mini.badge.plus.fill")
+    static var hifispeakerAndHomepodMiniBadgePlusFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini.badge.plus.fill") }
 
     /// 􀷮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6663,7 +6663,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let hifispeakerAndHomepodMiniFill = SFSymbol(rawValue: "hifispeaker.and.homepod.mini.fill")
+    static var hifispeakerAndHomepodMiniFill: SFSymbol { .init(rawValue: "hifispeaker.and.homepod.mini.fill") }
 
     /// 􂡸
     /// Single Localization, 2 Layersets
@@ -6671,7 +6671,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hifispeakerArrowForward = SFSymbol(rawValue: "hifispeaker.arrow.forward")
+    static var hifispeakerArrowForward: SFSymbol { .init(rawValue: "hifispeaker.arrow.forward") }
 
     /// 􂡹
     /// Single Localization, 2 Layersets
@@ -6679,7 +6679,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hifispeakerArrowForwardFill = SFSymbol(rawValue: "hifispeaker.arrow.forward.fill")
+    static var hifispeakerArrowForwardFill: SFSymbol { .init(rawValue: "hifispeaker.arrow.forward.fill") }
 
     /// 􂡜
     /// Single Localization, 3 Layersets
@@ -6688,7 +6688,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeakerBadgeMinus = SFSymbol(rawValue: "hifispeaker.badge.minus")
+    static var hifispeakerBadgeMinus: SFSymbol { .init(rawValue: "hifispeaker.badge.minus") }
 
     /// 􂡝
     /// Single Localization, 3 Layersets
@@ -6697,7 +6697,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeakerBadgeMinusFill = SFSymbol(rawValue: "hifispeaker.badge.minus.fill")
+    static var hifispeakerBadgeMinusFill: SFSymbol { .init(rawValue: "hifispeaker.badge.minus.fill") }
 
     /// 􂡚
     /// Single Localization, 3 Layersets
@@ -6706,7 +6706,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeakerBadgePlus = SFSymbol(rawValue: "hifispeaker.badge.plus")
+    static var hifispeakerBadgePlus: SFSymbol { .init(rawValue: "hifispeaker.badge.plus") }
 
     /// 􂡛
     /// Single Localization, 3 Layersets
@@ -6715,7 +6715,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hifispeakerBadgePlusFill = SFSymbol(rawValue: "hifispeaker.badge.plus.fill")
+    static var hifispeakerBadgePlusFill: SFSymbol { .init(rawValue: "hifispeaker.badge.plus.fill") }
 
     /// 􂡀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6726,7 +6726,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2BadgeMinus = SFSymbol(rawValue: "homepod.2.badge.minus")
+    static var homepod2BadgeMinus: SFSymbol { .init(rawValue: "homepod.2.badge.minus") }
 
     /// 􂡁
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6737,7 +6737,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2BadgeMinusFill = SFSymbol(rawValue: "homepod.2.badge.minus.fill")
+    static var homepod2BadgeMinusFill: SFSymbol { .init(rawValue: "homepod.2.badge.minus.fill") }
 
     /// 􂠾
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6748,7 +6748,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2BadgePlus = SFSymbol(rawValue: "homepod.2.badge.plus")
+    static var homepod2BadgePlus: SFSymbol { .init(rawValue: "homepod.2.badge.plus") }
 
     /// 􂠿
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6759,7 +6759,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepod2BadgePlusFill = SFSymbol(rawValue: "homepod.2.badge.plus.fill")
+    static var homepod2BadgePlusFill: SFSymbol { .init(rawValue: "homepod.2.badge.plus.fill") }
 
     /// 􀷫
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6769,7 +6769,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMini = SFSymbol(rawValue: "homepod.and.homepod.mini")
+    static var homepodAndHomepodMini: SFSymbol { .init(rawValue: "homepod.and.homepod.mini") }
 
     /// 􂠧
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6780,7 +6780,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMiniBadgeMinus = SFSymbol(rawValue: "homepod.and.homepod.mini.badge.minus")
+    static var homepodAndHomepodMiniBadgeMinus: SFSymbol { .init(rawValue: "homepod.and.homepod.mini.badge.minus") }
 
     /// 􂠨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6791,7 +6791,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMiniBadgeMinusFill = SFSymbol(rawValue: "homepod.and.homepod.mini.badge.minus.fill")
+    static var homepodAndHomepodMiniBadgeMinusFill: SFSymbol { .init(rawValue: "homepod.and.homepod.mini.badge.minus.fill") }
 
     /// 􂠥
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6802,7 +6802,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMiniBadgePlus = SFSymbol(rawValue: "homepod.and.homepod.mini.badge.plus")
+    static var homepodAndHomepodMiniBadgePlus: SFSymbol { .init(rawValue: "homepod.and.homepod.mini.badge.plus") }
 
     /// 􂠦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6813,7 +6813,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMiniBadgePlusFill = SFSymbol(rawValue: "homepod.and.homepod.mini.badge.plus.fill")
+    static var homepodAndHomepodMiniBadgePlusFill: SFSymbol { .init(rawValue: "homepod.and.homepod.mini.badge.plus.fill") }
 
     /// 􀷬
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6823,7 +6823,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod and HomePod mini.
-    static let homepodAndHomepodMiniFill = SFSymbol(rawValue: "homepod.and.homepod.mini.fill")
+    static var homepodAndHomepodMiniFill: SFSymbol { .init(rawValue: "homepod.and.homepod.mini.fill") }
 
     /// 􂋞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6833,7 +6833,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodArrowForward = SFSymbol(rawValue: "homepod.arrow.forward")
+    static var homepodArrowForward: SFSymbol { .init(rawValue: "homepod.arrow.forward") }
 
     /// 􂋟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6843,7 +6843,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodArrowForwardFill = SFSymbol(rawValue: "homepod.arrow.forward.fill")
+    static var homepodArrowForwardFill: SFSymbol { .init(rawValue: "homepod.arrow.forward.fill") }
 
     /// 􂋥
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6854,7 +6854,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgeMinus = SFSymbol(rawValue: "homepod.badge.minus")
+    static var homepodBadgeMinus: SFSymbol { .init(rawValue: "homepod.badge.minus") }
 
     /// 􂋦
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6865,7 +6865,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgeMinusFill = SFSymbol(rawValue: "homepod.badge.minus.fill")
+    static var homepodBadgeMinusFill: SFSymbol { .init(rawValue: "homepod.badge.minus.fill") }
 
     /// 􂋡
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6876,7 +6876,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgePlus = SFSymbol(rawValue: "homepod.badge.plus")
+    static var homepodBadgePlus: SFSymbol { .init(rawValue: "homepod.badge.plus") }
 
     /// 􂋢
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6887,7 +6887,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgePlusFill = SFSymbol(rawValue: "homepod.badge.plus.fill")
+    static var homepodBadgePlusFill: SFSymbol { .init(rawValue: "homepod.badge.plus.fill") }
 
     /// 􀷧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6897,7 +6897,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini = SFSymbol(rawValue: "homepod.mini")
+    static var homepodMini: SFSymbol { .init(rawValue: "homepod.mini") }
 
     /// 􀷩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6907,7 +6907,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2 = SFSymbol(rawValue: "homepod.mini.2")
+    static var homepodMini2: SFSymbol { .init(rawValue: "homepod.mini.2") }
 
     /// 􂠟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6918,7 +6918,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2BadgeMinus = SFSymbol(rawValue: "homepod.mini.2.badge.minus")
+    static var homepodMini2BadgeMinus: SFSymbol { .init(rawValue: "homepod.mini.2.badge.minus") }
 
     /// 􂠠
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6929,7 +6929,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2BadgeMinusFill = SFSymbol(rawValue: "homepod.mini.2.badge.minus.fill")
+    static var homepodMini2BadgeMinusFill: SFSymbol { .init(rawValue: "homepod.mini.2.badge.minus.fill") }
 
     /// 􂠝
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6940,7 +6940,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2BadgePlus = SFSymbol(rawValue: "homepod.mini.2.badge.plus")
+    static var homepodMini2BadgePlus: SFSymbol { .init(rawValue: "homepod.mini.2.badge.plus") }
 
     /// 􂠞
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6951,7 +6951,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2BadgePlusFill = SFSymbol(rawValue: "homepod.mini.2.badge.plus.fill")
+    static var homepodMini2BadgePlusFill: SFSymbol { .init(rawValue: "homepod.mini.2.badge.plus.fill") }
 
     /// 􀷪
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6961,7 +6961,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMini2Fill = SFSymbol(rawValue: "homepod.mini.2.fill")
+    static var homepodMini2Fill: SFSymbol { .init(rawValue: "homepod.mini.2.fill") }
 
     /// 􂋛
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6971,7 +6971,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniArrowForward = SFSymbol(rawValue: "homepod.mini.arrow.forward")
+    static var homepodMiniArrowForward: SFSymbol { .init(rawValue: "homepod.mini.arrow.forward") }
 
     /// 􂋜
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -6981,7 +6981,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniArrowForwardFill = SFSymbol(rawValue: "homepod.mini.arrow.forward.fill")
+    static var homepodMiniArrowForwardFill: SFSymbol { .init(rawValue: "homepod.mini.arrow.forward.fill") }
 
     /// 􂋗
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -6992,7 +6992,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgeMinus = SFSymbol(rawValue: "homepod.mini.badge.minus")
+    static var homepodMiniBadgeMinus: SFSymbol { .init(rawValue: "homepod.mini.badge.minus") }
 
     /// 􂋘
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7003,7 +7003,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgeMinusFill = SFSymbol(rawValue: "homepod.mini.badge.minus.fill")
+    static var homepodMiniBadgeMinusFill: SFSymbol { .init(rawValue: "homepod.mini.badge.minus.fill") }
 
     /// 􂋓
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7014,7 +7014,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgePlus = SFSymbol(rawValue: "homepod.mini.badge.plus")
+    static var homepodMiniBadgePlus: SFSymbol { .init(rawValue: "homepod.mini.badge.plus") }
 
     /// 􂋔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7025,7 +7025,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgePlusFill = SFSymbol(rawValue: "homepod.mini.badge.plus.fill")
+    static var homepodMiniBadgePlusFill: SFSymbol { .init(rawValue: "homepod.mini.badge.plus.fill") }
 
     /// 􀷨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7035,7 +7035,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniFill = SFSymbol(rawValue: "homepod.mini.fill")
+    static var homepodMiniFill: SFSymbol { .init(rawValue: "homepod.mini.fill") }
 
     /// 􂜶
     /// Single Localization, 3 Layersets
@@ -7044,7 +7044,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassBadgeEye = SFSymbol(rawValue: "hourglass.badge.eye")
+    static var hourglassBadgeEye: SFSymbol { .init(rawValue: "hourglass.badge.eye") }
 
     /// 􂧄
     /// Single Localization, 3 Layersets
@@ -7053,7 +7053,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseBadgeExclamationmark = SFSymbol(rawValue: "house.badge.exclamationmark")
+    static var houseBadgeExclamationmark: SFSymbol { .init(rawValue: "house.badge.exclamationmark") }
 
     /// 􂧅
     /// Single Localization, 3 Layersets
@@ -7062,7 +7062,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseBadgeExclamationmarkFill = SFSymbol(rawValue: "house.badge.exclamationmark.fill")
+    static var houseBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "house.badge.exclamationmark.fill") }
 
     /// 􂘞
     /// Single Localization, 3 Layersets
@@ -7071,7 +7071,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseBadgeWifi = SFSymbol(rawValue: "house.badge.wifi")
+    static var houseBadgeWifi: SFSymbol { .init(rawValue: "house.badge.wifi") }
 
     /// 􂘟
     /// Single Localization, 3 Layersets
@@ -7080,7 +7080,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let houseBadgeWifiFill = SFSymbol(rawValue: "house.badge.wifi.fill")
+    static var houseBadgeWifiFill: SFSymbol { .init(rawValue: "house.badge.wifi.fill") }
 
     /// 􂣊
     /// Single Localization, 2 Layersets
@@ -7088,7 +7088,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let houseSlash = SFSymbol(rawValue: "house.slash")
+    static var houseSlash: SFSymbol { .init(rawValue: "house.slash") }
 
     /// 􂣋
     /// Single Localization, 2 Layersets
@@ -7096,7 +7096,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let houseSlashFill = SFSymbol(rawValue: "house.slash.fill")
+    static var houseSlashFill: SFSymbol { .init(rawValue: "house.slash.fill") }
 
     /// 􂈤
     /// Single Localization, 2 Layersets
@@ -7104,7 +7104,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "hryvniasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var hryvniasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "hryvniasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔟
     /// Single Localization, 2 Layersets
@@ -7112,7 +7112,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignBankBuilding = SFSymbol(rawValue: "hryvniasign.bank.building")
+    static var hryvniasignBankBuilding: SFSymbol { .init(rawValue: "hryvniasign.bank.building") }
 
     /// 􂔠
     /// Single Localization, 3 Layersets
@@ -7121,7 +7121,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hryvniasignBankBuildingFill = SFSymbol(rawValue: "hryvniasign.bank.building.fill")
+    static var hryvniasignBankBuildingFill: SFSymbol { .init(rawValue: "hryvniasign.bank.building.fill") }
 
     /// 􂩌
     /// Single Localization, 2 Layersets
@@ -7129,7 +7129,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "hryvniasign.gauge.chart.lefthalf.righthalf")
+    static var hryvniasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "hryvniasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩶
     /// Single Localization, 2 Layersets
@@ -7137,7 +7137,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "hryvniasign.gauge.chart.leftthird.topthird.rightthird")
+    static var hryvniasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "hryvniasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰜
     /// Single Localization, 2 Layersets
@@ -7145,7 +7145,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignRing = SFSymbol(rawValue: "hryvniasign.ring")
+    static var hryvniasignRing: SFSymbol { .init(rawValue: "hryvniasign.ring") }
 
     /// 􂯲
     /// Single Localization, 2 Layersets
@@ -7153,7 +7153,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hryvniasignRingDashed = SFSymbol(rawValue: "hryvniasign.ring.dashed")
+    static var hryvniasignRingDashed: SFSymbol { .init(rawValue: "hryvniasign.ring.dashed") }
 
     /// 􂈜
     /// Single Localization, 2 Layersets
@@ -7161,7 +7161,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "indianrupeesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var indianrupeesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "indianrupeesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔏
     /// Single Localization, 2 Layersets
@@ -7169,7 +7169,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignBankBuilding = SFSymbol(rawValue: "indianrupeesign.bank.building")
+    static var indianrupeesignBankBuilding: SFSymbol { .init(rawValue: "indianrupeesign.bank.building") }
 
     /// 􂔐
     /// Single Localization, 3 Layersets
@@ -7178,7 +7178,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let indianrupeesignBankBuildingFill = SFSymbol(rawValue: "indianrupeesign.bank.building.fill")
+    static var indianrupeesignBankBuildingFill: SFSymbol { .init(rawValue: "indianrupeesign.bank.building.fill") }
 
     /// 􂩍
     /// Single Localization, 2 Layersets
@@ -7186,7 +7186,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "indianrupeesign.gauge.chart.lefthalf.righthalf")
+    static var indianrupeesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "indianrupeesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩷
     /// Single Localization, 2 Layersets
@@ -7194,7 +7194,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "indianrupeesign.gauge.chart.leftthird.topthird.rightthird")
+    static var indianrupeesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "indianrupeesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰝
     /// Single Localization, 2 Layersets
@@ -7202,7 +7202,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignRing = SFSymbol(rawValue: "indianrupeesign.ring")
+    static var indianrupeesignRing: SFSymbol { .init(rawValue: "indianrupeesign.ring") }
 
     /// 􂯳
     /// Single Localization, 2 Layersets
@@ -7210,21 +7210,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let indianrupeesignRingDashed = SFSymbol(rawValue: "indianrupeesign.ring.dashed")
+    static var indianrupeesignRingDashed: SFSymbol { .init(rawValue: "indianrupeesign.ring.dashed") }
 
     /// 􂞜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let inhaler = SFSymbol(rawValue: "inhaler")
+    static var inhaler: SFSymbol { .init(rawValue: "inhaler") }
 
     /// 􂞝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let inhalerFill = SFSymbol(rawValue: "inhaler.fill")
+    static var inhalerFill: SFSymbol { .init(rawValue: "inhaler.fill") }
 
     /// 􀴪
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7234,7 +7234,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let insetFilledApplewatchCase = SFSymbol(rawValue: "inset.filled.applewatch.case")
+    static var insetFilledApplewatchCase: SFSymbol { .init(rawValue: "inset.filled.applewatch.case") }
 
     /// 􀾯
     /// Single Localization, 2 Layersets
@@ -7242,7 +7242,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomhalfRectangle = SFSymbol(rawValue: "inset.filled.bottomhalf.rectangle")
+    static var insetFilledBottomhalfRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomhalf.rectangle") }
 
     /// 􀽺
     /// Single Localization, 2 Layersets
@@ -7250,7 +7250,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomhalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomhalf.rectangle.portrait")
+    static var insetFilledBottomhalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomhalf.rectangle.portrait") }
 
     /// 􂮡
     /// Single Localization, 2 Layersets
@@ -7258,7 +7258,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomhalfTophalfRectangle = SFSymbol(rawValue: "inset.filled.bottomhalf.tophalf.rectangle")
+    static var insetFilledBottomhalfTophalfRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomhalf.tophalf.rectangle") }
 
     /// 􁁫
     /// Single Localization, 2 Layersets
@@ -7266,7 +7266,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleadingRectangle = SFSymbol(rawValue: "inset.filled.bottomleading.rectangle")
+    static var insetFilledBottomleadingRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomleading.rectangle") }
 
     /// 􁁳
     /// Single Localization, 2 Layersets
@@ -7274,7 +7274,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleadingRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomleading.rectangle.portrait")
+    static var insetFilledBottomleadingRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomleading.rectangle.portrait") }
 
     /// 􀭵
     /// Single Localization, 2 Layersets
@@ -7282,7 +7282,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleftRectangle = SFSymbol(rawValue: "inset.filled.bottomleft.rectangle")
+    static var insetFilledBottomleftRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomleft.rectangle") }
 
     /// 􀾃
     /// Single Localization, 2 Layersets
@@ -7290,7 +7290,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleftRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomleft.rectangle.portrait")
+    static var insetFilledBottomleftRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomleft.rectangle.portrait") }
 
     /// 􀭶
     /// Single Localization, 2 Layersets
@@ -7298,7 +7298,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomrightRectangle = SFSymbol(rawValue: "inset.filled.bottomright.rectangle")
+    static var insetFilledBottomrightRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomright.rectangle") }
 
     /// 􀾂
     /// Single Localization, 2 Layersets
@@ -7306,7 +7306,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomrightRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomright.rectangle.portrait")
+    static var insetFilledBottomrightRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomright.rectangle.portrait") }
 
     /// 􀨨
     /// Single Localization, 2 Layersets
@@ -7314,7 +7314,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomthirdRectangle = SFSymbol(rawValue: "inset.filled.bottomthird.rectangle")
+    static var insetFilledBottomthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomthird.rectangle") }
 
     /// 􀽾
     /// Single Localization, 2 Layersets
@@ -7322,7 +7322,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomthird.rectangle.portrait")
+    static var insetFilledBottomthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomthird.rectangle.portrait") }
 
     /// 􁒡
     /// Single Localization, 2 Layersets
@@ -7330,7 +7330,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomthirdSquare = SFSymbol(rawValue: "inset.filled.bottomthird.square")
+    static var insetFilledBottomthirdSquare: SFSymbol { .init(rawValue: "inset.filled.bottomthird.square") }
 
     /// 􁁬
     /// Single Localization, 2 Layersets
@@ -7338,7 +7338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomtrailingRectangle = SFSymbol(rawValue: "inset.filled.bottomtrailing.rectangle")
+    static var insetFilledBottomtrailingRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomtrailing.rectangle") }
 
     /// 􁁴
     /// Single Localization, 2 Layersets
@@ -7346,7 +7346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomtrailingRectanglePortrait = SFSymbol(rawValue: "inset.filled.bottomtrailing.rectangle.portrait")
+    static var insetFilledBottomtrailingRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.bottomtrailing.rectangle.portrait") }
 
     /// 􀾚
     /// Single Localization, 2 Layersets
@@ -7354,7 +7354,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCapsule = SFSymbol(rawValue: "inset.filled.capsule")
+    static var insetFilledCapsule: SFSymbol { .init(rawValue: "inset.filled.capsule") }
 
     /// 􀾛
     /// Single Localization, 2 Layersets
@@ -7362,7 +7362,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCapsulePortrait = SFSymbol(rawValue: "inset.filled.capsule.portrait")
+    static var insetFilledCapsulePortrait: SFSymbol { .init(rawValue: "inset.filled.capsule.portrait") }
 
     /// 􀥝
     /// Single Localization, 2 Layersets
@@ -7370,7 +7370,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCenterRectangle = SFSymbol(rawValue: "inset.filled.center.rectangle")
+    static var insetFilledCenterRectangle: SFSymbol { .init(rawValue: "inset.filled.center.rectangle") }
 
     /// 􁈔
     /// Single Localization, 3 Layersets
@@ -7379,7 +7379,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let insetFilledCenterRectangleBadgePlus = SFSymbol(rawValue: "inset.filled.center.rectangle.badge.plus")
+    static var insetFilledCenterRectangleBadgePlus: SFSymbol { .init(rawValue: "inset.filled.center.rectangle.badge.plus") }
 
     /// 􀽿
     /// Single Localization, 2 Layersets
@@ -7387,7 +7387,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCenterRectanglePortrait = SFSymbol(rawValue: "inset.filled.center.rectangle.portrait")
+    static var insetFilledCenterRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.center.rectangle.portrait") }
 
     /// 􀝜
     /// Single Localization, 2 Layersets
@@ -7395,7 +7395,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCircle = SFSymbol(rawValue: "inset.filled.circle")
+    static var insetFilledCircle: SFSymbol { .init(rawValue: "inset.filled.circle") }
 
     /// 􀧒
     /// Single Localization, 2 Layersets
@@ -7403,7 +7403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCircleDashed = SFSymbol(rawValue: "inset.filled.circle.dashed")
+    static var insetFilledCircleDashed: SFSymbol { .init(rawValue: "inset.filled.circle.dashed") }
 
     /// 􀾗
     /// Single Localization, 2 Layersets
@@ -7411,7 +7411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledDiamond = SFSymbol(rawValue: "inset.filled.diamond")
+    static var insetFilledDiamond: SFSymbol { .init(rawValue: "inset.filled.diamond") }
 
     /// 􁁥
     /// Single Localization, 2 Layersets
@@ -7419,7 +7419,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadinghalfArrowLeadingRectangle = SFSymbol(rawValue: "inset.filled.leadinghalf.arrow.leading.rectangle")
+    static var insetFilledLeadinghalfArrowLeadingRectangle: SFSymbol { .init(rawValue: "inset.filled.leadinghalf.arrow.leading.rectangle") }
 
     /// 􁁣
     /// Single Localization, 2 Layersets
@@ -7427,7 +7427,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadinghalfRectangle = SFSymbol(rawValue: "inset.filled.leadinghalf.rectangle")
+    static var insetFilledLeadinghalfRectangle: SFSymbol { .init(rawValue: "inset.filled.leadinghalf.rectangle") }
 
     /// 􁁭
     /// Single Localization, 2 Layersets
@@ -7435,7 +7435,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadinghalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.leadinghalf.rectangle.portrait")
+    static var insetFilledLeadinghalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.leadinghalf.rectangle.portrait") }
 
     /// 􂨜
     /// Single Localization, 2 Layersets
@@ -7443,7 +7443,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadinghalfToptrailingBottomtrailingRectangle = SFSymbol(rawValue: "inset.filled.leadinghalf.toptrailing.bottomtrailing.rectangle")
+    static var insetFilledLeadinghalfToptrailingBottomtrailingRectangle: SFSymbol { .init(rawValue: "inset.filled.leadinghalf.toptrailing.bottomtrailing.rectangle") }
 
     /// 􂬓
     /// Single Localization, 2 Layersets
@@ -7451,7 +7451,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadinghalfTrailinghalfRectangle = SFSymbol(rawValue: "inset.filled.leadinghalf.trailinghalf.rectangle")
+    static var insetFilledLeadinghalfTrailinghalfRectangle: SFSymbol { .init(rawValue: "inset.filled.leadinghalf.trailinghalf.rectangle") }
 
     /// 􁁧
     /// Single Localization, 2 Layersets
@@ -7459,7 +7459,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadingthirdRectangle = SFSymbol(rawValue: "inset.filled.leadingthird.rectangle")
+    static var insetFilledLeadingthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.leadingthird.rectangle") }
 
     /// 􁁯
     /// Single Localization, 2 Layersets
@@ -7467,7 +7467,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadingthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.leadingthird.rectangle.portrait")
+    static var insetFilledLeadingthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.leadingthird.rectangle.portrait") }
 
     /// 􁒤
     /// Single Localization, 2 Layersets
@@ -7475,7 +7475,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeadingthirdSquare = SFSymbol(rawValue: "inset.filled.leadingthird.square")
+    static var insetFilledLeadingthirdSquare: SFSymbol { .init(rawValue: "inset.filled.leadingthird.square") }
 
     /// 􀥞
     /// Single Localization, 2 Layersets
@@ -7483,7 +7483,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLefthalfArrowLeftRectangle = SFSymbol(rawValue: "inset.filled.lefthalf.arrow.left.rectangle")
+    static var insetFilledLefthalfArrowLeftRectangle: SFSymbol { .init(rawValue: "inset.filled.lefthalf.arrow.left.rectangle") }
 
     /// 􀤴
     /// Single Localization, 2 Layersets
@@ -7491,7 +7491,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLefthalfRectangle = SFSymbol(rawValue: "inset.filled.lefthalf.rectangle")
+    static var insetFilledLefthalfRectangle: SFSymbol { .init(rawValue: "inset.filled.lefthalf.rectangle") }
 
     /// 􀾄
     /// Single Localization, 2 Layersets
@@ -7499,7 +7499,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLefthalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.lefthalf.rectangle.portrait")
+    static var insetFilledLefthalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.lefthalf.rectangle.portrait") }
 
     /// 􂧬
     /// Single Localization, 2 Layersets
@@ -7507,7 +7507,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLefthalfRighthalfRectangle = SFSymbol(rawValue: "inset.filled.lefthalf.righthalf.rectangle")
+    static var insetFilledLefthalfRighthalfRectangle: SFSymbol { .init(rawValue: "inset.filled.lefthalf.righthalf.rectangle") }
 
     /// 􂧮
     /// Single Localization, 2 Layersets
@@ -7515,7 +7515,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLefthalfToprightBottomrightRectangle = SFSymbol(rawValue: "inset.filled.lefthalf.topright.bottomright.rectangle")
+    static var insetFilledLefthalfToprightBottomrightRectangle: SFSymbol { .init(rawValue: "inset.filled.lefthalf.topright.bottomright.rectangle") }
 
     /// 􀨱
     /// Single Localization, 2 Layersets
@@ -7523,7 +7523,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeftthirdRectangle = SFSymbol(rawValue: "inset.filled.leftthird.rectangle")
+    static var insetFilledLeftthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.leftthird.rectangle") }
 
     /// 􀽼
     /// Single Localization, 2 Layersets
@@ -7531,7 +7531,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeftthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.leftthird.rectangle.portrait")
+    static var insetFilledLeftthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.leftthird.rectangle.portrait") }
 
     /// 􁒢
     /// Single Localization, 2 Layersets
@@ -7539,7 +7539,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeftthirdSquare = SFSymbol(rawValue: "inset.filled.leftthird.square")
+    static var insetFilledLeftthirdSquare: SFSymbol { .init(rawValue: "inset.filled.leftthird.square") }
 
     /// 􀾜
     /// Single Localization, 2 Layersets
@@ -7547,7 +7547,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledOval = SFSymbol(rawValue: "inset.filled.oval")
+    static var insetFilledOval: SFSymbol { .init(rawValue: "inset.filled.oval") }
 
     /// 􀾝
     /// Single Localization, 2 Layersets
@@ -7555,7 +7555,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledOvalPortrait = SFSymbol(rawValue: "inset.filled.oval.portrait")
+    static var insetFilledOvalPortrait: SFSymbol { .init(rawValue: "inset.filled.oval.portrait") }
 
     /// 􀤳
     /// Single Localization, 2 Layersets
@@ -7563,7 +7563,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangle = SFSymbol(rawValue: "inset.filled.rectangle")
+    static var insetFilledRectangle: SFSymbol { .init(rawValue: "inset.filled.rectangle") }
 
     /// 􂇕
     /// Single Localization, 2 Layersets
@@ -7576,7 +7576,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 18.0, deprecated: 26.0, renamed: "insetFilledRectangleAndPointerArrow")
     @available(watchOS, introduced: 11.0, deprecated: 26.0, renamed: "insetFilledRectangleAndPointerArrow")
     @available(visionOS, introduced: 2.0, deprecated: 26.0, renamed: "insetFilledRectangleAndPointerArrow")
-    static let insetFilledRectangleAndCursorarrow = SFSymbol(rawValue: "inset.filled.rectangle.and.cursorarrow")
+    static var insetFilledRectangleAndCursorarrow: SFSymbol { .init(rawValue: "inset.filled.rectangle.and.cursorarrow") }
 
     /// 􁅀
     /// Single Localization, 2 Layersets
@@ -7584,7 +7584,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangleAndPersonFilled = SFSymbol(rawValue: "inset.filled.rectangle.and.person.filled")
+    static var insetFilledRectangleAndPersonFilled: SFSymbol { .init(rawValue: "inset.filled.rectangle.and.person.filled") }
 
     /// 􂃕
     /// Single Localization, 2 Layersets
@@ -7592,7 +7592,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangleBadgeRecord = SFSymbol(rawValue: "inset.filled.rectangle.badge.record")
+    static var insetFilledRectangleBadgeRecord: SFSymbol { .init(rawValue: "inset.filled.rectangle.badge.record") }
 
     /// 􀶣
     /// Single Localization, 2 Layersets
@@ -7600,7 +7600,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangleOnRectangle = SFSymbol(rawValue: "inset.filled.rectangle.on.rectangle")
+    static var insetFilledRectangleOnRectangle: SFSymbol { .init(rawValue: "inset.filled.rectangle.on.rectangle") }
 
     /// 􀽸
     /// Single Localization, 2 Layersets
@@ -7608,7 +7608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectanglePortrait = SFSymbol(rawValue: "inset.filled.rectangle.portrait")
+    static var insetFilledRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.rectangle.portrait") }
 
     /// 􀥟
     /// Single Localization, 2 Layersets
@@ -7616,7 +7616,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRighthalfArrowRightRectangle = SFSymbol(rawValue: "inset.filled.righthalf.arrow.right.rectangle")
+    static var insetFilledRighthalfArrowRightRectangle: SFSymbol { .init(rawValue: "inset.filled.righthalf.arrow.right.rectangle") }
 
     /// 􂬑
     /// Single Localization, 2 Layersets
@@ -7624,7 +7624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRighthalfLefthalfRectangle = SFSymbol(rawValue: "inset.filled.righthalf.lefthalf.rectangle")
+    static var insetFilledRighthalfLefthalfRectangle: SFSymbol { .init(rawValue: "inset.filled.righthalf.lefthalf.rectangle") }
 
     /// 􀤵
     /// Single Localization, 2 Layersets
@@ -7632,7 +7632,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRighthalfRectangle = SFSymbol(rawValue: "inset.filled.righthalf.rectangle")
+    static var insetFilledRighthalfRectangle: SFSymbol { .init(rawValue: "inset.filled.righthalf.rectangle") }
 
     /// 􀾅
     /// Single Localization, 2 Layersets
@@ -7640,7 +7640,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRighthalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.righthalf.rectangle.portrait")
+    static var insetFilledRighthalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.righthalf.rectangle.portrait") }
 
     /// 􀨩
     /// Single Localization, 2 Layersets
@@ -7648,7 +7648,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRightthirdRectangle = SFSymbol(rawValue: "inset.filled.rightthird.rectangle")
+    static var insetFilledRightthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.rightthird.rectangle") }
 
     /// 􀽻
     /// Single Localization, 2 Layersets
@@ -7656,7 +7656,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRightthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.rightthird.rectangle.portrait")
+    static var insetFilledRightthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.rightthird.rectangle.portrait") }
 
     /// 􁒣
     /// Single Localization, 2 Layersets
@@ -7664,7 +7664,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRightthirdSquare = SFSymbol(rawValue: "inset.filled.rightthird.square")
+    static var insetFilledRightthirdSquare: SFSymbol { .init(rawValue: "inset.filled.rightthird.square") }
 
     /// 􀾘
     /// Single Localization, 2 Layersets
@@ -7672,7 +7672,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledSquare = SFSymbol(rawValue: "inset.filled.square")
+    static var insetFilledSquare: SFSymbol { .init(rawValue: "inset.filled.square") }
 
     /// 􀧑
     /// Single Localization, 2 Layersets
@@ -7680,7 +7680,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledSquareDashed = SFSymbol(rawValue: "inset.filled.square.dashed")
+    static var insetFilledSquareDashed: SFSymbol { .init(rawValue: "inset.filled.square.dashed") }
 
     /// 􂧭
     /// Single Localization, 2 Layersets
@@ -7688,7 +7688,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTophalfBottomhalfRectangle = SFSymbol(rawValue: "inset.filled.tophalf.bottomhalf.rectangle")
+    static var insetFilledTophalfBottomhalfRectangle: SFSymbol { .init(rawValue: "inset.filled.tophalf.bottomhalf.rectangle") }
 
     /// 􂧯
     /// Single Localization, 2 Layersets
@@ -7696,7 +7696,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTophalfBottomleftBottomrightRectangle = SFSymbol(rawValue: "inset.filled.tophalf.bottomleft.bottomright.rectangle")
+    static var insetFilledTophalfBottomleftBottomrightRectangle: SFSymbol { .init(rawValue: "inset.filled.tophalf.bottomleft.bottomright.rectangle") }
 
     /// 􀾮
     /// Single Localization, 2 Layersets
@@ -7704,7 +7704,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTophalfRectangle = SFSymbol(rawValue: "inset.filled.tophalf.rectangle")
+    static var insetFilledTophalfRectangle: SFSymbol { .init(rawValue: "inset.filled.tophalf.rectangle") }
 
     /// 􀽹
     /// Single Localization, 2 Layersets
@@ -7712,7 +7712,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTophalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.tophalf.rectangle.portrait")
+    static var insetFilledTophalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.tophalf.rectangle.portrait") }
 
     /// 􂬐
     /// Single Localization, 2 Layersets
@@ -7720,7 +7720,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleadingBottomleadingTrailinghalfRectangle = SFSymbol(rawValue: "inset.filled.topleading.bottomleading.trailinghalf.rectangle")
+    static var insetFilledTopleadingBottomleadingTrailinghalfRectangle: SFSymbol { .init(rawValue: "inset.filled.topleading.bottomleading.trailinghalf.rectangle") }
 
     /// 􁁩
     /// Single Localization, 2 Layersets
@@ -7728,7 +7728,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleadingRectangle = SFSymbol(rawValue: "inset.filled.topleading.rectangle")
+    static var insetFilledTopleadingRectangle: SFSymbol { .init(rawValue: "inset.filled.topleading.rectangle") }
 
     /// 􁁱
     /// Single Localization, 2 Layersets
@@ -7736,7 +7736,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleadingRectanglePortrait = SFSymbol(rawValue: "inset.filled.topleading.rectangle.portrait")
+    static var insetFilledTopleadingRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.topleading.rectangle.portrait") }
 
     /// 􂬏
     /// Single Localization, 2 Layersets
@@ -7744,7 +7744,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleftBottomleftRighthalfRectangle = SFSymbol(rawValue: "inset.filled.topleft.bottomleft.righthalf.rectangle")
+    static var insetFilledTopleftBottomleftRighthalfRectangle: SFSymbol { .init(rawValue: "inset.filled.topleft.bottomleft.righthalf.rectangle") }
 
     /// 􀭳
     /// Single Localization, 2 Layersets
@@ -7752,7 +7752,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleftRectangle = SFSymbol(rawValue: "inset.filled.topleft.rectangle")
+    static var insetFilledTopleftRectangle: SFSymbol { .init(rawValue: "inset.filled.topleft.rectangle") }
 
     /// 􀾀
     /// Single Localization, 2 Layersets
@@ -7760,7 +7760,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleftRectanglePortrait = SFSymbol(rawValue: "inset.filled.topleft.rectangle.portrait")
+    static var insetFilledTopleftRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.topleft.rectangle.portrait") }
 
     /// 􂬗
     /// Single Localization, 2 Layersets
@@ -7768,7 +7768,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleftToprightBottomhalfRectangle = SFSymbol(rawValue: "inset.filled.topleft.topright.bottomhalf.rectangle")
+    static var insetFilledTopleftToprightBottomhalfRectangle: SFSymbol { .init(rawValue: "inset.filled.topleft.topright.bottomhalf.rectangle") }
 
     /// 􂧰
     /// Single Localization, 2 Layersets
@@ -7776,7 +7776,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopleftToprightBottomleftBottomrightRectangle = SFSymbol(rawValue: "inset.filled.topleft.topright.bottomleft.bottomright.rectangle")
+    static var insetFilledTopleftToprightBottomleftBottomrightRectangle: SFSymbol { .init(rawValue: "inset.filled.topleft.topright.bottomleft.bottomright.rectangle") }
 
     /// 􀭴
     /// Single Localization, 2 Layersets
@@ -7784,7 +7784,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledToprightRectangle = SFSymbol(rawValue: "inset.filled.topright.rectangle")
+    static var insetFilledToprightRectangle: SFSymbol { .init(rawValue: "inset.filled.topright.rectangle") }
 
     /// 􀾁
     /// Single Localization, 2 Layersets
@@ -7792,7 +7792,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledToprightRectanglePortrait = SFSymbol(rawValue: "inset.filled.topright.rectangle.portrait")
+    static var insetFilledToprightRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.topright.rectangle.portrait") }
 
     /// 􀴊
     /// Single Localization, 2 Layersets
@@ -7800,7 +7800,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopthirdRectangle = SFSymbol(rawValue: "inset.filled.topthird.rectangle")
+    static var insetFilledTopthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.topthird.rectangle") }
 
     /// 􀽽
     /// Single Localization, 2 Layersets
@@ -7808,7 +7808,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.topthird.rectangle.portrait")
+    static var insetFilledTopthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.topthird.rectangle.portrait") }
 
     /// 􁒠
     /// Single Localization, 2 Layersets
@@ -7816,7 +7816,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopthirdSquare = SFSymbol(rawValue: "inset.filled.topthird.square")
+    static var insetFilledTopthirdSquare: SFSymbol { .init(rawValue: "inset.filled.topthird.square") }
 
     /// 􁁪
     /// Single Localization, 2 Layersets
@@ -7824,7 +7824,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledToptrailingRectangle = SFSymbol(rawValue: "inset.filled.toptrailing.rectangle")
+    static var insetFilledToptrailingRectangle: SFSymbol { .init(rawValue: "inset.filled.toptrailing.rectangle") }
 
     /// 􁁲
     /// Single Localization, 2 Layersets
@@ -7832,7 +7832,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledToptrailingRectanglePortrait = SFSymbol(rawValue: "inset.filled.toptrailing.rectangle.portrait")
+    static var insetFilledToptrailingRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.toptrailing.rectangle.portrait") }
 
     /// 􁁦
     /// Single Localization, 2 Layersets
@@ -7840,7 +7840,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailinghalfArrowTrailingRectangle = SFSymbol(rawValue: "inset.filled.trailinghalf.arrow.trailing.rectangle")
+    static var insetFilledTrailinghalfArrowTrailingRectangle: SFSymbol { .init(rawValue: "inset.filled.trailinghalf.arrow.trailing.rectangle") }
 
     /// 􂬒
     /// Single Localization, 2 Layersets
@@ -7848,7 +7848,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailinghalfLeadinghalfRectangle = SFSymbol(rawValue: "inset.filled.trailinghalf.leadinghalf.rectangle")
+    static var insetFilledTrailinghalfLeadinghalfRectangle: SFSymbol { .init(rawValue: "inset.filled.trailinghalf.leadinghalf.rectangle") }
 
     /// 􁁤
     /// Single Localization, 2 Layersets
@@ -7856,7 +7856,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailinghalfRectangle = SFSymbol(rawValue: "inset.filled.trailinghalf.rectangle")
+    static var insetFilledTrailinghalfRectangle: SFSymbol { .init(rawValue: "inset.filled.trailinghalf.rectangle") }
 
     /// 􁁮
     /// Single Localization, 2 Layersets
@@ -7864,7 +7864,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailinghalfRectanglePortrait = SFSymbol(rawValue: "inset.filled.trailinghalf.rectangle.portrait")
+    static var insetFilledTrailinghalfRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.trailinghalf.rectangle.portrait") }
 
     /// 􁁨
     /// Single Localization, 2 Layersets
@@ -7872,7 +7872,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailingthirdRectangle = SFSymbol(rawValue: "inset.filled.trailingthird.rectangle")
+    static var insetFilledTrailingthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.trailingthird.rectangle") }
 
     /// 􁁰
     /// Single Localization, 2 Layersets
@@ -7880,7 +7880,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailingthirdRectanglePortrait = SFSymbol(rawValue: "inset.filled.trailingthird.rectangle.portrait")
+    static var insetFilledTrailingthirdRectanglePortrait: SFSymbol { .init(rawValue: "inset.filled.trailingthird.rectangle.portrait") }
 
     /// 􁒥
     /// Single Localization, 2 Layersets
@@ -7888,7 +7888,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTrailingthirdSquare = SFSymbol(rawValue: "inset.filled.trailingthird.square")
+    static var insetFilledTrailingthirdSquare: SFSymbol { .init(rawValue: "inset.filled.trailingthird.square") }
 
     /// 􀾙
     /// Single Localization, 2 Layersets
@@ -7896,7 +7896,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTriangle = SFSymbol(rawValue: "inset.filled.triangle")
+    static var insetFilledTriangle: SFSymbol { .init(rawValue: "inset.filled.triangle") }
 
     /// 􀷘
     /// Single Localization, 2 Layersets
@@ -7904,7 +7904,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTv = SFSymbol(rawValue: "inset.filled.tv")
+    static var insetFilledTv: SFSymbol { .init(rawValue: "inset.filled.tv") }
 
     /// 􂝺
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7915,7 +7915,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadBadgeLocation = SFSymbol(rawValue: "ipad.badge.location")
+    static var ipadBadgeLocation: SFSymbol { .init(rawValue: "ipad.badge.location") }
 
     /// 􂝲
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7926,7 +7926,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1BadgeLocation = SFSymbol(rawValue: "ipad.gen1.badge.location")
+    static var ipadGen1BadgeLocation: SFSymbol { .init(rawValue: "ipad.gen1.badge.location") }
 
     /// 􂝴
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7937,7 +7937,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1LandscapeBadgeLocation = SFSymbol(rawValue: "ipad.gen1.landscape.badge.location")
+    static var ipadGen1LandscapeBadgeLocation: SFSymbol { .init(rawValue: "ipad.gen1.landscape.badge.location") }
 
     /// 􂲖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7947,7 +7947,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1LandscapeSlash = SFSymbol(rawValue: "ipad.gen1.landscape.slash")
+    static var ipadGen1LandscapeSlash: SFSymbol { .init(rawValue: "ipad.gen1.landscape.slash") }
 
     /// 􂲔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7957,7 +7957,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1Slash = SFSymbol(rawValue: "ipad.gen1.slash")
+    static var ipadGen1Slash: SFSymbol { .init(rawValue: "ipad.gen1.slash") }
 
     /// 􂝶
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7968,7 +7968,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2BadgeLocation = SFSymbol(rawValue: "ipad.gen2.badge.location")
+    static var ipadGen2BadgeLocation: SFSymbol { .init(rawValue: "ipad.gen2.badge.location") }
 
     /// 􂝸
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -7979,7 +7979,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2LandscapeBadgeLocation = SFSymbol(rawValue: "ipad.gen2.landscape.badge.location")
+    static var ipadGen2LandscapeBadgeLocation: SFSymbol { .init(rawValue: "ipad.gen2.landscape.badge.location") }
 
     /// 􂲚
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7989,7 +7989,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2LandscapeSlash = SFSymbol(rawValue: "ipad.gen2.landscape.slash")
+    static var ipadGen2LandscapeSlash: SFSymbol { .init(rawValue: "ipad.gen2.landscape.slash") }
 
     /// 􂲘
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -7999,7 +7999,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2Slash = SFSymbol(rawValue: "ipad.gen2.slash")
+    static var ipadGen2Slash: SFSymbol { .init(rawValue: "ipad.gen2.slash") }
 
     /// 􁄟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8010,7 +8010,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad and iPhone.
-    static let ipadLandscapeAndIphone = SFSymbol(rawValue: "ipad.landscape.and.iphone")
+    static var ipadLandscapeAndIphone: SFSymbol { .init(rawValue: "ipad.landscape.and.iphone") }
 
     /// 􁋟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8020,7 +8020,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad and iPhone.
-    static let ipadLandscapeAndIphoneSlash = SFSymbol(rawValue: "ipad.landscape.and.iphone.slash")
+    static var ipadLandscapeAndIphoneSlash: SFSymbol { .init(rawValue: "ipad.landscape.and.iphone.slash") }
 
     /// 􂝼
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8031,7 +8031,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadLandscapeBadgeLocation = SFSymbol(rawValue: "ipad.landscape.badge.location")
+    static var ipadLandscapeBadgeLocation: SFSymbol { .init(rawValue: "ipad.landscape.badge.location") }
 
     /// 􀶼
     /// Single Localization, 2 Layersets
@@ -8039,7 +8039,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphoneAndArrowForwardInward = SFSymbol(rawValue: "iphone.and.arrow.forward.inward")
+    static var iphoneAndArrowForwardInward: SFSymbol { .init(rawValue: "iphone.and.arrow.forward.inward") }
 
     /// 􂎽
     /// Single Localization, 2 Layersets
@@ -8047,7 +8047,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphoneAndArrowForwardOutward = SFSymbol(rawValue: "iphone.and.arrow.forward.outward")
+    static var iphoneAndArrowForwardOutward: SFSymbol { .init(rawValue: "iphone.and.arrow.forward.outward") }
 
     /// 􁰿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8057,7 +8057,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneAndArrowLeftAndArrowRightInward = SFSymbol(rawValue: "iphone.and.arrow.left.and.arrow.right.inward")
+    static var iphoneAndArrowLeftAndArrowRightInward: SFSymbol { .init(rawValue: "iphone.and.arrow.left.and.arrow.right.inward") }
 
     /// 􂏹
     /// Single Localization, 2 Layersets
@@ -8065,7 +8065,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphoneAndArrowRightInward = SFSymbol(rawValue: "iphone.and.arrow.right.inward")
+    static var iphoneAndArrowRightInward: SFSymbol { .init(rawValue: "iphone.and.arrow.right.inward") }
 
     /// 􂏻
     /// Single Localization, 2 Layersets
@@ -8073,7 +8073,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphoneAndArrowRightOutward = SFSymbol(rawValue: "iphone.and.arrow.right.outward")
+    static var iphoneAndArrowRightOutward: SFSymbol { .init(rawValue: "iphone.and.arrow.right.outward") }
 
     /// 􂤹
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8083,7 +8083,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneAppSwitcher = SFSymbol(rawValue: "iphone.app.switcher")
+    static var iphoneAppSwitcher: SFSymbol { .init(rawValue: "iphone.app.switcher") }
 
     /// 􂜸
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8094,7 +8094,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneBadgeLocation = SFSymbol(rawValue: "iphone.badge.location")
+    static var iphoneBadgeLocation: SFSymbol { .init(rawValue: "iphone.badge.location") }
 
     /// 􂙔
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8103,7 +8103,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneCropCircle = SFSymbol(rawValue: "iphone.crop.circle")
+    static var iphoneCropCircle: SFSymbol { .init(rawValue: "iphone.crop.circle") }
 
     /// 􂈉
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8114,7 +8114,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to accessories and software that are compatible with the DockKit API.
-    static let iphoneDockMotorizedViewfinder = SFSymbol(rawValue: "iphone.dock.motorized.viewfinder")
+    static var iphoneDockMotorizedViewfinder: SFSymbol { .init(rawValue: "iphone.dock.motorized.viewfinder") }
 
     /// 􂘨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8124,7 +8124,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1AndArrowLeft = SFSymbol(rawValue: "iphone.gen1.and.arrow.left")
+    static var iphoneGen1AndArrowLeft: SFSymbol { .init(rawValue: "iphone.gen1.and.arrow.left") }
 
     /// 􂝰
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8135,7 +8135,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1BadgeLocation = SFSymbol(rawValue: "iphone.gen1.badge.location")
+    static var iphoneGen1BadgeLocation: SFSymbol { .init(rawValue: "iphone.gen1.badge.location") }
 
     /// 􂙑
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8144,7 +8144,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1CropCircle = SFSymbol(rawValue: "iphone.gen1.crop.circle")
+    static var iphoneGen1CropCircle: SFSymbol { .init(rawValue: "iphone.gen1.crop.circle") }
 
     /// 􂲒
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8154,7 +8154,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1LandscapeSlash = SFSymbol(rawValue: "iphone.gen1.landscape.slash")
+    static var iphoneGen1LandscapeSlash: SFSymbol { .init(rawValue: "iphone.gen1.landscape.slash") }
 
     /// 􂘢
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8164,7 +8164,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1Motion = SFSymbol(rawValue: "iphone.gen1.motion")
+    static var iphoneGen1Motion: SFSymbol { .init(rawValue: "iphone.gen1.motion") }
 
     /// 􂘩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8174,7 +8174,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2AndArrowLeftAndArrowRightInward = SFSymbol(rawValue: "iphone.gen2.and.arrow.left.and.arrow.right.inward")
+    static var iphoneGen2AndArrowLeftAndArrowRightInward: SFSymbol { .init(rawValue: "iphone.gen2.and.arrow.left.and.arrow.right.inward") }
 
     /// 􂝮
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8185,7 +8185,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2BadgeLocation = SFSymbol(rawValue: "iphone.gen2.badge.location")
+    static var iphoneGen2BadgeLocation: SFSymbol { .init(rawValue: "iphone.gen2.badge.location") }
 
     /// 􂙒
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8194,7 +8194,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2CropCircle = SFSymbol(rawValue: "iphone.gen2.crop.circle")
+    static var iphoneGen2CropCircle: SFSymbol { .init(rawValue: "iphone.gen2.crop.circle") }
 
     /// 􂲎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8204,7 +8204,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2LandscapeSlash = SFSymbol(rawValue: "iphone.gen2.landscape.slash")
+    static var iphoneGen2LandscapeSlash: SFSymbol { .init(rawValue: "iphone.gen2.landscape.slash") }
 
     /// 􂘤
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8214,7 +8214,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2Motion = SFSymbol(rawValue: "iphone.gen2.motion")
+    static var iphoneGen2Motion: SFSymbol { .init(rawValue: "iphone.gen2.motion") }
 
     /// 􂘪
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8224,7 +8224,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3AndArrowLeftAndArrowRightInward = SFSymbol(rawValue: "iphone.gen3.and.arrow.left.and.arrow.right.inward")
+    static var iphoneGen3AndArrowLeftAndArrowRightInward: SFSymbol { .init(rawValue: "iphone.gen3.and.arrow.left.and.arrow.right.inward") }
 
     /// 􂝬
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -8235,7 +8235,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3BadgeLocation = SFSymbol(rawValue: "iphone.gen3.badge.location")
+    static var iphoneGen3BadgeLocation: SFSymbol { .init(rawValue: "iphone.gen3.badge.location") }
 
     /// 􂙓
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8244,7 +8244,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3CropCircle = SFSymbol(rawValue: "iphone.gen3.crop.circle")
+    static var iphoneGen3CropCircle: SFSymbol { .init(rawValue: "iphone.gen3.crop.circle") }
 
     /// 􂲐
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8254,7 +8254,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3LandscapeSlash = SFSymbol(rawValue: "iphone.gen3.landscape.slash")
+    static var iphoneGen3LandscapeSlash: SFSymbol { .init(rawValue: "iphone.gen3.landscape.slash") }
 
     /// 􂘦
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8264,7 +8264,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3Motion = SFSymbol(rawValue: "iphone.gen3.motion")
+    static var iphoneGen3Motion: SFSymbol { .init(rawValue: "iphone.gen3.motion") }
 
     /// 􂘒
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8274,7 +8274,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneMotion = SFSymbol(rawValue: "iphone.motion")
+    static var iphoneMotion: SFSymbol { .init(rawValue: "iphone.motion") }
 
     /// 􀫨
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8283,7 +8283,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod shuffle.
-    static let ipodShuffleGen1 = SFSymbol(rawValue: "ipod.shuffle.gen1")
+    static var ipodShuffleGen1: SFSymbol { .init(rawValue: "ipod.shuffle.gen1") }
 
     /// 􀫩
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8292,7 +8292,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod shuffle.
-    static let ipodShuffleGen2 = SFSymbol(rawValue: "ipod.shuffle.gen2")
+    static var ipodShuffleGen2: SFSymbol { .init(rawValue: "ipod.shuffle.gen2") }
 
     /// 􀫪
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8301,7 +8301,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod shuffle.
-    static let ipodShuffleGen3 = SFSymbol(rawValue: "ipod.shuffle.gen3")
+    static var ipodShuffleGen3: SFSymbol { .init(rawValue: "ipod.shuffle.gen3") }
 
     /// 􀫫
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8310,7 +8310,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod shuffle.
-    static let ipodShuffleGen4 = SFSymbol(rawValue: "ipod.shuffle.gen4")
+    static var ipodShuffleGen4: SFSymbol { .init(rawValue: "ipod.shuffle.gen4") }
 
     /// 􀫧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8320,7 +8320,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod touch.
-    static let ipodTouch = SFSymbol(rawValue: "ipod.touch")
+    static var ipodTouch: SFSymbol { .init(rawValue: "ipod.touch") }
 
     /// 􀴐
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8330,7 +8330,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod touch.
-    static let ipodTouchLandscape = SFSymbol(rawValue: "ipod.touch.landscape")
+    static var ipodTouchLandscape: SFSymbol { .init(rawValue: "ipod.touch.landscape") }
 
     /// 􁂲
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8340,35 +8340,35 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod touch.
-    static let ipodTouchSlash = SFSymbol(rawValue: "ipod.touch.slash")
+    static var ipodTouchSlash: SFSymbol { .init(rawValue: "ipod.touch.slash") }
 
     /// 􂏬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let jacket = SFSymbol(rawValue: "jacket")
+    static var jacket: SFSymbol { .init(rawValue: "jacket") }
 
     /// 􂏭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let jacketFill = SFSymbol(rawValue: "jacket.fill")
+    static var jacketFill: SFSymbol { .init(rawValue: "jacket.fill") }
 
     /// 􂏪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let key2OnRing = SFSymbol(rawValue: "key.2.on.ring")
+    static var key2OnRing: SFSymbol { .init(rawValue: "key.2.on.ring") }
 
     /// 􂏫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let key2OnRingFill = SFSymbol(rawValue: "key.2.on.ring.fill")
+    static var key2OnRingFill: SFSymbol { .init(rawValue: "key.2.on.ring.fill") }
 
     /// 􂬲
     /// 2 Localizations, 2 Layersets
@@ -8380,7 +8380,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyCarRadiowavesForward = SymbolWith1Localization<Rtl>(rawValue: "key.car.radiowaves.forward")
+    static var keyCarRadiowavesForward: SymbolWith1Localization<Rtl> { .init(rawValue: "key.car.radiowaves.forward") }
 
     /// 􂬳
     /// 2 Localizations, 2 Layersets
@@ -8392,7 +8392,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyCarRadiowavesForwardFill = SymbolWith1Localization<Rtl>(rawValue: "key.car.radiowaves.forward.fill")
+    static var keyCarRadiowavesForwardFill: SymbolWith1Localization<Rtl> { .init(rawValue: "key.car.radiowaves.forward.fill") }
 
     /// 􂬠
     /// Single Localization, 2 Layersets
@@ -8400,7 +8400,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyCard = SFSymbol(rawValue: "key.card")
+    static var keyCard: SFSymbol { .init(rawValue: "key.card") }
 
     /// 􂬡
     /// Single Localization, 3 Layersets
@@ -8409,7 +8409,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyCardFill = SFSymbol(rawValue: "key.card.fill")
+    static var keyCardFill: SFSymbol { .init(rawValue: "key.card.fill") }
 
     /// 􂈠
     /// Single Localization, 2 Layersets
@@ -8417,7 +8417,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "kipsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var kipsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "kipsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔗
     /// Single Localization, 2 Layersets
@@ -8425,7 +8425,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignBankBuilding = SFSymbol(rawValue: "kipsign.bank.building")
+    static var kipsignBankBuilding: SFSymbol { .init(rawValue: "kipsign.bank.building") }
 
     /// 􂔘
     /// Single Localization, 3 Layersets
@@ -8434,7 +8434,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let kipsignBankBuildingFill = SFSymbol(rawValue: "kipsign.bank.building.fill")
+    static var kipsignBankBuildingFill: SFSymbol { .init(rawValue: "kipsign.bank.building.fill") }
 
     /// 􂩎
     /// Single Localization, 2 Layersets
@@ -8442,7 +8442,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "kipsign.gauge.chart.lefthalf.righthalf")
+    static var kipsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "kipsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩸
     /// Single Localization, 2 Layersets
@@ -8450,7 +8450,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "kipsign.gauge.chart.leftthird.topthird.rightthird")
+    static var kipsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "kipsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰞
     /// Single Localization, 2 Layersets
@@ -8458,7 +8458,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignRing = SFSymbol(rawValue: "kipsign.ring")
+    static var kipsignRing: SFSymbol { .init(rawValue: "kipsign.ring") }
 
     /// 􂯴
     /// Single Localization, 2 Layersets
@@ -8466,7 +8466,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let kipsignRingDashed = SFSymbol(rawValue: "kipsign.ring.dashed")
+    static var kipsignRingDashed: SFSymbol { .init(rawValue: "kipsign.ring.dashed") }
 
     /// 􂟦
     /// Single Localization, 2 Layersets
@@ -8474,7 +8474,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ladybugSlash = SFSymbol(rawValue: "ladybug.slash")
+    static var ladybugSlash: SFSymbol { .init(rawValue: "ladybug.slash") }
 
     /// 􂟪
     /// Single Localization, 2 Layersets
@@ -8482,7 +8482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ladybugSlashCircle = SFSymbol(rawValue: "ladybug.slash.circle")
+    static var ladybugSlashCircle: SFSymbol { .init(rawValue: "ladybug.slash.circle") }
 
     /// 􂟬
     /// Single Localization, 3 Layersets
@@ -8491,7 +8491,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ladybugSlashCircleFill = SFSymbol(rawValue: "ladybug.slash.circle.fill")
+    static var ladybugSlashCircleFill: SFSymbol { .init(rawValue: "ladybug.slash.circle.fill") }
 
     /// 􂟨
     /// Single Localization, 2 Layersets
@@ -8499,7 +8499,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ladybugSlashFill = SFSymbol(rawValue: "ladybug.slash.fill")
+    static var ladybugSlashFill: SFSymbol { .init(rawValue: "ladybug.slash.fill") }
 
     /// 􂈰
     /// Single Localization, 2 Layersets
@@ -8507,7 +8507,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "larisign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var larisignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "larisign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔷
     /// Single Localization, 2 Layersets
@@ -8515,7 +8515,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignBankBuilding = SFSymbol(rawValue: "larisign.bank.building")
+    static var larisignBankBuilding: SFSymbol { .init(rawValue: "larisign.bank.building") }
 
     /// 􂔸
     /// Single Localization, 3 Layersets
@@ -8524,7 +8524,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let larisignBankBuildingFill = SFSymbol(rawValue: "larisign.bank.building.fill")
+    static var larisignBankBuildingFill: SFSymbol { .init(rawValue: "larisign.bank.building.fill") }
 
     /// 􂩏
     /// Single Localization, 2 Layersets
@@ -8532,7 +8532,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "larisign.gauge.chart.lefthalf.righthalf")
+    static var larisignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "larisign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩹
     /// Single Localization, 2 Layersets
@@ -8540,7 +8540,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "larisign.gauge.chart.leftthird.topthird.rightthird")
+    static var larisignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "larisign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰟
     /// Single Localization, 2 Layersets
@@ -8548,7 +8548,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignRing = SFSymbol(rawValue: "larisign.ring")
+    static var larisignRing: SFSymbol { .init(rawValue: "larisign.ring") }
 
     /// 􂯵
     /// Single Localization, 2 Layersets
@@ -8556,7 +8556,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let larisignRingDashed = SFSymbol(rawValue: "larisign.ring.dashed")
+    static var larisignRingDashed: SFSymbol { .init(rawValue: "larisign.ring.dashed") }
 
     /// 􀙜
     /// Single Localization, 3 Layersets
@@ -8565,14 +8565,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let leafArrowTriangleheadClockwise = SFSymbol(rawValue: "leaf.arrow.trianglehead.clockwise")
+    static var leafArrowTriangleheadClockwise: SFSymbol { .init(rawValue: "leaf.arrow.trianglehead.clockwise") }
 
     /// 􂪰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lessthanorequalto = SFSymbol(rawValue: "lessthanorequalto")
+    static var lessthanorequalto: SFSymbol { .init(rawValue: "lessthanorequalto") }
 
     /// 􂫇
     /// Single Localization, 2 Layersets
@@ -8580,7 +8580,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lessthanorequaltoCircle = SFSymbol(rawValue: "lessthanorequalto.circle")
+    static var lessthanorequaltoCircle: SFSymbol { .init(rawValue: "lessthanorequalto.circle") }
 
     /// 􂫈
     /// Single Localization, 3 Layersets
@@ -8589,7 +8589,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lessthanorequaltoCircleFill = SFSymbol(rawValue: "lessthanorequalto.circle.fill")
+    static var lessthanorequaltoCircleFill: SFSymbol { .init(rawValue: "lessthanorequalto.circle.fill") }
 
     /// 􂫉
     /// Single Localization, 2 Layersets
@@ -8597,7 +8597,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lessthanorequaltoSquare = SFSymbol(rawValue: "lessthanorequalto.square")
+    static var lessthanorequaltoSquare: SFSymbol { .init(rawValue: "lessthanorequalto.square") }
 
     /// 􂫊
     /// Single Localization, 3 Layersets
@@ -8606,7 +8606,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lessthanorequaltoSquareFill = SFSymbol(rawValue: "lessthanorequalto.square.fill")
+    static var lessthanorequaltoSquareFill: SFSymbol { .init(rawValue: "lessthanorequalto.square.fill") }
 
     /// 􂈢
     /// Single Localization, 2 Layersets
@@ -8614,7 +8614,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "lirasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var lirasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "lirasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔛
     /// Single Localization, 2 Layersets
@@ -8622,7 +8622,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignBankBuilding = SFSymbol(rawValue: "lirasign.bank.building")
+    static var lirasignBankBuilding: SFSymbol { .init(rawValue: "lirasign.bank.building") }
 
     /// 􂔜
     /// Single Localization, 3 Layersets
@@ -8631,7 +8631,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lirasignBankBuildingFill = SFSymbol(rawValue: "lirasign.bank.building.fill")
+    static var lirasignBankBuildingFill: SFSymbol { .init(rawValue: "lirasign.bank.building.fill") }
 
     /// 􂩐
     /// Single Localization, 2 Layersets
@@ -8639,7 +8639,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "lirasign.gauge.chart.lefthalf.righthalf")
+    static var lirasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "lirasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩺
     /// Single Localization, 2 Layersets
@@ -8647,7 +8647,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "lirasign.gauge.chart.leftthird.topthird.rightthird")
+    static var lirasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "lirasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰠
     /// Single Localization, 2 Layersets
@@ -8655,7 +8655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignRing = SFSymbol(rawValue: "lirasign.ring")
+    static var lirasignRing: SFSymbol { .init(rawValue: "lirasign.ring") }
 
     /// 􂯶
     /// Single Localization, 2 Layersets
@@ -8663,7 +8663,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lirasignRingDashed = SFSymbol(rawValue: "lirasign.ring.dashed")
+    static var lirasignRingDashed: SFSymbol { .init(rawValue: "lirasign.ring.dashed") }
 
     /// 􂜰
     /// Single Localization, 2 Layersets
@@ -8671,7 +8671,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let locationApp = SFSymbol(rawValue: "location.app")
+    static var locationApp: SFSymbol { .init(rawValue: "location.app") }
 
     /// 􂜱
     /// Single Localization, 3 Layersets
@@ -8680,7 +8680,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let locationAppFill = SFSymbol(rawValue: "location.app.fill")
+    static var locationAppFill: SFSymbol { .init(rawValue: "location.app.fill") }
 
     /// 􀢍
     /// Single Localization, 2 Layersets
@@ -8688,7 +8688,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockDocument = SFSymbol(rawValue: "lock.document")
+    static var lockDocument: SFSymbol { .init(rawValue: "lock.document") }
 
     /// 􀢎
     /// Single Localization, 3 Layersets
@@ -8697,7 +8697,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockDocumentFill = SFSymbol(rawValue: "lock.document.fill")
+    static var lockDocumentFill: SFSymbol { .init(rawValue: "lock.document.fill") }
 
     /// 􂠘
     /// Single Localization, 2 Layersets
@@ -8705,7 +8705,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockRectangleOnRectangleDashed = SFSymbol(rawValue: "lock.rectangle.on.rectangle.dashed")
+    static var lockRectangleOnRectangleDashed: SFSymbol { .init(rawValue: "lock.rectangle.on.rectangle.dashed") }
 
     /// 􂭶
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8715,7 +8715,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook and Apple Watch.
-    static let macbookAndApplewatch = SFSymbol(rawValue: "macbook.and.applewatch")
+    static var macbookAndApplewatch: SFSymbol { .init(rawValue: "macbook.and.applewatch") }
 
     /// 􁜙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8725,7 +8725,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro and MacBook.
-    static let macbookAndVisionPro = SFSymbol(rawValue: "macbook.and.vision.pro")
+    static var macbookAndVisionPro: SFSymbol { .init(rawValue: "macbook.and.vision.pro") }
 
     /// 􂲌
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -8735,14 +8735,14 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookSlash = SFSymbol(rawValue: "macbook.slash")
+    static var macbookSlash: SFSymbol { .init(rawValue: "macbook.slash") }
 
     /// 􂣪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let malaysianringgitsign = SFSymbol(rawValue: "malaysianringgitsign")
+    static var malaysianringgitsign: SFSymbol { .init(rawValue: "malaysianringgitsign") }
 
     /// 􂣱
     /// Single Localization, 2 Layersets
@@ -8750,7 +8750,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "malaysianringgitsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var malaysianringgitsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "malaysianringgitsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂣯
     /// Single Localization, 2 Layersets
@@ -8758,7 +8758,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignBankBuilding = SFSymbol(rawValue: "malaysianringgitsign.bank.building")
+    static var malaysianringgitsignBankBuilding: SFSymbol { .init(rawValue: "malaysianringgitsign.bank.building") }
 
     /// 􂣰
     /// Single Localization, 2 Layersets
@@ -8766,7 +8766,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignBankBuildingFill = SFSymbol(rawValue: "malaysianringgitsign.bank.building.fill")
+    static var malaysianringgitsignBankBuildingFill: SFSymbol { .init(rawValue: "malaysianringgitsign.bank.building.fill") }
 
     /// 􂣫
     /// Single Localization, 2 Layersets
@@ -8774,7 +8774,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignCircle = SFSymbol(rawValue: "malaysianringgitsign.circle")
+    static var malaysianringgitsignCircle: SFSymbol { .init(rawValue: "malaysianringgitsign.circle") }
 
     /// 􂣬
     /// Single Localization, 3 Layersets
@@ -8783,7 +8783,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let malaysianringgitsignCircleFill = SFSymbol(rawValue: "malaysianringgitsign.circle.fill")
+    static var malaysianringgitsignCircleFill: SFSymbol { .init(rawValue: "malaysianringgitsign.circle.fill") }
 
     /// 􂩒
     /// Single Localization, 2 Layersets
@@ -8791,7 +8791,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "malaysianringgitsign.gauge.chart.lefthalf.righthalf")
+    static var malaysianringgitsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "malaysianringgitsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩼
     /// Single Localization, 2 Layersets
@@ -8799,7 +8799,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "malaysianringgitsign.gauge.chart.leftthird.topthird.rightthird")
+    static var malaysianringgitsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "malaysianringgitsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰢
     /// Single Localization, 2 Layersets
@@ -8807,7 +8807,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignRing = SFSymbol(rawValue: "malaysianringgitsign.ring")
+    static var malaysianringgitsignRing: SFSymbol { .init(rawValue: "malaysianringgitsign.ring") }
 
     /// 􂯸
     /// Single Localization, 2 Layersets
@@ -8815,7 +8815,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignRingDashed = SFSymbol(rawValue: "malaysianringgitsign.ring.dashed")
+    static var malaysianringgitsignRingDashed: SFSymbol { .init(rawValue: "malaysianringgitsign.ring.dashed") }
 
     /// 􂣭
     /// Single Localization, 2 Layersets
@@ -8823,7 +8823,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let malaysianringgitsignSquare = SFSymbol(rawValue: "malaysianringgitsign.square")
+    static var malaysianringgitsignSquare: SFSymbol { .init(rawValue: "malaysianringgitsign.square") }
 
     /// 􂣮
     /// Single Localization, 3 Layersets
@@ -8832,7 +8832,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let malaysianringgitsignSquareFill = SFSymbol(rawValue: "malaysianringgitsign.square.fill")
+    static var malaysianringgitsignSquareFill: SFSymbol { .init(rawValue: "malaysianringgitsign.square.fill") }
 
     /// 􂈭
     /// Single Localization, 2 Layersets
@@ -8840,7 +8840,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "manatsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var manatsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "manatsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔱
     /// Single Localization, 2 Layersets
@@ -8848,7 +8848,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignBankBuilding = SFSymbol(rawValue: "manatsign.bank.building")
+    static var manatsignBankBuilding: SFSymbol { .init(rawValue: "manatsign.bank.building") }
 
     /// 􂔲
     /// Single Localization, 3 Layersets
@@ -8857,7 +8857,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let manatsignBankBuildingFill = SFSymbol(rawValue: "manatsign.bank.building.fill")
+    static var manatsignBankBuildingFill: SFSymbol { .init(rawValue: "manatsign.bank.building.fill") }
 
     /// 􂩑
     /// Single Localization, 2 Layersets
@@ -8865,7 +8865,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "manatsign.gauge.chart.lefthalf.righthalf")
+    static var manatsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "manatsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩻
     /// Single Localization, 2 Layersets
@@ -8873,7 +8873,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "manatsign.gauge.chart.leftthird.topthird.rightthird")
+    static var manatsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "manatsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰡
     /// Single Localization, 2 Layersets
@@ -8881,7 +8881,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignRing = SFSymbol(rawValue: "manatsign.ring")
+    static var manatsignRing: SFSymbol { .init(rawValue: "manatsign.ring") }
 
     /// 􂯷
     /// Single Localization, 2 Layersets
@@ -8889,7 +8889,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let manatsignRingDashed = SFSymbol(rawValue: "manatsign.ring.dashed")
+    static var manatsignRingDashed: SFSymbol { .init(rawValue: "manatsign.ring.dashed") }
 
     /// 􀴗
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -8898,14 +8898,14 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to the Connectivity Standards Alliance Matter connectivity protocol.
-    static let matterLogo = SFSymbol(rawValue: "matter.logo")
+    static var matterLogo: SFSymbol { .init(rawValue: "matter.logo") }
 
     /// 􂥮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mecca = SFSymbol(rawValue: "mecca")
+    static var mecca: SFSymbol { .init(rawValue: "mecca") }
 
     /// 􀊰
     /// Single Localization, 2 Layersets
@@ -8913,7 +8913,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let microphone = SFSymbol(rawValue: "microphone")
+    static var microphone: SFSymbol { .init(rawValue: "microphone") }
 
     /// 􁎔
     /// Single Localization, 3 Layersets
@@ -8922,7 +8922,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneAndSignalMeter = SFSymbol(rawValue: "microphone.and.signal.meter")
+    static var microphoneAndSignalMeter: SFSymbol { .init(rawValue: "microphone.and.signal.meter") }
 
     /// 􁎓
     /// Single Localization, 3 Layersets
@@ -8931,7 +8931,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneAndSignalMeterFill = SFSymbol(rawValue: "microphone.and.signal.meter.fill")
+    static var microphoneAndSignalMeterFill: SFSymbol { .init(rawValue: "microphone.and.signal.meter.fill") }
 
     /// 􂙍
     /// Single Localization, 3 Layersets
@@ -8940,7 +8940,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgeEllipsis = SFSymbol(rawValue: "microphone.badge.ellipsis")
+    static var microphoneBadgeEllipsis: SFSymbol { .init(rawValue: "microphone.badge.ellipsis") }
 
     /// 􂙎
     /// Single Localization, 3 Layersets
@@ -8949,7 +8949,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgeEllipsisFill = SFSymbol(rawValue: "microphone.badge.ellipsis.fill")
+    static var microphoneBadgeEllipsisFill: SFSymbol { .init(rawValue: "microphone.badge.ellipsis.fill") }
 
     /// 􀺁
     /// Single Localization, 3 Layersets
@@ -8958,7 +8958,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgePlus = SFSymbol(rawValue: "microphone.badge.plus")
+    static var microphoneBadgePlus: SFSymbol { .init(rawValue: "microphone.badge.plus") }
 
     /// 􀺂
     /// Single Localization, 3 Layersets
@@ -8967,7 +8967,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgePlusFill = SFSymbol(rawValue: "microphone.badge.plus.fill")
+    static var microphoneBadgePlusFill: SFSymbol { .init(rawValue: "microphone.badge.plus.fill") }
 
     /// 􁙃
     /// Single Localization, 3 Layersets
@@ -8976,7 +8976,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgeXmark = SFSymbol(rawValue: "microphone.badge.xmark")
+    static var microphoneBadgeXmark: SFSymbol { .init(rawValue: "microphone.badge.xmark") }
 
     /// 􁙄
     /// Single Localization, 3 Layersets
@@ -8985,7 +8985,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneBadgeXmarkFill = SFSymbol(rawValue: "microphone.badge.xmark.fill")
+    static var microphoneBadgeXmarkFill: SFSymbol { .init(rawValue: "microphone.badge.xmark.fill") }
 
     /// 􀒩
     /// Single Localization, 3 Layersets
@@ -8994,7 +8994,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneCircle = SFSymbol(rawValue: "microphone.circle")
+    static var microphoneCircle: SFSymbol { .init(rawValue: "microphone.circle") }
 
     /// 􀒪
     /// Single Localization, 3 Layersets
@@ -9003,7 +9003,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneCircleFill = SFSymbol(rawValue: "microphone.circle.fill")
+    static var microphoneCircleFill: SFSymbol { .init(rawValue: "microphone.circle.fill") }
 
     /// 􀊱
     /// Single Localization, 2 Layersets
@@ -9011,7 +9011,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let microphoneFill = SFSymbol(rawValue: "microphone.fill")
+    static var microphoneFill: SFSymbol { .init(rawValue: "microphone.fill") }
 
     /// 􀊲
     /// Single Localization, 3 Layersets
@@ -9020,7 +9020,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSlash = SFSymbol(rawValue: "microphone.slash")
+    static var microphoneSlash: SFSymbol { .init(rawValue: "microphone.slash") }
 
     /// 􀻩
     /// Single Localization, 3 Layersets
@@ -9029,7 +9029,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSlashCircle = SFSymbol(rawValue: "microphone.slash.circle")
+    static var microphoneSlashCircle: SFSymbol { .init(rawValue: "microphone.slash.circle") }
 
     /// 􀻪
     /// Single Localization, 3 Layersets
@@ -9038,7 +9038,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSlashCircleFill = SFSymbol(rawValue: "microphone.slash.circle.fill")
+    static var microphoneSlashCircleFill: SFSymbol { .init(rawValue: "microphone.slash.circle.fill") }
 
     /// 􀊳
     /// Single Localization, 3 Layersets
@@ -9047,7 +9047,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSlashFill = SFSymbol(rawValue: "microphone.slash.fill")
+    static var microphoneSlashFill: SFSymbol { .init(rawValue: "microphone.slash.fill") }
 
     /// 􀼿
     /// Single Localization, 3 Layersets
@@ -9056,7 +9056,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSquare = SFSymbol(rawValue: "microphone.square")
+    static var microphoneSquare: SFSymbol { .init(rawValue: "microphone.square") }
 
     /// 􀽀
     /// Single Localization, 3 Layersets
@@ -9065,7 +9065,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let microphoneSquareFill = SFSymbol(rawValue: "microphone.square.fill")
+    static var microphoneSquareFill: SFSymbol { .init(rawValue: "microphone.square.fill") }
 
     /// 􂈫
     /// Single Localization, 2 Layersets
@@ -9073,7 +9073,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "millsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var millsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "millsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔭
     /// Single Localization, 2 Layersets
@@ -9081,7 +9081,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignBankBuilding = SFSymbol(rawValue: "millsign.bank.building")
+    static var millsignBankBuilding: SFSymbol { .init(rawValue: "millsign.bank.building") }
 
     /// 􂔮
     /// Single Localization, 3 Layersets
@@ -9090,7 +9090,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let millsignBankBuildingFill = SFSymbol(rawValue: "millsign.bank.building.fill")
+    static var millsignBankBuildingFill: SFSymbol { .init(rawValue: "millsign.bank.building.fill") }
 
     /// 􂩓
     /// Single Localization, 2 Layersets
@@ -9098,7 +9098,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "millsign.gauge.chart.lefthalf.righthalf")
+    static var millsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "millsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩽
     /// Single Localization, 2 Layersets
@@ -9106,7 +9106,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "millsign.gauge.chart.leftthird.topthird.rightthird")
+    static var millsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "millsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰣
     /// Single Localization, 2 Layersets
@@ -9114,7 +9114,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignRing = SFSymbol(rawValue: "millsign.ring")
+    static var millsignRing: SFSymbol { .init(rawValue: "millsign.ring") }
 
     /// 􂯹
     /// Single Localization, 2 Layersets
@@ -9122,7 +9122,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let millsignRingDashed = SFSymbol(rawValue: "millsign.ring.dashed")
+    static var millsignRingDashed: SFSymbol { .init(rawValue: "millsign.ring.dashed") }
 
     /// 􀘩
     /// Single Localization, 2 Layersets
@@ -9130,7 +9130,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusArrowTriangleheadCounterclockwise = SFSymbol(rawValue: "minus.arrow.trianglehead.counterclockwise")
+    static var minusArrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "minus.arrow.trianglehead.counterclockwise") }
 
     /// 􂣸
     /// Single Localization, 2 Layersets
@@ -9138,42 +9138,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let moonRoadLanes = SFSymbol(rawValue: "moon.road.lanes")
+    static var moonRoadLanes: SFSymbol { .init(rawValue: "moon.road.lanes") }
 
     /// 􂏮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let moped = SFSymbol(rawValue: "moped")
+    static var moped: SFSymbol { .init(rawValue: "moped") }
 
     /// 􂏯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let mopedFill = SFSymbol(rawValue: "moped.fill")
+    static var mopedFill: SFSymbol { .init(rawValue: "moped.fill") }
 
     /// 􂓴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let motorcycle = SFSymbol(rawValue: "motorcycle")
+    static var motorcycle: SFSymbol { .init(rawValue: "motorcycle") }
 
     /// 􂓵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let motorcycleFill = SFSymbol(rawValue: "motorcycle.fill")
+    static var motorcycleFill: SFSymbol { .init(rawValue: "motorcycle.fill") }
 
     /// 􀑫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let musicMicrophone = SFSymbol(rawValue: "music.microphone")
+    static var musicMicrophone: SFSymbol { .init(rawValue: "music.microphone") }
 
     /// 􁁑
     /// Single Localization, 2 Layersets
@@ -9181,7 +9181,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicMicrophoneCircle = SFSymbol(rawValue: "music.microphone.circle")
+    static var musicMicrophoneCircle: SFSymbol { .init(rawValue: "music.microphone.circle") }
 
     /// 􁁒
     /// Single Localization, 3 Layersets
@@ -9190,7 +9190,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let musicMicrophoneCircleFill = SFSymbol(rawValue: "music.microphone.circle.fill")
+    static var musicMicrophoneCircleFill: SFSymbol { .init(rawValue: "music.microphone.circle.fill") }
 
     /// 􂈥
     /// Single Localization, 2 Layersets
@@ -9198,7 +9198,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "nairasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var nairasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "nairasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔡
     /// Single Localization, 2 Layersets
@@ -9206,7 +9206,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignBankBuilding = SFSymbol(rawValue: "nairasign.bank.building")
+    static var nairasignBankBuilding: SFSymbol { .init(rawValue: "nairasign.bank.building") }
 
     /// 􂔢
     /// Single Localization, 3 Layersets
@@ -9215,7 +9215,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let nairasignBankBuildingFill = SFSymbol(rawValue: "nairasign.bank.building.fill")
+    static var nairasignBankBuildingFill: SFSymbol { .init(rawValue: "nairasign.bank.building.fill") }
 
     /// 􂩔
     /// Single Localization, 2 Layersets
@@ -9223,7 +9223,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "nairasign.gauge.chart.lefthalf.righthalf")
+    static var nairasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "nairasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩾
     /// Single Localization, 2 Layersets
@@ -9231,7 +9231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "nairasign.gauge.chart.leftthird.topthird.rightthird")
+    static var nairasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "nairasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰤
     /// Single Localization, 2 Layersets
@@ -9239,7 +9239,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignRing = SFSymbol(rawValue: "nairasign.ring")
+    static var nairasignRing: SFSymbol { .init(rawValue: "nairasign.ring") }
 
     /// 􂯺
     /// Single Localization, 2 Layersets
@@ -9247,7 +9247,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let nairasignRingDashed = SFSymbol(rawValue: "nairasign.ring.dashed")
+    static var nairasignRingDashed: SFSymbol { .init(rawValue: "nairasign.ring.dashed") }
 
     /// 􂈵
     /// Single Localization, 2 Layersets
@@ -9255,7 +9255,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "norwegiankronesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var norwegiankronesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "norwegiankronesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂕁
     /// Single Localization, 2 Layersets
@@ -9263,7 +9263,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignBankBuilding = SFSymbol(rawValue: "norwegiankronesign.bank.building")
+    static var norwegiankronesignBankBuilding: SFSymbol { .init(rawValue: "norwegiankronesign.bank.building") }
 
     /// 􂕂
     /// Single Localization, 3 Layersets
@@ -9272,7 +9272,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let norwegiankronesignBankBuildingFill = SFSymbol(rawValue: "norwegiankronesign.bank.building.fill")
+    static var norwegiankronesignBankBuildingFill: SFSymbol { .init(rawValue: "norwegiankronesign.bank.building.fill") }
 
     /// 􂩕
     /// Single Localization, 2 Layersets
@@ -9280,7 +9280,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "norwegiankronesign.gauge.chart.lefthalf.righthalf")
+    static var norwegiankronesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "norwegiankronesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂩿
     /// Single Localization, 2 Layersets
@@ -9288,7 +9288,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "norwegiankronesign.gauge.chart.leftthird.topthird.rightthird")
+    static var norwegiankronesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "norwegiankronesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰥
     /// Single Localization, 2 Layersets
@@ -9296,7 +9296,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignRing = SFSymbol(rawValue: "norwegiankronesign.ring")
+    static var norwegiankronesignRing: SFSymbol { .init(rawValue: "norwegiankronesign.ring") }
 
     /// 􂯻
     /// Single Localization, 2 Layersets
@@ -9304,14 +9304,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let norwegiankronesignRingDashed = SFSymbol(rawValue: "norwegiankronesign.ring.dashed")
+    static var norwegiankronesignRingDashed: SFSymbol { .init(rawValue: "norwegiankronesign.ring.dashed") }
 
     /// 􂪯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let notequal = SFSymbol(rawValue: "notequal")
+    static var notequal: SFSymbol { .init(rawValue: "notequal") }
 
     /// 􂫃
     /// Single Localization, 2 Layersets
@@ -9319,7 +9319,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let notequalCircle = SFSymbol(rawValue: "notequal.circle")
+    static var notequalCircle: SFSymbol { .init(rawValue: "notequal.circle") }
 
     /// 􂫄
     /// Single Localization, 3 Layersets
@@ -9328,7 +9328,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let notequalCircleFill = SFSymbol(rawValue: "notequal.circle.fill")
+    static var notequalCircleFill: SFSymbol { .init(rawValue: "notequal.circle.fill") }
 
     /// 􂫅
     /// Single Localization, 2 Layersets
@@ -9336,7 +9336,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let notequalSquare = SFSymbol(rawValue: "notequal.square")
+    static var notequalSquare: SFSymbol { .init(rawValue: "notequal.square") }
 
     /// 􂫆
     /// Single Localization, 3 Layersets
@@ -9345,7 +9345,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let notequalSquareFill = SFSymbol(rawValue: "notequal.square.fill")
+    static var notequalSquareFill: SFSymbol { .init(rawValue: "notequal.square.fill") }
 
     /// 􀅱
     /// 15 Localizations, Single Layerset
@@ -9369,7 +9369,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let numbers = SymbolWith14Localizations<Ar, Bn_v7, Gu_v7, Hi, Km_v7, Kn_v7, Ml_v7, Mni_v7, Mr_v7, My_v7, Or_v7, Pa_v7, Sat_v7, Te_v7>(rawValue: "numbers")
+    static var numbers: SymbolWith14Localizations<Ar, Bn_v7, Gu_v7, Hi, Km_v7, Kn_v7, Ml_v7, Mni_v7, Mr_v7, My_v7, Or_v7, Pa_v7, Sat_v7, Te_v7> { .init(rawValue: "numbers") }
 
     /// 􁂷
     /// 3 Localizations, 2 Layersets
@@ -9382,7 +9382,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let numbersRectangle = SymbolWith2Localizations<Ar, Hi>(rawValue: "numbers.rectangle")
+    static var numbersRectangle: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "numbers.rectangle") }
 
     /// 􁂸
     /// 3 Localizations, 3 Layersets
@@ -9396,7 +9396,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let numbersRectangleFill = SymbolWith2Localizations<Ar, Hi>(rawValue: "numbers.rectangle.fill")
+    static var numbersRectangleFill: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "numbers.rectangle.fill") }
 
     /// 􂕳
     /// Single Localization, 2 Layersets
@@ -9404,7 +9404,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let oar2CrossedCircle = SFSymbol(rawValue: "oar.2.crossed.circle")
+    static var oar2CrossedCircle: SFSymbol { .init(rawValue: "oar.2.crossed.circle") }
 
     /// 􂕴
     /// Single Localization, 3 Layersets
@@ -9413,7 +9413,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let oar2CrossedCircleFill = SFSymbol(rawValue: "oar.2.crossed.circle.fill")
+    static var oar2CrossedCircleFill: SFSymbol { .init(rawValue: "oar.2.crossed.circle.fill") }
 
     /// 􂞎
     /// Single Localization, 2 Layersets
@@ -9421,7 +9421,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let oilcanAndThermometer = SFSymbol(rawValue: "oilcan.and.thermometer")
+    static var oilcanAndThermometer: SFSymbol { .init(rawValue: "oilcan.and.thermometer") }
 
     /// 􂞐
     /// Single Localization, 2 Layersets
@@ -9429,7 +9429,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let oilcanAndThermometerFill = SFSymbol(rawValue: "oilcan.and.thermometer.fill")
+    static var oilcanAndThermometerFill: SFSymbol { .init(rawValue: "oilcan.and.thermometer.fill") }
 
     /// 􂊸
     /// Single Localization, 2 Layersets
@@ -9437,7 +9437,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignRadiowavesDownRightOff = SFSymbol(rawValue: "parkingsign.radiowaves.down.right.off")
+    static var parkingsignRadiowavesDownRightOff: SFSymbol { .init(rawValue: "parkingsign.radiowaves.down.right.off") }
 
     /// 􂊳
     /// Single Localization, 2 Layersets
@@ -9445,7 +9445,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignRadiowavesLeftAndRightSlash = SFSymbol(rawValue: "parkingsign.radiowaves.left.and.right.slash")
+    static var parkingsignRadiowavesLeftAndRightSlash: SFSymbol { .init(rawValue: "parkingsign.radiowaves.left.and.right.slash") }
 
     /// 􂨈
     /// Single Localization, 2 Layersets
@@ -9453,7 +9453,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let parkingsignSquare = SFSymbol(rawValue: "parkingsign.square")
+    static var parkingsignSquare: SFSymbol { .init(rawValue: "parkingsign.square") }
 
     /// 􂨉
     /// Single Localization, 3 Layersets
@@ -9462,7 +9462,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let parkingsignSquareFill = SFSymbol(rawValue: "parkingsign.square.fill")
+    static var parkingsignSquareFill: SFSymbol { .init(rawValue: "parkingsign.square.fill") }
 
     /// 􁙙
     /// Single Localization, 2 Layersets
@@ -9470,7 +9470,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2ArrowTriangleheadCounterclockwise = SFSymbol(rawValue: "person.2.arrow.trianglehead.counterclockwise")
+    static var person2ArrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "person.2.arrow.trianglehead.counterclockwise") }
 
     /// 􂪡
     /// Single Localization, 3 Layersets
@@ -9479,7 +9479,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2BadgeMinus = SFSymbol(rawValue: "person.2.badge.minus")
+    static var person2BadgeMinus: SFSymbol { .init(rawValue: "person.2.badge.minus") }
 
     /// 􂪢
     /// Single Localization, 3 Layersets
@@ -9488,7 +9488,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2BadgeMinusFill = SFSymbol(rawValue: "person.2.badge.minus.fill")
+    static var person2BadgeMinusFill: SFSymbol { .init(rawValue: "person.2.badge.minus.fill") }
 
     /// 􂪝
     /// Single Localization, 3 Layersets
@@ -9497,7 +9497,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2BadgePlus = SFSymbol(rawValue: "person.2.badge.plus")
+    static var person2BadgePlus: SFSymbol { .init(rawValue: "person.2.badge.plus") }
 
     /// 􂪞
     /// Single Localization, 3 Layersets
@@ -9506,7 +9506,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2BadgePlusFill = SFSymbol(rawValue: "person.2.badge.plus.fill")
+    static var person2BadgePlusFill: SFSymbol { .init(rawValue: "person.2.badge.plus.fill") }
 
     /// 􀪼
     /// Single Localization, 2 Layersets
@@ -9514,7 +9514,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personAndArrowLeftAndArrowRightOutward = SFSymbol(rawValue: "person.and.arrow.left.and.arrow.right.outward")
+    static var personAndArrowLeftAndArrowRightOutward: SFSymbol { .init(rawValue: "person.and.arrow.left.and.arrow.right.outward") }
 
     /// 􂧻
     /// Single Localization, 3 Layersets
@@ -9523,7 +9523,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personBadgeShieldExclamationmark = SFSymbol(rawValue: "person.badge.shield.exclamationmark")
+    static var personBadgeShieldExclamationmark: SFSymbol { .init(rawValue: "person.badge.shield.exclamationmark") }
 
     /// 􂧼
     /// Single Localization, 3 Layersets
@@ -9532,7 +9532,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personBadgeShieldExclamationmarkFill = SFSymbol(rawValue: "person.badge.shield.exclamationmark.fill")
+    static var personBadgeShieldExclamationmarkFill: SFSymbol { .init(rawValue: "person.badge.shield.exclamationmark.fill") }
 
     /// 􁹕
     /// Single Localization, 2 Layersets
@@ -9540,7 +9540,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropBadgeMagnifyingglass = SFSymbol(rawValue: "person.crop.badge.magnifyingglass")
+    static var personCropBadgeMagnifyingglass: SFSymbol { .init(rawValue: "person.crop.badge.magnifyingglass") }
 
     /// 􁹖
     /// Single Localization, 2 Layersets
@@ -9548,7 +9548,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropBadgeMagnifyingglassFill = SFSymbol(rawValue: "person.crop.badge.magnifyingglass.fill")
+    static var personCropBadgeMagnifyingglassFill: SFSymbol { .init(rawValue: "person.crop.badge.magnifyingglass.fill") }
 
     /// 􂣄
     /// Single Localization, 2 Layersets
@@ -9556,7 +9556,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareOnSquareAngled = SFSymbol(rawValue: "person.crop.square.on.square.angled")
+    static var personCropSquareOnSquareAngled: SFSymbol { .init(rawValue: "person.crop.square.on.square.angled") }
 
     /// 􂣅
     /// Single Localization, 2 Layersets
@@ -9564,7 +9564,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCropSquareOnSquareAngledFill = SFSymbol(rawValue: "person.crop.square.on.square.angled.fill")
+    static var personCropSquareOnSquareAngledFill: SFSymbol { .init(rawValue: "person.crop.square.on.square.angled.fill") }
 
     /// 􀪽
     /// Single Localization, 2 Layersets
@@ -9572,7 +9572,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personFillAndArrowLeftAndArrowRightOutward = SFSymbol(rawValue: "person.fill.and.arrow.left.and.arrow.right.outward")
+    static var personFillAndArrowLeftAndArrowRightOutward: SFSymbol { .init(rawValue: "person.fill.and.arrow.left.and.arrow.right.outward") }
 
     /// 􂮿
     /// Single Localization, 2 Layersets
@@ -9580,14 +9580,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personalhotspotSlash = SFSymbol(rawValue: "personalhotspot.slash")
+    static var personalhotspotSlash: SFSymbol { .init(rawValue: "personalhotspot.slash") }
 
     /// 􂨴
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let peruviansolessign = SFSymbol(rawValue: "peruviansolessign")
+    static var peruviansolessign: SFSymbol { .init(rawValue: "peruviansolessign") }
 
     /// 􂥯
     /// Single Localization, 2 Layersets
@@ -9595,7 +9595,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "peruviansolessign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var peruviansolessignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "peruviansolessign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂨹
     /// Single Localization, 2 Layersets
@@ -9603,7 +9603,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignBankBuilding = SFSymbol(rawValue: "peruviansolessign.bank.building")
+    static var peruviansolessignBankBuilding: SFSymbol { .init(rawValue: "peruviansolessign.bank.building") }
 
     /// 􂨺
     /// Single Localization, 3 Layersets
@@ -9612,7 +9612,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let peruviansolessignBankBuildingFill = SFSymbol(rawValue: "peruviansolessign.bank.building.fill")
+    static var peruviansolessignBankBuildingFill: SFSymbol { .init(rawValue: "peruviansolessign.bank.building.fill") }
 
     /// 􂨵
     /// Single Localization, 2 Layersets
@@ -9620,7 +9620,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignCircle = SFSymbol(rawValue: "peruviansolessign.circle")
+    static var peruviansolessignCircle: SFSymbol { .init(rawValue: "peruviansolessign.circle") }
 
     /// 􂨶
     /// Single Localization, 3 Layersets
@@ -9629,7 +9629,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let peruviansolessignCircleFill = SFSymbol(rawValue: "peruviansolessign.circle.fill")
+    static var peruviansolessignCircleFill: SFSymbol { .init(rawValue: "peruviansolessign.circle.fill") }
 
     /// 􂩖
     /// Single Localization, 2 Layersets
@@ -9637,7 +9637,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "peruviansolessign.gauge.chart.lefthalf.righthalf")
+    static var peruviansolessignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "peruviansolessign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪀
     /// Single Localization, 2 Layersets
@@ -9645,7 +9645,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "peruviansolessign.gauge.chart.leftthird.topthird.rightthird")
+    static var peruviansolessignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "peruviansolessign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰦
     /// Single Localization, 2 Layersets
@@ -9653,7 +9653,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignRing = SFSymbol(rawValue: "peruviansolessign.ring")
+    static var peruviansolessignRing: SFSymbol { .init(rawValue: "peruviansolessign.ring") }
 
     /// 􂯼
     /// Single Localization, 2 Layersets
@@ -9661,7 +9661,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignRingDashed = SFSymbol(rawValue: "peruviansolessign.ring.dashed")
+    static var peruviansolessignRingDashed: SFSymbol { .init(rawValue: "peruviansolessign.ring.dashed") }
 
     /// 􂨷
     /// Single Localization, 2 Layersets
@@ -9669,7 +9669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let peruviansolessignSquare = SFSymbol(rawValue: "peruviansolessign.square")
+    static var peruviansolessignSquare: SFSymbol { .init(rawValue: "peruviansolessign.square") }
 
     /// 􂨸
     /// Single Localization, 3 Layersets
@@ -9678,7 +9678,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let peruviansolessignSquareFill = SFSymbol(rawValue: "peruviansolessign.square.fill")
+    static var peruviansolessignSquareFill: SFSymbol { .init(rawValue: "peruviansolessign.square.fill") }
 
     /// 􂈞
     /// Single Localization, 2 Layersets
@@ -9686,7 +9686,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "pesetasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var pesetasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "pesetasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔓
     /// Single Localization, 2 Layersets
@@ -9694,7 +9694,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignBankBuilding = SFSymbol(rawValue: "pesetasign.bank.building")
+    static var pesetasignBankBuilding: SFSymbol { .init(rawValue: "pesetasign.bank.building") }
 
     /// 􂔔
     /// Single Localization, 3 Layersets
@@ -9703,7 +9703,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pesetasignBankBuildingFill = SFSymbol(rawValue: "pesetasign.bank.building.fill")
+    static var pesetasignBankBuildingFill: SFSymbol { .init(rawValue: "pesetasign.bank.building.fill") }
 
     /// 􂩗
     /// Single Localization, 2 Layersets
@@ -9711,7 +9711,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "pesetasign.gauge.chart.lefthalf.righthalf")
+    static var pesetasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "pesetasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪁
     /// Single Localization, 2 Layersets
@@ -9719,7 +9719,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "pesetasign.gauge.chart.leftthird.topthird.rightthird")
+    static var pesetasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "pesetasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰧
     /// Single Localization, 2 Layersets
@@ -9727,7 +9727,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignRing = SFSymbol(rawValue: "pesetasign.ring")
+    static var pesetasignRing: SFSymbol { .init(rawValue: "pesetasign.ring") }
 
     /// 􂯽
     /// Single Localization, 2 Layersets
@@ -9735,7 +9735,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesetasignRingDashed = SFSymbol(rawValue: "pesetasign.ring.dashed")
+    static var pesetasignRingDashed: SFSymbol { .init(rawValue: "pesetasign.ring.dashed") }
 
     /// 􂈟
     /// Single Localization, 2 Layersets
@@ -9743,7 +9743,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "pesosign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var pesosignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "pesosign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔕
     /// Single Localization, 2 Layersets
@@ -9751,7 +9751,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignBankBuilding = SFSymbol(rawValue: "pesosign.bank.building")
+    static var pesosignBankBuilding: SFSymbol { .init(rawValue: "pesosign.bank.building") }
 
     /// 􂔖
     /// Single Localization, 3 Layersets
@@ -9760,7 +9760,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pesosignBankBuildingFill = SFSymbol(rawValue: "pesosign.bank.building.fill")
+    static var pesosignBankBuildingFill: SFSymbol { .init(rawValue: "pesosign.bank.building.fill") }
 
     /// 􂩘
     /// Single Localization, 2 Layersets
@@ -9768,7 +9768,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "pesosign.gauge.chart.lefthalf.righthalf")
+    static var pesosignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "pesosign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪂
     /// Single Localization, 2 Layersets
@@ -9776,7 +9776,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "pesosign.gauge.chart.leftthird.topthird.rightthird")
+    static var pesosignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "pesosign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰨
     /// Single Localization, 2 Layersets
@@ -9784,7 +9784,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignRing = SFSymbol(rawValue: "pesosign.ring")
+    static var pesosignRing: SFSymbol { .init(rawValue: "pesosign.ring") }
 
     /// 􂯾
     /// Single Localization, 2 Layersets
@@ -9792,7 +9792,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pesosignRingDashed = SFSymbol(rawValue: "pesosign.ring.dashed")
+    static var pesosignRingDashed: SFSymbol { .init(rawValue: "pesosign.ring.dashed") }
 
     /// 􂞲
     /// Single Localization, 3 Layersets
@@ -9801,7 +9801,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBadgeClock = SFSymbol(rawValue: "phone.badge.clock")
+    static var phoneBadgeClock: SFSymbol { .init(rawValue: "phone.badge.clock") }
 
     /// 􂞳
     /// Single Localization, 3 Layersets
@@ -9810,7 +9810,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phoneBadgeClockFill = SFSymbol(rawValue: "phone.badge.clock.fill")
+    static var phoneBadgeClockFill: SFSymbol { .init(rawValue: "phone.badge.clock.fill") }
 
     /// 􂪥
     /// Single Localization, 3 Layersets
@@ -9819,7 +9819,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeExclamationmark = SFSymbol(rawValue: "photo.badge.exclamationmark")
+    static var photoBadgeExclamationmark: SFSymbol { .init(rawValue: "photo.badge.exclamationmark") }
 
     /// 􂪦
     /// Single Localization, 3 Layersets
@@ -9828,7 +9828,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeExclamationmarkFill = SFSymbol(rawValue: "photo.badge.exclamationmark.fill")
+    static var photoBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "photo.badge.exclamationmark.fill") }
 
     /// 􂣳
     /// Single Localization, 2 Layersets
@@ -9836,7 +9836,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoOnRectangleAngledFill = SFSymbol(rawValue: "photo.on.rectangle.angled.fill")
+    static var photoOnRectangleAngledFill: SFSymbol { .init(rawValue: "photo.on.rectangle.angled.fill") }
 
     /// 􀘨
     /// Single Localization, 2 Layersets
@@ -9844,7 +9844,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusArrowTriangleheadClockwise = SFSymbol(rawValue: "plus.arrow.trianglehead.clockwise")
+    static var plusArrowTriangleheadClockwise: SFSymbol { .init(rawValue: "plus.arrow.trianglehead.clockwise") }
 
     /// 􂤜
     /// Single Localization, 2 Layersets
@@ -9852,7 +9852,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToArrowTriangleScurvepath = SFSymbol(rawValue: "point.bottomleft.forward.to.arrow.triangle.scurvepath")
+    static var pointBottomleftForwardToArrowTriangleScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrow.triangle.scurvepath") }
 
     /// 􂤝
     /// Single Localization, 2 Layersets
@@ -9860,7 +9860,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToArrowTriangleScurvepathFill = SFSymbol(rawValue: "point.bottomleft.forward.to.arrow.triangle.scurvepath.fill")
+    static var pointBottomleftForwardToArrowTriangleScurvepathFill: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrow.triangle.scurvepath.fill") }
 
     /// 􁻷
     /// Single Localization, 2 Layersets
@@ -9868,7 +9868,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToArrowTriangleUturnScurvepath = SFSymbol(rawValue: "point.bottomleft.forward.to.arrow.triangle.uturn.scurvepath")
+    static var pointBottomleftForwardToArrowTriangleUturnScurvepath: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrow.triangle.uturn.scurvepath") }
 
     /// 􁸹
     /// Single Localization, 2 Layersets
@@ -9876,7 +9876,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointBottomleftForwardToArrowTriangleUturnScurvepathFill = SFSymbol(rawValue: "point.bottomleft.forward.to.arrow.triangle.uturn.scurvepath.fill")
+    static var pointBottomleftForwardToArrowTriangleUturnScurvepathFill: SFSymbol { .init(rawValue: "point.bottomleft.forward.to.arrow.triangle.uturn.scurvepath.fill") }
 
     /// 􂤛
     /// Single Localization, 2 Layersets
@@ -9884,7 +9884,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointToprightArrowTriangleBackwardToPointBottomleftFilledScurvepath = SFSymbol(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.filled.scurvepath")
+    static var pointToprightArrowTriangleBackwardToPointBottomleftFilledScurvepath: SFSymbol { .init(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.filled.scurvepath") }
 
     /// 􂤙
     /// Single Localization, 2 Layersets
@@ -9892,7 +9892,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointToprightArrowTriangleBackwardToPointBottomleftScurvepath = SFSymbol(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath")
+    static var pointToprightArrowTriangleBackwardToPointBottomleftScurvepath: SFSymbol { .init(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath") }
 
     /// 􂤚
     /// Single Localization, 2 Layersets
@@ -9900,7 +9900,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointToprightArrowTriangleBackwardToPointBottomleftScurvepathFill = SFSymbol(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill")
+    static var pointToprightArrowTriangleBackwardToPointBottomleftScurvepathFill: SFSymbol { .init(rawValue: "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill") }
 
     /// 􂤞
     /// Single Localization, 2 Layersets
@@ -9908,7 +9908,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointToprightFilledArrowTriangleBackwardToPointBottomleftScurvepath = SFSymbol(rawValue: "point.topright.filled.arrow.triangle.backward.to.point.bottomleft.scurvepath")
+    static var pointToprightFilledArrowTriangleBackwardToPointBottomleftScurvepath: SFSymbol { .init(rawValue: "point.topright.filled.arrow.triangle.backward.to.point.bottomleft.scurvepath") }
 
     /// 􂈴
     /// Single Localization, 2 Layersets
@@ -9916,7 +9916,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "polishzlotysign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var polishzlotysignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "polishzlotysign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔿
     /// Single Localization, 2 Layersets
@@ -9924,7 +9924,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignBankBuilding = SFSymbol(rawValue: "polishzlotysign.bank.building")
+    static var polishzlotysignBankBuilding: SFSymbol { .init(rawValue: "polishzlotysign.bank.building") }
 
     /// 􂕀
     /// Single Localization, 3 Layersets
@@ -9933,7 +9933,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let polishzlotysignBankBuildingFill = SFSymbol(rawValue: "polishzlotysign.bank.building.fill")
+    static var polishzlotysignBankBuildingFill: SFSymbol { .init(rawValue: "polishzlotysign.bank.building.fill") }
 
     /// 􂩙
     /// Single Localization, 2 Layersets
@@ -9941,7 +9941,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "polishzlotysign.gauge.chart.lefthalf.righthalf")
+    static var polishzlotysignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "polishzlotysign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪃
     /// Single Localization, 2 Layersets
@@ -9949,7 +9949,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "polishzlotysign.gauge.chart.leftthird.topthird.rightthird")
+    static var polishzlotysignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "polishzlotysign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰩
     /// Single Localization, 2 Layersets
@@ -9957,7 +9957,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignRing = SFSymbol(rawValue: "polishzlotysign.ring")
+    static var polishzlotysignRing: SFSymbol { .init(rawValue: "polishzlotysign.ring") }
 
     /// 􂯿
     /// Single Localization, 2 Layersets
@@ -9965,7 +9965,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let polishzlotysignRingDashed = SFSymbol(rawValue: "polishzlotysign.ring.dashed")
+    static var polishzlotysignRingDashed: SFSymbol { .init(rawValue: "polishzlotysign.ring.dashed") }
 
     /// 􂚛
     /// Single Localization, 2 Layersets
@@ -9973,56 +9973,56 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let powermeter = SFSymbol(rawValue: "powermeter")
+    static var powermeter: SFSymbol { .init(rawValue: "powermeter") }
 
     /// 􂬹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powerplugPortrait = SFSymbol(rawValue: "powerplug.portrait")
+    static var powerplugPortrait: SFSymbol { .init(rawValue: "powerplug.portrait") }
 
     /// 􂬺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let powerplugPortraitFill = SFSymbol(rawValue: "powerplug.portrait.fill")
+    static var powerplugPortraitFill: SFSymbol { .init(rawValue: "powerplug.portrait.fill") }
 
     /// 􁑲
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerDotmatrixFilledAndPaperInverse = SFSymbol(rawValue: "printer.dotmatrix.filled.and.paper.inverse")
+    static var printerDotmatrixFilledAndPaperInverse: SFSymbol { .init(rawValue: "printer.dotmatrix.filled.and.paper.inverse") }
 
     /// 􂨣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerDotmatrixInverse = SFSymbol(rawValue: "printer.dotmatrix.inverse")
+    static var printerDotmatrixInverse: SFSymbol { .init(rawValue: "printer.dotmatrix.inverse") }
 
     /// 􁑱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerFilledAndPaperInverse = SFSymbol(rawValue: "printer.filled.and.paper.inverse")
+    static var printerFilledAndPaperInverse: SFSymbol { .init(rawValue: "printer.filled.and.paper.inverse") }
 
     /// 􂨖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let printerInverse = SFSymbol(rawValue: "printer.inverse")
+    static var printerInverse: SFSymbol { .init(rawValue: "printer.inverse") }
 
     /// 􀴽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let progressIndicator = SFSymbol(rawValue: "progress.indicator")
+    static var progressIndicator: SFSymbol { .init(rawValue: "progress.indicator") }
 
     /// 􂞷
     /// 2 Localizations, 2 Layersets
@@ -10034,7 +10034,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let questionmarkCircleDashed = SymbolWith1Localization<Ar>(rawValue: "questionmark.circle.dashed")
+    static var questionmarkCircleDashed: SymbolWith1Localization<Ar> { .init(rawValue: "questionmark.circle.dashed") }
 
     /// 􂇲
     /// 3 Localizations, 2 Layersets
@@ -10047,7 +10047,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let questionmarkTextPage = SymbolWith2Localizations<Ar, Rtl>(rawValue: "questionmark.text.page")
+    static var questionmarkTextPage: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "questionmark.text.page") }
 
     /// 􂇳
     /// 3 Localizations, Single Layerset
@@ -10059,7 +10059,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let questionmarkTextPageFill = SymbolWith2Localizations<Ar, Rtl>(rawValue: "questionmark.text.page.fill")
+    static var questionmarkTextPageFill: SymbolWith2Localizations<Ar, Rtl> { .init(rawValue: "questionmark.text.page.fill") }
 
     /// 􂮨
     /// Single Localization, 2 Layersets
@@ -10067,21 +10067,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleExpandDiagonal = SFSymbol(rawValue: "rectangle.expand.diagonal")
+    static var rectangleExpandDiagonal: SFSymbol { .init(rawValue: "rectangle.expand.diagonal") }
 
     /// 􂫑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x3 = SFSymbol(rawValue: "rectangle.grid.3x3")
+    static var rectangleGrid3x3: SFSymbol { .init(rawValue: "rectangle.grid.3x3") }
 
     /// 􂫒
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x3Fill = SFSymbol(rawValue: "rectangle.grid.3x3.fill")
+    static var rectangleGrid3x3Fill: SFSymbol { .init(rawValue: "rectangle.grid.3x3.fill") }
 
     /// 􂠗
     /// Single Localization, 2 Layersets
@@ -10089,14 +10089,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleOnRectangleDashed = SFSymbol(rawValue: "rectangle.on.rectangle.dashed")
+    static var rectangleOnRectangleDashed: SFSymbol { .init(rawValue: "rectangle.on.rectangle.dashed") }
 
     /// 􀪫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectanglePatternCheckered = SFSymbol(rawValue: "rectangle.pattern.checkered")
+    static var rectanglePatternCheckered: SFSymbol { .init(rawValue: "rectangle.pattern.checkered") }
 
     /// 􀉅
     /// 8 Localizations, Single Layerset
@@ -10113,7 +10113,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let richtextPage = SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh>(rawValue: "richtext.page")
+    static var richtextPage: SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh> { .init(rawValue: "richtext.page") }
 
     /// 􀦊
     /// 8 Localizations, Single Layerset
@@ -10130,21 +10130,21 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let richtextPageFill = SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh>(rawValue: "richtext.page.fill")
+    static var richtextPageFill: SymbolWith7Localizations<Ar, He, Hi, Ja, Ko, Th, Zh> { .init(rawValue: "richtext.page.fill") }
 
     /// 􂨭
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let roboticVacuum = SFSymbol(rawValue: "robotic.vacuum")
+    static var roboticVacuum: SFSymbol { .init(rawValue: "robotic.vacuum") }
 
     /// 􂨮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let roboticVacuumFill = SFSymbol(rawValue: "robotic.vacuum.fill")
+    static var roboticVacuumFill: SFSymbol { .init(rawValue: "robotic.vacuum.fill") }
 
     /// 􂈙
     /// Single Localization, 2 Layersets
@@ -10152,7 +10152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "rublesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var rublesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "rublesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔉
     /// Single Localization, 2 Layersets
@@ -10160,7 +10160,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignBankBuilding = SFSymbol(rawValue: "rublesign.bank.building")
+    static var rublesignBankBuilding: SFSymbol { .init(rawValue: "rublesign.bank.building") }
 
     /// 􂔊
     /// Single Localization, 3 Layersets
@@ -10169,7 +10169,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rublesignBankBuildingFill = SFSymbol(rawValue: "rublesign.bank.building.fill")
+    static var rublesignBankBuildingFill: SFSymbol { .init(rawValue: "rublesign.bank.building.fill") }
 
     /// 􂩚
     /// Single Localization, 2 Layersets
@@ -10177,7 +10177,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "rublesign.gauge.chart.lefthalf.righthalf")
+    static var rublesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "rublesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪄
     /// Single Localization, 2 Layersets
@@ -10185,7 +10185,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "rublesign.gauge.chart.leftthird.topthird.rightthird")
+    static var rublesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "rublesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰪
     /// Single Localization, 2 Layersets
@@ -10193,7 +10193,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignRing = SFSymbol(rawValue: "rublesign.ring")
+    static var rublesignRing: SFSymbol { .init(rawValue: "rublesign.ring") }
 
     /// 􂰀
     /// Single Localization, 2 Layersets
@@ -10201,14 +10201,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rublesignRingDashed = SFSymbol(rawValue: "rublesign.ring.dashed")
+    static var rublesignRingDashed: SFSymbol { .init(rawValue: "rublesign.ring.dashed") }
 
     /// 􂎹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rugbyball = SFSymbol(rawValue: "rugbyball")
+    static var rugbyball: SFSymbol { .init(rawValue: "rugbyball") }
 
     /// 􂎻
     /// Single Localization, 2 Layersets
@@ -10216,7 +10216,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rugbyballCircle = SFSymbol(rawValue: "rugbyball.circle")
+    static var rugbyballCircle: SFSymbol { .init(rawValue: "rugbyball.circle") }
 
     /// 􂎼
     /// Single Localization, 3 Layersets
@@ -10225,14 +10225,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rugbyballCircleFill = SFSymbol(rawValue: "rugbyball.circle.fill")
+    static var rugbyballCircleFill: SFSymbol { .init(rawValue: "rugbyball.circle.fill") }
 
     /// 􂎺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rugbyballFill = SFSymbol(rawValue: "rugbyball.fill")
+    static var rugbyballFill: SFSymbol { .init(rawValue: "rugbyball.fill") }
 
     /// 􂈮
     /// Single Localization, 2 Layersets
@@ -10240,7 +10240,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "rupeesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var rupeesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "rupeesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔳
     /// Single Localization, 2 Layersets
@@ -10248,7 +10248,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignBankBuilding = SFSymbol(rawValue: "rupeesign.bank.building")
+    static var rupeesignBankBuilding: SFSymbol { .init(rawValue: "rupeesign.bank.building") }
 
     /// 􂔴
     /// Single Localization, 3 Layersets
@@ -10257,7 +10257,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let rupeesignBankBuildingFill = SFSymbol(rawValue: "rupeesign.bank.building.fill")
+    static var rupeesignBankBuildingFill: SFSymbol { .init(rawValue: "rupeesign.bank.building.fill") }
 
     /// 􂩛
     /// Single Localization, 2 Layersets
@@ -10265,7 +10265,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "rupeesign.gauge.chart.lefthalf.righthalf")
+    static var rupeesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "rupeesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪅
     /// Single Localization, 2 Layersets
@@ -10273,7 +10273,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "rupeesign.gauge.chart.leftthird.topthird.rightthird")
+    static var rupeesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "rupeesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰫
     /// Single Localization, 2 Layersets
@@ -10281,7 +10281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignRing = SFSymbol(rawValue: "rupeesign.ring")
+    static var rupeesignRing: SFSymbol { .init(rawValue: "rupeesign.ring") }
 
     /// 􂰁
     /// Single Localization, 2 Layersets
@@ -10289,7 +10289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rupeesignRingDashed = SFSymbol(rawValue: "rupeesign.ring.dashed")
+    static var rupeesignRingDashed: SFSymbol { .init(rawValue: "rupeesign.ring.dashed") }
 
     /// 􁅁
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10299,7 +10299,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shared With You feature.
-    static let sharedwithyou = SFSymbol(rawValue: "sharedwithyou")
+    static var sharedwithyou: SFSymbol { .init(rawValue: "sharedwithyou") }
 
     /// 􂇄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10309,7 +10309,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shared With You feature.
-    static let sharedwithyouCircle = SFSymbol(rawValue: "sharedwithyou.circle")
+    static var sharedwithyouCircle: SFSymbol { .init(rawValue: "sharedwithyou.circle") }
 
     /// 􂄀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -10320,7 +10320,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shared With You feature.
-    static let sharedwithyouCircleFill = SFSymbol(rawValue: "sharedwithyou.circle.fill")
+    static var sharedwithyouCircleFill: SFSymbol { .init(rawValue: "sharedwithyou.circle.fill") }
 
     /// 􁇦
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -10330,7 +10330,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Shared With You feature.
-    static let sharedwithyouSlash = SFSymbol(rawValue: "sharedwithyou.slash")
+    static var sharedwithyouSlash: SFSymbol { .init(rawValue: "sharedwithyou.slash") }
 
     /// 􂈬
     /// Single Localization, 2 Layersets
@@ -10338,7 +10338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "shekelsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var shekelsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "shekelsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔯
     /// Single Localization, 2 Layersets
@@ -10346,7 +10346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignBankBuilding = SFSymbol(rawValue: "shekelsign.bank.building")
+    static var shekelsignBankBuilding: SFSymbol { .init(rawValue: "shekelsign.bank.building") }
 
     /// 􂔰
     /// Single Localization, 3 Layersets
@@ -10355,7 +10355,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shekelsignBankBuildingFill = SFSymbol(rawValue: "shekelsign.bank.building.fill")
+    static var shekelsignBankBuildingFill: SFSymbol { .init(rawValue: "shekelsign.bank.building.fill") }
 
     /// 􂩜
     /// Single Localization, 2 Layersets
@@ -10363,7 +10363,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "shekelsign.gauge.chart.lefthalf.righthalf")
+    static var shekelsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "shekelsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪆
     /// Single Localization, 2 Layersets
@@ -10371,7 +10371,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "shekelsign.gauge.chart.leftthird.topthird.rightthird")
+    static var shekelsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "shekelsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰬
     /// Single Localization, 2 Layersets
@@ -10379,7 +10379,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignRing = SFSymbol(rawValue: "shekelsign.ring")
+    static var shekelsignRing: SFSymbol { .init(rawValue: "shekelsign.ring") }
 
     /// 􂰂
     /// Single Localization, 2 Layersets
@@ -10387,21 +10387,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shekelsignRingDashed = SFSymbol(rawValue: "shekelsign.ring.dashed")
+    static var shekelsignRingDashed: SFSymbol { .init(rawValue: "shekelsign.ring.dashed") }
 
     /// 􀵔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let shieldPatternCheckered = SFSymbol(rawValue: "shield.pattern.checkered")
+    static var shieldPatternCheckered: SFSymbol { .init(rawValue: "shield.pattern.checkered") }
 
     /// 􂨰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let singaporedollarsign = SFSymbol(rawValue: "singaporedollarsign")
+    static var singaporedollarsign: SFSymbol { .init(rawValue: "singaporedollarsign") }
 
     /// 􂨱
     /// Single Localization, 2 Layersets
@@ -10409,7 +10409,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "singaporedollarsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var singaporedollarsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "singaporedollarsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂨲
     /// Single Localization, 2 Layersets
@@ -10417,7 +10417,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignBankBuilding = SFSymbol(rawValue: "singaporedollarsign.bank.building")
+    static var singaporedollarsignBankBuilding: SFSymbol { .init(rawValue: "singaporedollarsign.bank.building") }
 
     /// 􂨳
     /// Single Localization, 3 Layersets
@@ -10426,7 +10426,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let singaporedollarsignBankBuildingFill = SFSymbol(rawValue: "singaporedollarsign.bank.building.fill")
+    static var singaporedollarsignBankBuildingFill: SFSymbol { .init(rawValue: "singaporedollarsign.bank.building.fill") }
 
     /// 􂉮
     /// Single Localization, 2 Layersets
@@ -10434,7 +10434,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignCircle = SFSymbol(rawValue: "singaporedollarsign.circle")
+    static var singaporedollarsignCircle: SFSymbol { .init(rawValue: "singaporedollarsign.circle") }
 
     /// 􂉯
     /// Single Localization, 3 Layersets
@@ -10443,7 +10443,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let singaporedollarsignCircleFill = SFSymbol(rawValue: "singaporedollarsign.circle.fill")
+    static var singaporedollarsignCircleFill: SFSymbol { .init(rawValue: "singaporedollarsign.circle.fill") }
 
     /// 􂩝
     /// Single Localization, 2 Layersets
@@ -10451,7 +10451,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "singaporedollarsign.gauge.chart.lefthalf.righthalf")
+    static var singaporedollarsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "singaporedollarsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪇
     /// Single Localization, 2 Layersets
@@ -10459,7 +10459,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "singaporedollarsign.gauge.chart.leftthird.topthird.rightthird")
+    static var singaporedollarsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "singaporedollarsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰭
     /// Single Localization, 2 Layersets
@@ -10467,7 +10467,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignRing = SFSymbol(rawValue: "singaporedollarsign.ring")
+    static var singaporedollarsignRing: SFSymbol { .init(rawValue: "singaporedollarsign.ring") }
 
     /// 􂰃
     /// Single Localization, 2 Layersets
@@ -10475,7 +10475,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignRingDashed = SFSymbol(rawValue: "singaporedollarsign.ring.dashed")
+    static var singaporedollarsignRingDashed: SFSymbol { .init(rawValue: "singaporedollarsign.ring.dashed") }
 
     /// 􂉰
     /// Single Localization, 2 Layersets
@@ -10483,7 +10483,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let singaporedollarsignSquare = SFSymbol(rawValue: "singaporedollarsign.square")
+    static var singaporedollarsignSquare: SFSymbol { .init(rawValue: "singaporedollarsign.square") }
 
     /// 􂉱
     /// Single Localization, 3 Layersets
@@ -10492,7 +10492,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let singaporedollarsignSquareFill = SFSymbol(rawValue: "singaporedollarsign.square.fill")
+    static var singaporedollarsignSquareFill: SFSymbol { .init(rawValue: "singaporedollarsign.square.fill") }
 
     /// 􁚌
     /// Single Localization, 2 Layersets
@@ -10500,7 +10500,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontal2ArrowTriangleheadCounterclockwise = SFSymbol(rawValue: "slider.horizontal.2.arrow.trianglehead.counterclockwise")
+    static var sliderHorizontal2ArrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "slider.horizontal.2.arrow.trianglehead.counterclockwise") }
 
     /// 􁅊
     /// Single Localization, 2 Layersets
@@ -10508,7 +10508,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90 = SFSymbol(rawValue: "slider.horizontal.2.rectangle.and.arrow.trianglehead.2.clockwise.rotate.90")
+    static var sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90: SFSymbol { .init(rawValue: "slider.horizontal.2.rectangle.and.arrow.trianglehead.2.clockwise.rotate.90") }
 
     /// 􂠻
     /// Single Localization, 2 Layersets
@@ -10516,7 +10516,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let speakerWave1ArrowtrianglesUpRightDownLeft = SFSymbol(rawValue: "speaker.wave.1.arrowtriangles.up.right.down.left")
+    static var speakerWave1ArrowtrianglesUpRightDownLeft: SFSymbol { .init(rawValue: "speaker.wave.1.arrowtriangles.up.right.down.left") }
 
     /// 􂰵
     /// Single Localization, 3 Layersets
@@ -10525,7 +10525,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeClock = SFSymbol(rawValue: "square.and.arrow.down.badge.clock")
+    static var squareAndArrowDownBadgeClock: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.clock") }
 
     /// 􂰶
     /// Single Localization, 3 Layersets
@@ -10534,7 +10534,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeClockFill = SFSymbol(rawValue: "square.and.arrow.down.badge.clock.fill")
+    static var squareAndArrowDownBadgeClockFill: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.clock.fill") }
 
     /// 􂋑
     /// Single Localization, 3 Layersets
@@ -10543,7 +10543,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "square.and.arrow.up.trianglebadge.exclamationmark.fill")
+    static var squareAndArrowUpTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "square.and.arrow.up.trianglebadge.exclamationmark.fill") }
 
     /// 􂠄
     /// Single Localization, 3 Layersets
@@ -10552,14 +10552,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareGrid3x3SquareBadgeEllipsis = SFSymbol(rawValue: "square.grid.3x3.square.badge.ellipsis")
+    static var squareGrid3x3SquareBadgeEllipsis: SFSymbol { .init(rawValue: "square.grid.3x3.square.badge.ellipsis") }
 
     /// 􂲯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareroot = SFSymbol(rawValue: "squareroot")
+    static var squareroot: SFSymbol { .init(rawValue: "squareroot") }
 
     /// 􂏐
     /// Single Localization, 2 Layersets
@@ -10567,7 +10567,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelAndHands = SFSymbol(rawValue: "steeringwheel.and.hands")
+    static var steeringwheelAndHands: SFSymbol { .init(rawValue: "steeringwheel.and.hands") }
 
     /// 􂥡
     /// Single Localization, 2 Layersets
@@ -10575,7 +10575,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelArrowTriangleheadCounterclockwiseAndClockwise = SFSymbol(rawValue: "steeringwheel.arrow.trianglehead.counterclockwise.and.clockwise")
+    static var steeringwheelArrowTriangleheadCounterclockwiseAndClockwise: SFSymbol { .init(rawValue: "steeringwheel.arrow.trianglehead.counterclockwise.and.clockwise") }
 
     /// 􂈕
     /// Single Localization, 2 Layersets
@@ -10583,7 +10583,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "sterlingsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var sterlingsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "sterlingsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔁
     /// Single Localization, 2 Layersets
@@ -10591,7 +10591,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignBankBuilding = SFSymbol(rawValue: "sterlingsign.bank.building")
+    static var sterlingsignBankBuilding: SFSymbol { .init(rawValue: "sterlingsign.bank.building") }
 
     /// 􂔂
     /// Single Localization, 3 Layersets
@@ -10600,7 +10600,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sterlingsignBankBuildingFill = SFSymbol(rawValue: "sterlingsign.bank.building.fill")
+    static var sterlingsignBankBuildingFill: SFSymbol { .init(rawValue: "sterlingsign.bank.building.fill") }
 
     /// 􂩞
     /// Single Localization, 2 Layersets
@@ -10608,7 +10608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "sterlingsign.gauge.chart.lefthalf.righthalf")
+    static var sterlingsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "sterlingsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪈
     /// Single Localization, 2 Layersets
@@ -10616,7 +10616,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "sterlingsign.gauge.chart.leftthird.topthird.rightthird")
+    static var sterlingsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "sterlingsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰮
     /// Single Localization, 2 Layersets
@@ -10624,7 +10624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignRing = SFSymbol(rawValue: "sterlingsign.ring")
+    static var sterlingsignRing: SFSymbol { .init(rawValue: "sterlingsign.ring") }
 
     /// 􂰄
     /// Single Localization, 2 Layersets
@@ -10632,42 +10632,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sterlingsignRingDashed = SFSymbol(rawValue: "sterlingsign.ring.dashed")
+    static var sterlingsignRingDashed: SFSymbol { .init(rawValue: "sterlingsign.ring.dashed") }
 
     /// 􂱢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunLefthalfFilled = SFSymbol(rawValue: "sun.lefthalf.filled")
+    static var sunLefthalfFilled: SFSymbol { .init(rawValue: "sun.lefthalf.filled") }
 
     /// 􂱣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sunRighthalfFilled = SFSymbol(rawValue: "sun.righthalf.filled")
+    static var sunRighthalfFilled: SFSymbol { .init(rawValue: "sun.righthalf.filled") }
 
     /// 􂊯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suspensionShock = SFSymbol(rawValue: "suspension.shock")
+    static var suspensionShock: SFSymbol { .init(rawValue: "suspension.shock") }
 
     /// 􂞖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSideFrontOpenCrop = SFSymbol(rawValue: "suv.side.front.open.crop")
+    static var suvSideFrontOpenCrop: SFSymbol { .init(rawValue: "suv.side.front.open.crop") }
 
     /// 􂞗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSideFrontOpenCropFill = SFSymbol(rawValue: "suv.side.front.open.crop.fill")
+    static var suvSideFrontOpenCropFill: SFSymbol { .init(rawValue: "suv.side.front.open.crop.fill") }
 
     /// 􂊨
     /// Single Localization, 2 Layersets
@@ -10675,7 +10675,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillDescentControl = SFSymbol(rawValue: "suv.side.hill.descent.control")
+    static var suvSideHillDescentControl: SFSymbol { .init(rawValue: "suv.side.hill.descent.control") }
 
     /// 􂊩
     /// Single Localization, 2 Layersets
@@ -10683,21 +10683,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideHillDescentControlFill = SFSymbol(rawValue: "suv.side.hill.descent.control.fill")
+    static var suvSideHillDescentControlFill: SFSymbol { .init(rawValue: "suv.side.hill.descent.control.fill") }
 
     /// 􂞘
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSideRearOpenCrop = SFSymbol(rawValue: "suv.side.rear.open.crop")
+    static var suvSideRearOpenCrop: SFSymbol { .init(rawValue: "suv.side.rear.open.crop") }
 
     /// 􂞙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let suvSideRearOpenCropFill = SFSymbol(rawValue: "suv.side.rear.open.crop.fill")
+    static var suvSideRearOpenCropFill: SFSymbol { .init(rawValue: "suv.side.rear.open.crop.fill") }
 
     /// 􂊢
     /// Single Localization, 2 Layersets
@@ -10705,7 +10705,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideRoofCargoCarrier = SFSymbol(rawValue: "suv.side.roof.cargo.carrier")
+    static var suvSideRoofCargoCarrier: SFSymbol { .init(rawValue: "suv.side.roof.cargo.carrier") }
 
     /// 􂊣
     /// Single Localization, 2 Layersets
@@ -10713,7 +10713,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideRoofCargoCarrierFill = SFSymbol(rawValue: "suv.side.roof.cargo.carrier.fill")
+    static var suvSideRoofCargoCarrierFill: SFSymbol { .init(rawValue: "suv.side.roof.cargo.carrier.fill") }
 
     /// 􂙅
     /// Single Localization, 2 Layersets
@@ -10721,7 +10721,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideRoofCargoCarrierSlash = SFSymbol(rawValue: "suv.side.roof.cargo.carrier.slash")
+    static var suvSideRoofCargoCarrierSlash: SFSymbol { .init(rawValue: "suv.side.roof.cargo.carrier.slash") }
 
     /// 􂙇
     /// Single Localization, 2 Layersets
@@ -10729,7 +10729,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideRoofCargoCarrierSlashFill = SFSymbol(rawValue: "suv.side.roof.cargo.carrier.slash.fill")
+    static var suvSideRoofCargoCarrierSlashFill: SFSymbol { .init(rawValue: "suv.side.roof.cargo.carrier.slash.fill") }
 
     /// 􂈶
     /// Single Localization, 2 Layersets
@@ -10737,7 +10737,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "swedishkronasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var swedishkronasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "swedishkronasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂕃
     /// Single Localization, 2 Layersets
@@ -10745,7 +10745,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignBankBuilding = SFSymbol(rawValue: "swedishkronasign.bank.building")
+    static var swedishkronasignBankBuilding: SFSymbol { .init(rawValue: "swedishkronasign.bank.building") }
 
     /// 􂕄
     /// Single Localization, 3 Layersets
@@ -10754,7 +10754,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let swedishkronasignBankBuildingFill = SFSymbol(rawValue: "swedishkronasign.bank.building.fill")
+    static var swedishkronasignBankBuildingFill: SFSymbol { .init(rawValue: "swedishkronasign.bank.building.fill") }
 
     /// 􂩟
     /// Single Localization, 2 Layersets
@@ -10762,7 +10762,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "swedishkronasign.gauge.chart.lefthalf.righthalf")
+    static var swedishkronasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "swedishkronasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪉
     /// Single Localization, 2 Layersets
@@ -10770,7 +10770,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "swedishkronasign.gauge.chart.leftthird.topthird.rightthird")
+    static var swedishkronasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "swedishkronasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰯
     /// Single Localization, 2 Layersets
@@ -10778,7 +10778,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignRing = SFSymbol(rawValue: "swedishkronasign.ring")
+    static var swedishkronasignRing: SFSymbol { .init(rawValue: "swedishkronasign.ring") }
 
     /// 􂰅
     /// Single Localization, 2 Layersets
@@ -10786,7 +10786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let swedishkronasignRingDashed = SFSymbol(rawValue: "swedishkronasign.ring.dashed")
+    static var swedishkronasignRingDashed: SFSymbol { .init(rawValue: "swedishkronasign.ring.dashed") }
 
     /// 􂚚
     /// Single Localization, 2 Layersets
@@ -10794,7 +10794,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tachometer = SFSymbol(rawValue: "tachometer")
+    static var tachometer: SFSymbol { .init(rawValue: "tachometer") }
 
     /// 􂈝
     /// Single Localization, 2 Layersets
@@ -10802,7 +10802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "tengesign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var tengesignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "tengesign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔑
     /// Single Localization, 2 Layersets
@@ -10810,7 +10810,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignBankBuilding = SFSymbol(rawValue: "tengesign.bank.building")
+    static var tengesignBankBuilding: SFSymbol { .init(rawValue: "tengesign.bank.building") }
 
     /// 􂔒
     /// Single Localization, 3 Layersets
@@ -10819,7 +10819,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tengesignBankBuildingFill = SFSymbol(rawValue: "tengesign.bank.building.fill")
+    static var tengesignBankBuildingFill: SFSymbol { .init(rawValue: "tengesign.bank.building.fill") }
 
     /// 􂩠
     /// Single Localization, 2 Layersets
@@ -10827,7 +10827,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "tengesign.gauge.chart.lefthalf.righthalf")
+    static var tengesignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "tengesign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪊
     /// Single Localization, 2 Layersets
@@ -10835,7 +10835,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "tengesign.gauge.chart.leftthird.topthird.rightthird")
+    static var tengesignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "tengesign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰰
     /// Single Localization, 2 Layersets
@@ -10843,7 +10843,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignRing = SFSymbol(rawValue: "tengesign.ring")
+    static var tengesignRing: SFSymbol { .init(rawValue: "tengesign.ring") }
 
     /// 􂰆
     /// Single Localization, 2 Layersets
@@ -10851,7 +10851,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tengesignRingDashed = SFSymbol(rawValue: "tengesign.ring.dashed")
+    static var tengesignRingDashed: SFSymbol { .init(rawValue: "tengesign.ring.dashed") }
 
     /// 􂱤
     /// 2 Localizations, 3 Layersets
@@ -10864,7 +10864,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let textBubbleBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "text.bubble.badge.clock")
+    static var textBubbleBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "text.bubble.badge.clock") }
 
     /// 􂱥
     /// 2 Localizations, 3 Layersets
@@ -10877,7 +10877,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let textBubbleBadgeClockFill = SymbolWith1Localization<Rtl>(rawValue: "text.bubble.badge.clock.fill")
+    static var textBubbleBadgeClockFill: SymbolWith1Localization<Rtl> { .init(rawValue: "text.bubble.badge.clock.fill") }
 
     /// 􀈿
     /// Single Localization, 2 Layersets
@@ -10885,7 +10885,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let textDocument = SFSymbol(rawValue: "text.document")
+    static var textDocument: SFSymbol { .init(rawValue: "text.document") }
 
     /// 􀉀
     /// Single Localization, 2 Layersets
@@ -10893,7 +10893,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let textDocumentFill = SFSymbol(rawValue: "text.document.fill")
+    static var textDocumentFill: SFSymbol { .init(rawValue: "text.document.fill") }
 
     /// 􂬁
     /// Single Localization, 2 Layersets
@@ -10901,14 +10901,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textLineMagnify = SFSymbol(rawValue: "text.line.magnify")
+    static var textLineMagnify: SFSymbol { .init(rawValue: "text.line.magnify") }
 
     /// 􀉆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textPage = SFSymbol(rawValue: "text.page")
+    static var textPage: SFSymbol { .init(rawValue: "text.page") }
 
     /// 􀕹
     /// Single Localization, 2 Layersets
@@ -10916,7 +10916,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textPageBadgeMagnifyingglass = SFSymbol(rawValue: "text.page.badge.magnifyingglass")
+    static var textPageBadgeMagnifyingglass: SFSymbol { .init(rawValue: "text.page.badge.magnifyingglass") }
 
     /// 􀥨
     /// Single Localization, 3 Layersets
@@ -10925,7 +10925,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let textPageFill = SFSymbol(rawValue: "text.page.fill")
+    static var textPageFill: SFSymbol { .init(rawValue: "text.page.fill") }
 
     /// 􂱑
     /// 2 Localizations, 2 Layersets
@@ -10937,7 +10937,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textPageSlash = SymbolWith1Localization<Rtl>(rawValue: "text.page.slash")
+    static var textPageSlash: SymbolWith1Localization<Rtl> { .init(rawValue: "text.page.slash") }
 
     /// 􂱒
     /// 2 Localizations, 2 Layersets
@@ -10949,14 +10949,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textPageSlashFill = SymbolWith1Localization<Rtl>(rawValue: "text.page.slash.fill")
+    static var textPageSlashFill: SymbolWith1Localization<Rtl> { .init(rawValue: "text.page.slash.fill") }
 
     /// 􀩽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textRectanglePage = SFSymbol(rawValue: "text.rectangle.page")
+    static var textRectanglePage: SFSymbol { .init(rawValue: "text.rectangle.page") }
 
     /// 􀩾
     /// Single Localization, 2 Layersets
@@ -10964,7 +10964,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let textRectanglePageFill = SFSymbol(rawValue: "text.rectangle.page.fill")
+    static var textRectanglePageFill: SFSymbol { .init(rawValue: "text.rectangle.page.fill") }
 
     /// 􀅯
     /// 22 Localizations, Single Layerset
@@ -10995,7 +10995,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatCharacters = SymbolWith21Localizations<Ar, Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh>(rawValue: "textformat.characters")
+    static var textformatCharacters: SymbolWith21Localizations<Ar, Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh> { .init(rawValue: "textformat.characters") }
 
     /// 􂐭
     /// 21 Localizations, 2 Layersets
@@ -11026,7 +11026,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textformatCharactersArrowLeftAndRight = SymbolWith20Localizations<Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh>(rawValue: "textformat.characters.arrow.left.and.right")
+    static var textformatCharactersArrowLeftAndRight: SymbolWith20Localizations<Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh> { .init(rawValue: "textformat.characters.arrow.left.and.right") }
 
     /// 􀅰
     /// 22 Localizations, 3 Layersets
@@ -11059,7 +11059,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let textformatCharactersDottedunderline = SymbolWith21Localizations<Ar, Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh>(rawValue: "textformat.characters.dottedunderline")
+    static var textformatCharactersDottedunderline: SymbolWith21Localizations<Ar, Bn_v6_3, El, Gu_v6_3, He, Hi, Ja, Kn_v6_3, Ko, Ml_v6_3, Mni_v6_3, Mr_v6_3, Or_v6_3, Pa_v6_3, Ru, Sat_v6_3, Si_v6_3, Ta_v6_3, Te_v6_3, Th, Zh> { .init(rawValue: "textformat.characters.dottedunderline") }
 
     /// 􁖻
     /// 15 Localizations, Single Layerset
@@ -11083,7 +11083,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let textformatNumbers = SymbolWith14Localizations<Ar, Bn, Gu, Hi, Km, Kn, Ml, Mni, Mr_v7, My, Or, Pa, Sat, Te>(rawValue: "textformat.numbers")
+    static var textformatNumbers: SymbolWith14Localizations<Ar, Bn, Gu, Hi, Km, Kn, Ml, Mni, Mr_v7, My, Or, Pa, Sat, Te> { .init(rawValue: "textformat.numbers") }
 
     /// 􂘔
     /// Single Localization, 2 Layersets
@@ -11091,7 +11091,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerAndLiquidWavesSnowflake = SFSymbol(rawValue: "thermometer.and.liquid.waves.snowflake")
+    static var thermometerAndLiquidWavesSnowflake: SFSymbol { .init(rawValue: "thermometer.and.liquid.waves.snowflake") }
 
     /// 􂘖
     /// Single Localization, 3 Layersets
@@ -11100,7 +11100,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerAndLiquidWavesTrianglebadgeExclamationmark = SFSymbol(rawValue: "thermometer.and.liquid.waves.trianglebadge.exclamationmark")
+    static var thermometerAndLiquidWavesTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "thermometer.and.liquid.waves.trianglebadge.exclamationmark") }
 
     /// 􂬮
     /// Single Localization, 3 Layersets
@@ -11109,14 +11109,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerVariable = SFSymbol(rawValue: "thermometer.variable")
+    static var thermometerVariable: SFSymbol { .init(rawValue: "thermometer.variable") }
 
     /// 􂥰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tire = SFSymbol(rawValue: "tire")
+    static var tire: SFSymbol { .init(rawValue: "tire") }
 
     /// 􂥱
     /// Single Localization, 2 Layersets
@@ -11124,14 +11124,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tireBadgeSnowflake = SFSymbol(rawValue: "tire.badge.snowflake")
+    static var tireBadgeSnowflake: SFSymbol { .init(rawValue: "tire.badge.snowflake") }
 
     /// 􂊛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let towHitch = SFSymbol(rawValue: "tow.hitch")
+    static var towHitch: SFSymbol { .init(rawValue: "tow.hitch") }
 
     /// 􂊝
     /// Single Localization, 2 Layersets
@@ -11139,7 +11139,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let towHitchExclamationmark = SFSymbol(rawValue: "tow.hitch.exclamationmark")
+    static var towHitchExclamationmark: SFSymbol { .init(rawValue: "tow.hitch.exclamationmark") }
 
     /// 􂊞
     /// Single Localization, 2 Layersets
@@ -11147,28 +11147,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let towHitchExclamationmarkFill = SFSymbol(rawValue: "tow.hitch.exclamationmark.fill")
+    static var towHitchExclamationmarkFill: SFSymbol { .init(rawValue: "tow.hitch.exclamationmark.fill") }
 
     /// 􂊜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let towHitchFill = SFSymbol(rawValue: "tow.hitch.fill")
+    static var towHitchFill: SFSymbol { .init(rawValue: "tow.hitch.fill") }
 
     /// 􂞚
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckPickupSideFrontOpenCrop = SFSymbol(rawValue: "truck.pickup.side.front.open.crop")
+    static var truckPickupSideFrontOpenCrop: SFSymbol { .init(rawValue: "truck.pickup.side.front.open.crop") }
 
     /// 􂞛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let truckPickupSideFrontOpenCropFill = SFSymbol(rawValue: "truck.pickup.side.front.open.crop.fill")
+    static var truckPickupSideFrontOpenCropFill: SFSymbol { .init(rawValue: "truck.pickup.side.front.open.crop.fill") }
 
     /// 􂊪
     /// Single Localization, 2 Layersets
@@ -11176,7 +11176,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideHillDescentControl = SFSymbol(rawValue: "truck.side.hill.descent.control")
+    static var truckSideHillDescentControl: SFSymbol { .init(rawValue: "truck.side.hill.descent.control") }
 
     /// 􂊫
     /// Single Localization, 2 Layersets
@@ -11184,7 +11184,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideHillDescentControlFill = SFSymbol(rawValue: "truck.side.hill.descent.control.fill")
+    static var truckSideHillDescentControlFill: SFSymbol { .init(rawValue: "truck.side.hill.descent.control.fill") }
 
     /// 􂊤
     /// Single Localization, 2 Layersets
@@ -11192,7 +11192,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideRoofCargoCarrier = SFSymbol(rawValue: "truck.side.roof.cargo.carrier")
+    static var truckSideRoofCargoCarrier: SFSymbol { .init(rawValue: "truck.side.roof.cargo.carrier") }
 
     /// 􂊥
     /// Single Localization, 2 Layersets
@@ -11200,7 +11200,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideRoofCargoCarrierFill = SFSymbol(rawValue: "truck.side.roof.cargo.carrier.fill")
+    static var truckSideRoofCargoCarrierFill: SFSymbol { .init(rawValue: "truck.side.roof.cargo.carrier.fill") }
 
     /// 􂙉
     /// Single Localization, 2 Layersets
@@ -11208,7 +11208,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideRoofCargoCarrierSlash = SFSymbol(rawValue: "truck.side.roof.cargo.carrier.slash")
+    static var truckSideRoofCargoCarrierSlash: SFSymbol { .init(rawValue: "truck.side.roof.cargo.carrier.slash") }
 
     /// 􂙊
     /// Single Localization, 2 Layersets
@@ -11216,14 +11216,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckSideRoofCargoCarrierSlashFill = SFSymbol(rawValue: "truck.side.roof.cargo.carrier.slash.fill")
+    static var truckSideRoofCargoCarrierSlashFill: SFSymbol { .init(rawValue: "truck.side.roof.cargo.carrier.slash.fill") }
 
     /// 􂮑
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let tsa = SFSymbol(rawValue: "tsa")
+    static var tsa: SFSymbol { .init(rawValue: "tsa") }
 
     /// 􂮟
     /// Single Localization, 2 Layersets
@@ -11231,7 +11231,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tsaCircle = SFSymbol(rawValue: "tsa.circle")
+    static var tsaCircle: SFSymbol { .init(rawValue: "tsa.circle") }
 
     /// 􂮠
     /// Single Localization, 3 Layersets
@@ -11240,7 +11240,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tsaCircleFill = SFSymbol(rawValue: "tsa.circle.fill")
+    static var tsaCircleFill: SFSymbol { .init(rawValue: "tsa.circle.fill") }
 
     /// 􂮒
     /// Single Localization, 2 Layersets
@@ -11248,7 +11248,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tsaSlash = SFSymbol(rawValue: "tsa.slash")
+    static var tsaSlash: SFSymbol { .init(rawValue: "tsa.slash") }
 
     /// 􂈪
     /// Single Localization, 2 Layersets
@@ -11256,7 +11256,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "tugriksign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var tugriksignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "tugriksign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔫
     /// Single Localization, 2 Layersets
@@ -11264,7 +11264,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignBankBuilding = SFSymbol(rawValue: "tugriksign.bank.building")
+    static var tugriksignBankBuilding: SFSymbol { .init(rawValue: "tugriksign.bank.building") }
 
     /// 􂔬
     /// Single Localization, 3 Layersets
@@ -11273,7 +11273,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tugriksignBankBuildingFill = SFSymbol(rawValue: "tugriksign.bank.building.fill")
+    static var tugriksignBankBuildingFill: SFSymbol { .init(rawValue: "tugriksign.bank.building.fill") }
 
     /// 􂩡
     /// Single Localization, 2 Layersets
@@ -11281,7 +11281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "tugriksign.gauge.chart.lefthalf.righthalf")
+    static var tugriksignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "tugriksign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪋
     /// Single Localization, 2 Layersets
@@ -11289,7 +11289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "tugriksign.gauge.chart.leftthird.topthird.rightthird")
+    static var tugriksignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "tugriksign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰱
     /// Single Localization, 2 Layersets
@@ -11297,7 +11297,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignRing = SFSymbol(rawValue: "tugriksign.ring")
+    static var tugriksignRing: SFSymbol { .init(rawValue: "tugriksign.ring") }
 
     /// 􂰇
     /// Single Localization, 2 Layersets
@@ -11305,7 +11305,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tugriksignRingDashed = SFSymbol(rawValue: "tugriksign.ring.dashed")
+    static var tugriksignRingDashed: SFSymbol { .init(rawValue: "tugriksign.ring.dashed") }
 
     /// 􂈘
     /// Single Localization, 2 Layersets
@@ -11313,7 +11313,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "turkishlirasign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var turkishlirasignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "turkishlirasign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔇
     /// Single Localization, 2 Layersets
@@ -11321,7 +11321,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignBankBuilding = SFSymbol(rawValue: "turkishlirasign.bank.building")
+    static var turkishlirasignBankBuilding: SFSymbol { .init(rawValue: "turkishlirasign.bank.building") }
 
     /// 􂔈
     /// Single Localization, 3 Layersets
@@ -11330,7 +11330,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let turkishlirasignBankBuildingFill = SFSymbol(rawValue: "turkishlirasign.bank.building.fill")
+    static var turkishlirasignBankBuildingFill: SFSymbol { .init(rawValue: "turkishlirasign.bank.building.fill") }
 
     /// 􂩢
     /// Single Localization, 2 Layersets
@@ -11338,7 +11338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "turkishlirasign.gauge.chart.lefthalf.righthalf")
+    static var turkishlirasignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "turkishlirasign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪌
     /// Single Localization, 2 Layersets
@@ -11346,7 +11346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "turkishlirasign.gauge.chart.leftthird.topthird.rightthird")
+    static var turkishlirasignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "turkishlirasign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰲
     /// Single Localization, 2 Layersets
@@ -11354,7 +11354,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignRing = SFSymbol(rawValue: "turkishlirasign.ring")
+    static var turkishlirasignRing: SFSymbol { .init(rawValue: "turkishlirasign.ring") }
 
     /// 􂰈
     /// Single Localization, 2 Layersets
@@ -11362,7 +11362,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let turkishlirasignRingDashed = SFSymbol(rawValue: "turkishlirasign.ring.dashed")
+    static var turkishlirasignRingDashed: SFSymbol { .init(rawValue: "turkishlirasign.ring.dashed") }
 
     /// 􁎖
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11372,7 +11372,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionPro = SFSymbol(rawValue: "vision.pro")
+    static var visionPro: SFSymbol { .init(rawValue: "vision.pro") }
 
     /// 􁳔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11382,7 +11382,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProAndArrowForward = SFSymbol(rawValue: "vision.pro.and.arrow.forward")
+    static var visionProAndArrowForward: SFSymbol { .init(rawValue: "vision.pro.and.arrow.forward") }
 
     /// 􁳕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11392,7 +11392,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProAndArrowForwardFill = SFSymbol(rawValue: "vision.pro.and.arrow.forward.fill")
+    static var visionProAndArrowForwardFill: SFSymbol { .init(rawValue: "vision.pro.and.arrow.forward.fill") }
 
     /// 􁷇
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11403,7 +11403,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgeExclamationmark = SFSymbol(rawValue: "vision.pro.badge.exclamationmark")
+    static var visionProBadgeExclamationmark: SFSymbol { .init(rawValue: "vision.pro.badge.exclamationmark") }
 
     /// 􁷈
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11414,7 +11414,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgeExclamationmarkFill = SFSymbol(rawValue: "vision.pro.badge.exclamationmark.fill")
+    static var visionProBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "vision.pro.badge.exclamationmark.fill") }
 
     /// 􁼿
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11425,7 +11425,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgePlay = SFSymbol(rawValue: "vision.pro.badge.play")
+    static var visionProBadgePlay: SFSymbol { .init(rawValue: "vision.pro.badge.play") }
 
     /// 􁽀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11436,7 +11436,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgePlayFill = SFSymbol(rawValue: "vision.pro.badge.play.fill")
+    static var visionProBadgePlayFill: SFSymbol { .init(rawValue: "vision.pro.badge.play.fill") }
 
     /// 􂅿
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11446,7 +11446,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProCircle = SFSymbol(rawValue: "vision.pro.circle")
+    static var visionProCircle: SFSymbol { .init(rawValue: "vision.pro.circle") }
 
     /// 􂆀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11457,7 +11457,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProCircleFill = SFSymbol(rawValue: "vision.pro.circle.fill")
+    static var visionProCircleFill: SFSymbol { .init(rawValue: "vision.pro.circle.fill") }
 
     /// 􁎘
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -11466,7 +11466,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProFill = SFSymbol(rawValue: "vision.pro.fill")
+    static var visionProFill: SFSymbol { .init(rawValue: "vision.pro.fill") }
 
     /// 􁽃
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11476,7 +11476,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProSlash = SFSymbol(rawValue: "vision.pro.slash")
+    static var visionProSlash: SFSymbol { .init(rawValue: "vision.pro.slash") }
 
     /// 􂆞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11486,7 +11486,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProSlashCircle = SFSymbol(rawValue: "vision.pro.slash.circle")
+    static var visionProSlashCircle: SFSymbol { .init(rawValue: "vision.pro.slash.circle") }
 
     /// 􂆟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11497,7 +11497,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProSlashCircleFill = SFSymbol(rawValue: "vision.pro.slash.circle.fill")
+    static var visionProSlashCircleFill: SFSymbol { .init(rawValue: "vision.pro.slash.circle.fill") }
 
     /// 􁽄
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -11507,7 +11507,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProSlashFill = SFSymbol(rawValue: "vision.pro.slash.fill")
+    static var visionProSlashFill: SFSymbol { .init(rawValue: "vision.pro.slash.fill") }
 
     /// 􂓮
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11518,7 +11518,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProTrianglebadgeExclamationmark = SFSymbol(rawValue: "vision.pro.trianglebadge.exclamationmark")
+    static var visionProTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "vision.pro.trianglebadge.exclamationmark") }
 
     /// 􂓯
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -11529,21 +11529,21 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "vision.pro.trianglebadge.exclamationmark.fill")
+    static var visionProTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "vision.pro.trianglebadge.exclamationmark.fill") }
 
     /// 􂏰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let walletBifold = SFSymbol(rawValue: "wallet.bifold")
+    static var walletBifold: SFSymbol { .init(rawValue: "wallet.bifold") }
 
     /// 􂏱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let walletBifoldFill = SFSymbol(rawValue: "wallet.bifold.fill")
+    static var walletBifoldFill: SFSymbol { .init(rawValue: "wallet.bifold.fill") }
 
     /// 􀜍
     /// Single Localization, 2 Layersets
@@ -11551,7 +11551,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wandAndSparkles = SFSymbol(rawValue: "wand.and.sparkles")
+    static var wandAndSparkles: SFSymbol { .init(rawValue: "wand.and.sparkles") }
 
     /// 􀜎
     /// Single Localization, 2 Layersets
@@ -11559,7 +11559,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wandAndSparklesInverse = SFSymbol(rawValue: "wand.and.sparkles.inverse")
+    static var wandAndSparklesInverse: SFSymbol { .init(rawValue: "wand.and.sparkles.inverse") }
 
     /// 􁎆
     /// Single Localization, 3 Layersets
@@ -11568,7 +11568,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waterWavesAndArrowTriangleheadDown = SFSymbol(rawValue: "water.waves.and.arrow.trianglehead.down")
+    static var waterWavesAndArrowTriangleheadDown: SFSymbol { .init(rawValue: "water.waves.and.arrow.trianglehead.down") }
 
     /// 􁜰
     /// Single Localization, 3 Layersets
@@ -11577,7 +11577,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waterWavesAndArrowTriangleheadDownTrianglebadgeExclamationmark = SFSymbol(rawValue: "water.waves.and.arrow.trianglehead.down.trianglebadge.exclamationmark")
+    static var waterWavesAndArrowTriangleheadDownTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "water.waves.and.arrow.trianglehead.down.trianglebadge.exclamationmark") }
 
     /// 􁎅
     /// Single Localization, 3 Layersets
@@ -11586,14 +11586,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waterWavesAndArrowTriangleheadUp = SFSymbol(rawValue: "water.waves.and.arrow.trianglehead.up")
+    static var waterWavesAndArrowTriangleheadUp: SFSymbol { .init(rawValue: "water.waves.and.arrow.trianglehead.up") }
 
     /// 􂙪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wave3Down = SFSymbol(rawValue: "wave.3.down")
+    static var wave3Down: SFSymbol { .init(rawValue: "wave.3.down") }
 
     /// 􂨀
     /// Single Localization, 2 Layersets
@@ -11601,7 +11601,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3DownCarSide = SFSymbol(rawValue: "wave.3.down.car.side")
+    static var wave3DownCarSide: SFSymbol { .init(rawValue: "wave.3.down.car.side") }
 
     /// 􂨁
     /// Single Localization, 3 Layersets
@@ -11610,7 +11610,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3DownCarSideFill = SFSymbol(rawValue: "wave.3.down.car.side.fill")
+    static var wave3DownCarSideFill: SFSymbol { .init(rawValue: "wave.3.down.car.side.fill") }
 
     /// 􂙫
     /// Single Localization, 2 Layersets
@@ -11618,7 +11618,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3DownCircle = SFSymbol(rawValue: "wave.3.down.circle")
+    static var wave3DownCircle: SFSymbol { .init(rawValue: "wave.3.down.circle") }
 
     /// 􂙬
     /// Single Localization, 3 Layersets
@@ -11627,7 +11627,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3DownCircleFill = SFSymbol(rawValue: "wave.3.down.circle.fill")
+    static var wave3DownCircleFill: SFSymbol { .init(rawValue: "wave.3.down.circle.fill") }
 
     /// 􂨆
     /// Single Localization, 2 Layersets
@@ -11635,7 +11635,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3DownConvertibleSide = SFSymbol(rawValue: "wave.3.down.convertible.side")
+    static var wave3DownConvertibleSide: SFSymbol { .init(rawValue: "wave.3.down.convertible.side") }
 
     /// 􂨇
     /// Single Localization, 3 Layersets
@@ -11644,7 +11644,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3DownConvertibleSideFill = SFSymbol(rawValue: "wave.3.down.convertible.side.fill")
+    static var wave3DownConvertibleSideFill: SFSymbol { .init(rawValue: "wave.3.down.convertible.side.fill") }
 
     /// 􂨄
     /// Single Localization, 2 Layersets
@@ -11652,7 +11652,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3DownPickupSide = SFSymbol(rawValue: "wave.3.down.pickup.side")
+    static var wave3DownPickupSide: SFSymbol { .init(rawValue: "wave.3.down.pickup.side") }
 
     /// 􂨅
     /// Single Localization, 3 Layersets
@@ -11661,7 +11661,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3DownPickupSideFill = SFSymbol(rawValue: "wave.3.down.pickup.side.fill")
+    static var wave3DownPickupSideFill: SFSymbol { .init(rawValue: "wave.3.down.pickup.side.fill") }
 
     /// 􂨂
     /// Single Localization, 2 Layersets
@@ -11669,7 +11669,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3DownSuvSide = SFSymbol(rawValue: "wave.3.down.suv.side")
+    static var wave3DownSuvSide: SFSymbol { .init(rawValue: "wave.3.down.suv.side") }
 
     /// 􂨃
     /// Single Localization, 3 Layersets
@@ -11678,14 +11678,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3DownSuvSideFill = SFSymbol(rawValue: "wave.3.down.suv.side.fill")
+    static var wave3DownSuvSideFill: SFSymbol { .init(rawValue: "wave.3.down.suv.side.fill") }
 
     /// 􂙧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wave3Up = SFSymbol(rawValue: "wave.3.up")
+    static var wave3Up: SFSymbol { .init(rawValue: "wave.3.up") }
 
     /// 􂙨
     /// Single Localization, 2 Layersets
@@ -11693,7 +11693,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wave3UpCircle = SFSymbol(rawValue: "wave.3.up.circle")
+    static var wave3UpCircle: SFSymbol { .init(rawValue: "wave.3.up.circle") }
 
     /// 􂙩
     /// Single Localization, 3 Layersets
@@ -11702,7 +11702,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wave3UpCircleFill = SFSymbol(rawValue: "wave.3.up.circle.fill")
+    static var wave3UpCircleFill: SFSymbol { .init(rawValue: "wave.3.up.circle.fill") }
 
     /// 􁃨
     /// Single Localization, 3 Layersets
@@ -11711,14 +11711,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeMicrophone = SFSymbol(rawValue: "waveform.badge.microphone")
+    static var waveformBadgeMicrophone: SFSymbol { .init(rawValue: "waveform.badge.microphone") }
 
     /// 􂏥
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let wheelchair = SFSymbol(rawValue: "wheelchair")
+    static var wheelchair: SFSymbol { .init(rawValue: "wheelchair") }
 
     /// 􂈒
     /// Single Localization, 2 Layersets
@@ -11726,7 +11726,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let widgetExtralarge = SFSymbol(rawValue: "widget.extralarge")
+    static var widgetExtralarge: SFSymbol { .init(rawValue: "widget.extralarge") }
 
     /// 􂟴
     /// Single Localization, 3 Layersets
@@ -11735,7 +11735,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let widgetExtralargeBadgePlus = SFSymbol(rawValue: "widget.extralarge.badge.plus")
+    static var widgetExtralargeBadgePlus: SFSymbol { .init(rawValue: "widget.extralarge.badge.plus") }
 
     /// 􂘮
     /// Single Localization, 2 Layersets
@@ -11743,7 +11743,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let widgetLarge = SFSymbol(rawValue: "widget.large")
+    static var widgetLarge: SFSymbol { .init(rawValue: "widget.large") }
 
     /// 􂟲
     /// Single Localization, 3 Layersets
@@ -11752,7 +11752,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let widgetLargeBadgePlus = SFSymbol(rawValue: "widget.large.badge.plus")
+    static var widgetLargeBadgePlus: SFSymbol { .init(rawValue: "widget.large.badge.plus") }
 
     /// 􂘭
     /// Single Localization, 2 Layersets
@@ -11760,7 +11760,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let widgetMedium = SFSymbol(rawValue: "widget.medium")
+    static var widgetMedium: SFSymbol { .init(rawValue: "widget.medium") }
 
     /// 􂟰
     /// Single Localization, 3 Layersets
@@ -11769,7 +11769,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let widgetMediumBadgePlus = SFSymbol(rawValue: "widget.medium.badge.plus")
+    static var widgetMediumBadgePlus: SFSymbol { .init(rawValue: "widget.medium.badge.plus") }
 
     /// 􂘬
     /// Single Localization, 2 Layersets
@@ -11777,7 +11777,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let widgetSmall = SFSymbol(rawValue: "widget.small")
+    static var widgetSmall: SFSymbol { .init(rawValue: "widget.small") }
 
     /// 􂟮
     /// Single Localization, 3 Layersets
@@ -11786,7 +11786,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let widgetSmallBadgePlus = SFSymbol(rawValue: "widget.small.badge.plus")
+    static var widgetSmallBadgePlus: SFSymbol { .init(rawValue: "widget.small.badge.plus") }
 
     /// 􂈡
     /// Single Localization, 2 Layersets
@@ -11794,7 +11794,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "wonsign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var wonsignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "wonsign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂔙
     /// Single Localization, 2 Layersets
@@ -11802,7 +11802,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignBankBuilding = SFSymbol(rawValue: "wonsign.bank.building")
+    static var wonsignBankBuilding: SFSymbol { .init(rawValue: "wonsign.bank.building") }
 
     /// 􂔚
     /// Single Localization, 3 Layersets
@@ -11811,7 +11811,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let wonsignBankBuildingFill = SFSymbol(rawValue: "wonsign.bank.building.fill")
+    static var wonsignBankBuildingFill: SFSymbol { .init(rawValue: "wonsign.bank.building.fill") }
 
     /// 􂩤
     /// Single Localization, 2 Layersets
@@ -11819,7 +11819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "wonsign.gauge.chart.lefthalf.righthalf")
+    static var wonsignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "wonsign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪎
     /// Single Localization, 2 Layersets
@@ -11827,7 +11827,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "wonsign.gauge.chart.leftthird.topthird.rightthird")
+    static var wonsignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "wonsign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰴
     /// Single Localization, 2 Layersets
@@ -11835,7 +11835,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignRing = SFSymbol(rawValue: "wonsign.ring")
+    static var wonsignRing: SFSymbol { .init(rawValue: "wonsign.ring") }
 
     /// 􂰊
     /// Single Localization, 2 Layersets
@@ -11843,21 +11843,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wonsignRingDashed = SFSymbol(rawValue: "wonsign.ring.dashed")
+    static var wonsignRingDashed: SFSymbol { .init(rawValue: "wonsign.ring.dashed") }
 
     /// 􂮰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let xmarkTriangleCircleSquare = SFSymbol(rawValue: "xmark.triangle.circle.square")
+    static var xmarkTriangleCircleSquare: SFSymbol { .init(rawValue: "xmark.triangle.circle.square") }
 
     /// 􂮱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let xmarkTriangleCircleSquareFill = SFSymbol(rawValue: "xmark.triangle.circle.square.fill")
+    static var xmarkTriangleCircleSquareFill: SFSymbol { .init(rawValue: "xmark.triangle.circle.square.fill") }
 
     /// 􂈔
     /// Single Localization, 2 Layersets
@@ -11865,7 +11865,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(rawValue: "yensign.arrow.trianglehead.counterclockwise.rotate.90")
+    static var yensignArrowTriangleheadCounterclockwiseRotate90: SFSymbol { .init(rawValue: "yensign.arrow.trianglehead.counterclockwise.rotate.90") }
 
     /// 􂓿
     /// Single Localization, 2 Layersets
@@ -11873,7 +11873,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignBankBuilding = SFSymbol(rawValue: "yensign.bank.building")
+    static var yensignBankBuilding: SFSymbol { .init(rawValue: "yensign.bank.building") }
 
     /// 􂔀
     /// Single Localization, 3 Layersets
@@ -11882,7 +11882,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let yensignBankBuildingFill = SFSymbol(rawValue: "yensign.bank.building.fill")
+    static var yensignBankBuildingFill: SFSymbol { .init(rawValue: "yensign.bank.building.fill") }
 
     /// 􂩣
     /// Single Localization, 2 Layersets
@@ -11890,7 +11890,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignGaugeChartLefthalfRighthalf = SFSymbol(rawValue: "yensign.gauge.chart.lefthalf.righthalf")
+    static var yensignGaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "yensign.gauge.chart.lefthalf.righthalf") }
 
     /// 􂪍
     /// Single Localization, 2 Layersets
@@ -11898,7 +11898,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignGaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "yensign.gauge.chart.leftthird.topthird.rightthird")
+    static var yensignGaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "yensign.gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􂰳
     /// Single Localization, 2 Layersets
@@ -11906,7 +11906,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignRing = SFSymbol(rawValue: "yensign.ring")
+    static var yensignRing: SFSymbol { .init(rawValue: "yensign.ring") }
 
     /// 􂰉
     /// Single Localization, 2 Layersets
@@ -11914,12 +11914,12 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let yensignRingDashed = SFSymbol(rawValue: "yensign.ring.dashed")
+    static var yensignRingDashed: SFSymbol { .init(rawValue: "yensign.ring.dashed") }
 
     /// 􀤧
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let zipperPage = SFSymbol(rawValue: "zipper.page")
+    static var zipperPage: SFSymbol { .init(rawValue: "zipper.page") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+6.1.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+6.1.swift
@@ -9,7 +9,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let boltHouse = SFSymbol(rawValue: "bolt.house")
+    static var boltHouse: SFSymbol { .init(rawValue: "bolt.house") }
 
     /// 􂶡
     /// Single Localization, 3 Layersets
@@ -18,7 +18,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let boltHouseFill = SFSymbol(rawValue: "bolt.house.fill")
+    static var boltHouseFill: SFSymbol { .init(rawValue: "bolt.house.fill") }
 
     /// 􂷔
     /// Single Localization, 2 Layersets
@@ -26,7 +26,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let cableConnectorVideo = SFSymbol(rawValue: "cable.connector.video")
+    static var cableConnectorVideo: SFSymbol { .init(rawValue: "cable.connector.video") }
 
     /// 􂴾
     /// Single Localization, 2 Layersets
@@ -34,7 +34,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowaves2FrontLeftFrontFrontRight = SFSymbol(rawValue: "car.top.radiowaves.2.front.left.front.front.right")
+    static var carTopRadiowaves2FrontLeftFrontFrontRight: SFSymbol { .init(rawValue: "car.top.radiowaves.2.front.left.front.front.right") }
 
     /// 􂴿
     /// Single Localization, 2 Layersets
@@ -42,7 +42,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowaves2FrontLeftFrontFrontRightFill = SFSymbol(rawValue: "car.top.radiowaves.2.front.left.front.front.right.fill")
+    static var carTopRadiowaves2FrontLeftFrontFrontRightFill: SFSymbol { .init(rawValue: "car.top.radiowaves.2.front.left.front.front.right.fill") }
 
     /// 􂵂
     /// Single Localization, 2 Layersets
@@ -50,7 +50,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowaves2RearLeftRearRearRight = SFSymbol(rawValue: "car.top.radiowaves.2.rear.left.rear.rear.right")
+    static var carTopRadiowaves2RearLeftRearRearRight: SFSymbol { .init(rawValue: "car.top.radiowaves.2.rear.left.rear.rear.right") }
 
     /// 􂵃
     /// Single Localization, 2 Layersets
@@ -58,7 +58,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopRadiowaves2RearLeftRearRearRightFill = SFSymbol(rawValue: "car.top.radiowaves.2.rear.left.rear.rear.right.fill")
+    static var carTopRadiowaves2RearLeftRearRearRightFill: SFSymbol { .init(rawValue: "car.top.radiowaves.2.rear.left.rear.rear.right.fill") }
 
     /// 􂵆
     /// Single Localization, 2 Layersets
@@ -66,7 +66,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCarTopRadiowaves2RearLeftRearRearRight = SFSymbol(rawValue: "dot.car.top.radiowaves.2.rear.left.rear.rear.right")
+    static var dotCarTopRadiowaves2RearLeftRearRearRight: SFSymbol { .init(rawValue: "dot.car.top.radiowaves.2.rear.left.rear.rear.right") }
 
     /// 􂵇
     /// Single Localization, 2 Layersets
@@ -74,21 +74,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCarTopRadiowaves2RearLeftRearRearRightFill = SFSymbol(rawValue: "dot.car.top.radiowaves.2.rear.left.rear.rear.right.fill")
+    static var dotCarTopRadiowaves2RearLeftRearRearRightFill: SFSymbol { .init(rawValue: "dot.car.top.radiowaves.2.rear.left.rear.rear.right.fill") }
 
     /// 􀛫
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeStack = SFSymbol(rawValue: "envelope.stack")
+    static var envelopeStack: SFSymbol { .init(rawValue: "envelope.stack") }
 
     /// 􀛬
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let envelopeStackFill = SFSymbol(rawValue: "envelope.stack.fill")
+    static var envelopeStackFill: SFSymbol { .init(rawValue: "envelope.stack.fill") }
 
     /// 􂷩
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -98,7 +98,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let exclamationmarkMessage = SFSymbol(rawValue: "exclamationmark.message")
+    static var exclamationmarkMessage: SFSymbol { .init(rawValue: "exclamationmark.message") }
 
     /// 􂷪
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -109,7 +109,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let exclamationmarkMessageFill = SFSymbol(rawValue: "exclamationmark.message.fill")
+    static var exclamationmarkMessageFill: SFSymbol { .init(rawValue: "exclamationmark.message.fill") }
 
     /// 􂶩
     /// Single Localization, 2 Layersets
@@ -117,7 +117,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsdownSlash = SFSymbol(rawValue: "hand.thumbsdown.slash")
+    static var handThumbsdownSlash: SFSymbol { .init(rawValue: "hand.thumbsdown.slash") }
 
     /// 􂶪
     /// Single Localization, 2 Layersets
@@ -125,7 +125,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsdownSlashFill = SFSymbol(rawValue: "hand.thumbsdown.slash.fill")
+    static var handThumbsdownSlashFill: SFSymbol { .init(rawValue: "hand.thumbsdown.slash.fill") }
 
     /// 􂶥
     /// Single Localization, 2 Layersets
@@ -133,7 +133,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsupSlash = SFSymbol(rawValue: "hand.thumbsup.slash")
+    static var handThumbsupSlash: SFSymbol { .init(rawValue: "hand.thumbsup.slash") }
 
     /// 􂶦
     /// Single Localization, 2 Layersets
@@ -141,14 +141,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handThumbsupSlashFill = SFSymbol(rawValue: "hand.thumbsup.slash.fill")
+    static var handThumbsupSlashFill: SFSymbol { .init(rawValue: "hand.thumbsup.slash.fill") }
 
     /// 􂶟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let laurelLeadingLaurelTrailing = SFSymbol(rawValue: "laurel.leading.laurel.trailing")
+    static var laurelLeadingLaurelTrailing: SFSymbol { .init(rawValue: "laurel.leading.laurel.trailing") }
 
     /// 􂷃
     /// Single Localization, 3 Layersets
@@ -157,7 +157,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let memoriesBadgeCheckmark = SFSymbol(rawValue: "memories.badge.checkmark")
+    static var memoriesBadgeCheckmark: SFSymbol { .init(rawValue: "memories.badge.checkmark") }
 
     /// 􂷁
     /// Single Localization, 3 Layersets
@@ -166,7 +166,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let memoriesBadgeXmark = SFSymbol(rawValue: "memories.badge.xmark")
+    static var memoriesBadgeXmark: SFSymbol { .init(rawValue: "memories.badge.xmark") }
 
     /// 􂷐
     /// Single Localization, 2 Layersets
@@ -174,7 +174,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoBadgeMagnifyingglass = SFSymbol(rawValue: "photo.badge.magnifyingglass")
+    static var photoBadgeMagnifyingglass: SFSymbol { .init(rawValue: "photo.badge.magnifyingglass") }
 
     /// 􂷑
     /// Single Localization, 2 Layersets
@@ -182,7 +182,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let photoBadgeMagnifyingglassFill = SFSymbol(rawValue: "photo.badge.magnifyingglass.fill")
+    static var photoBadgeMagnifyingglassFill: SFSymbol { .init(rawValue: "photo.badge.magnifyingglass.fill") }
 
     /// 􂷫
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -196,7 +196,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let questionmarkMessage = SymbolWith1Localization<Ar_v6_2>(rawValue: "questionmark.message")
+    static var questionmarkMessage: SymbolWith1Localization<Ar_v6_2> { .init(rawValue: "questionmark.message") }
 
     /// 􂷬
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -211,21 +211,21 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Messages app.
-    static let questionmarkMessageFill = SymbolWith1Localization<Ar_v6_2>(rawValue: "questionmark.message.fill")
+    static var questionmarkMessageFill: SymbolWith1Localization<Ar_v6_2> { .init(rawValue: "questionmark.message.fill") }
 
     /// 􂶯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x1 = SFSymbol(rawValue: "rectangle.grid.3x1")
+    static var rectangleGrid3x1: SFSymbol { .init(rawValue: "rectangle.grid.3x1") }
 
     /// 􂶰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid3x1Fill = SFSymbol(rawValue: "rectangle.grid.3x1.fill")
+    static var rectangleGrid3x1Fill: SFSymbol { .init(rawValue: "rectangle.grid.3x1.fill") }
 
     /// 􂷡
     /// Single Localization, 3 Layersets
@@ -234,7 +234,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeCheckmark = SFSymbol(rawValue: "square.and.arrow.down.badge.checkmark")
+    static var squareAndArrowDownBadgeCheckmark: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.checkmark") }
 
     /// 􂷢
     /// Single Localization, 3 Layersets
@@ -243,7 +243,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeCheckmarkFill = SFSymbol(rawValue: "square.and.arrow.down.badge.checkmark.fill")
+    static var squareAndArrowDownBadgeCheckmarkFill: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.checkmark.fill") }
 
     /// 􂷥
     /// Single Localization, 3 Layersets
@@ -252,7 +252,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeXmark = SFSymbol(rawValue: "square.and.arrow.down.badge.xmark")
+    static var squareAndArrowDownBadgeXmark: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.xmark") }
 
     /// 􂷦
     /// Single Localization, 3 Layersets
@@ -261,7 +261,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowDownBadgeXmarkFill = SFSymbol(rawValue: "square.and.arrow.down.badge.xmark.fill")
+    static var squareAndArrowDownBadgeXmarkFill: SFSymbol { .init(rawValue: "square.and.arrow.down.badge.xmark.fill") }
 
     /// 􂷝
     /// Single Localization, 3 Layersets
@@ -270,7 +270,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeCheckmark = SFSymbol(rawValue: "waveform.badge.checkmark")
+    static var waveformBadgeCheckmark: SFSymbol { .init(rawValue: "waveform.badge.checkmark") }
 
     /// 􂷞
     /// Single Localization, 3 Layersets
@@ -279,7 +279,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let waveformBadgeXmark = SFSymbol(rawValue: "waveform.badge.xmark")
+    static var waveformBadgeXmark: SFSymbol { .init(rawValue: "waveform.badge.xmark") }
 
     /// 􂵊
     /// Single Localization, 2 Layersets
@@ -287,7 +287,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waveformPathEcgMagnifyingglass = SFSymbol(rawValue: "waveform.path.ecg.magnifyingglass")
+    static var waveformPathEcgMagnifyingglass: SFSymbol { .init(rawValue: "waveform.path.ecg.magnifyingglass") }
 
     /// 􂷚
     /// 2 Localizations, Single Layerset
@@ -298,7 +298,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformPathEcgText = SymbolWith1Localization<Rtl>(rawValue: "waveform.path.ecg.text")
+    static var waveformPathEcgText: SymbolWith1Localization<Rtl> { .init(rawValue: "waveform.path.ecg.text") }
 
     /// 􂵋
     /// 2 Localizations, 2 Layersets
@@ -310,7 +310,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waveformPathEcgTextClipboard = SymbolWith1Localization<Rtl>(rawValue: "waveform.path.ecg.text.clipboard")
+    static var waveformPathEcgTextClipboard: SymbolWith1Localization<Rtl> { .init(rawValue: "waveform.path.ecg.text.clipboard") }
 
     /// 􂵌
     /// 2 Localizations, 2 Layersets
@@ -322,7 +322,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let waveformPathEcgTextClipboardFill = SymbolWith1Localization<Rtl>(rawValue: "waveform.path.ecg.text.clipboard.fill")
+    static var waveformPathEcgTextClipboardFill: SymbolWith1Localization<Rtl> { .init(rawValue: "waveform.path.ecg.text.clipboard.fill") }
 
     /// 􀳼
     /// 2 Localizations, 2 Layersets
@@ -334,7 +334,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Multicolor
-    static let waveformPathEcgTextPage = SymbolWith1Localization<Rtl>(rawValue: "waveform.path.ecg.text.page")
+    static var waveformPathEcgTextPage: SymbolWith1Localization<Rtl> { .init(rawValue: "waveform.path.ecg.text.page") }
 
     /// 􀳽
     /// 2 Localizations, Single Layerset
@@ -345,5 +345,5 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformPathEcgTextPageFill = SymbolWith1Localization<Rtl>(rawValue: "waveform.path.ecg.text.page.fill")
+    static var waveformPathEcgTextPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "waveform.path.ecg.text.page.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+6.2.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+6.2.swift
@@ -10,7 +10,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen4 = SFSymbol(rawValue: "airpods.gen4")
+    static var airpodsGen4: SFSymbol { .init(rawValue: "airpods.gen4") }
 
     /// 􂭆
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -19,7 +19,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen4ChargingcaseWireless = SFSymbol(rawValue: "airpods.gen4.chargingcase.wireless")
+    static var airpodsGen4ChargingcaseWireless: SFSymbol { .init(rawValue: "airpods.gen4.chargingcase.wireless") }
 
     /// 􂭇
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -28,7 +28,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen4ChargingcaseWirelessFill = SFSymbol(rawValue: "airpods.gen4.chargingcase.wireless.fill")
+    static var airpodsGen4ChargingcaseWirelessFill: SFSymbol { .init(rawValue: "airpods.gen4.chargingcase.wireless.fill") }
 
     /// 􂭅
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -37,7 +37,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen4Left = SFSymbol(rawValue: "airpods.gen4.left")
+    static var airpodsGen4Left: SFSymbol { .init(rawValue: "airpods.gen4.left") }
 
     /// 􂭄
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s AirPods.
-    static let airpodsGen4Right = SFSymbol(rawValue: "airpods.gen4.right")
+    static var airpodsGen4Right: SFSymbol { .init(rawValue: "airpods.gen4.right") }
 
     /// 􂷴
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -57,7 +57,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Writing Tools.
-    static let appleWritingTools = SFSymbol(rawValue: "apple.writing.tools")
+    static var appleWritingTools: SFSymbol { .init(rawValue: "apple.writing.tools") }
 
     /// 􂹞
     /// 2 Localizations, Single Layerset
@@ -68,7 +68,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let exclamationmarkTriangleTextPage = SymbolWith1Localization<Rtl>(rawValue: "exclamationmark.triangle.text.page")
+    static var exclamationmarkTriangleTextPage: SymbolWith1Localization<Rtl> { .init(rawValue: "exclamationmark.triangle.text.page") }
 
     /// 􂹟
     /// 2 Localizations, Single Layerset
@@ -79,7 +79,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let exclamationmarkTriangleTextPageFill = SymbolWith1Localization<Rtl>(rawValue: "exclamationmark.triangle.text.page.fill")
+    static var exclamationmarkTriangleTextPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "exclamationmark.triangle.text.page.fill") }
 
     /// 􂸞
     /// Single Localization, 2 Layersets
@@ -87,7 +87,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpperAndMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper.and.middle.and.lower")
+    static var figureSeatedSideLeftAirDistributionUpperAndMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper.and.middle.and.lower") }
 
     /// 􂸟
     /// Single Localization, 2 Layersets
@@ -95,7 +95,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpperAndMiddleAndLower = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper.and.middle.and.lower")
+    static var figureSeatedSideRightAirDistributionUpperAndMiddleAndLower: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper.and.middle.and.lower") }
 
     /// 􂸔
     /// Single Localization, 2 Layersets
@@ -103,7 +103,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let headphonesDots = SFSymbol(rawValue: "headphones.dots")
+    static var headphonesDots: SFSymbol { .init(rawValue: "headphones.dots") }
 
     /// 􂹩
     /// Single Localization, 2 Layersets
@@ -111,7 +111,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let infoTriangle = SFSymbol(rawValue: "info.triangle")
+    static var infoTriangle: SFSymbol { .init(rawValue: "info.triangle") }
 
     /// 􂹪
     /// Single Localization, 3 Layersets
@@ -120,7 +120,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let infoTriangleFill = SFSymbol(rawValue: "info.triangle.fill")
+    static var infoTriangleFill: SFSymbol { .init(rawValue: "info.triangle.fill") }
 
     /// 􂸆
     /// Single Localization, 2 Layersets
@@ -128,7 +128,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangleAndPersonFilledCircle = SFSymbol(rawValue: "inset.filled.rectangle.and.person.filled.circle")
+    static var insetFilledRectangleAndPersonFilledCircle: SFSymbol { .init(rawValue: "inset.filled.rectangle.and.person.filled.circle") }
 
     /// 􂸇
     /// Single Localization, 3 Layersets
@@ -137,21 +137,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let insetFilledRectangleAndPersonFilledCircleFill = SFSymbol(rawValue: "inset.filled.rectangle.and.person.filled.circle.fill")
+    static var insetFilledRectangleAndPersonFilledCircleFill: SFSymbol { .init(rawValue: "inset.filled.rectangle.and.person.filled.circle.fill") }
 
     /// 􂷼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let receipt = SFSymbol(rawValue: "receipt")
+    static var receipt: SFSymbol { .init(rawValue: "receipt") }
 
     /// 􂷽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let receiptFill = SFSymbol(rawValue: "receipt.fill")
+    static var receiptFill: SFSymbol { .init(rawValue: "receipt.fill") }
 
     /// 􂸊
     /// Single Localization, 2 Layersets
@@ -159,7 +159,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wandAndOutline = SFSymbol(rawValue: "wand.and.outline")
+    static var wandAndOutline: SFSymbol { .init(rawValue: "wand.and.outline") }
 
     /// 􂸋
     /// Single Localization, 2 Layersets
@@ -167,5 +167,5 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wandAndOutlineInverse = SFSymbol(rawValue: "wand.and.outline.inverse")
+    static var wandAndOutlineInverse: SFSymbol { .init(rawValue: "wand.and.outline.inverse") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+6.3.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+6.3.swift
@@ -8,14 +8,14 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowBackwardToLineCompact = SFSymbol(rawValue: "arrow.backward.to.line.compact")
+    static var arrowBackwardToLineCompact: SFSymbol { .init(rawValue: "arrow.backward.to.line.compact") }
 
     /// 􁂏
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowForwardToLineCompact = SFSymbol(rawValue: "arrow.forward.to.line.compact")
+    static var arrowForwardToLineCompact: SFSymbol { .init(rawValue: "arrow.forward.to.line.compact") }
 
     /// 􂹼
     /// Single Localization, 2 Layersets
@@ -23,7 +23,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowLeftAndRight = SFSymbol(rawValue: "car.side.arrow.left.and.right")
+    static var carSideArrowLeftAndRight: SFSymbol { .init(rawValue: "car.side.arrow.left.and.right") }
 
     /// 􂹽
     /// Single Localization, 2 Layersets
@@ -31,7 +31,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideArrowLeftAndRightFill = SFSymbol(rawValue: "car.side.arrow.left.and.right.fill")
+    static var carSideArrowLeftAndRightFill: SFSymbol { .init(rawValue: "car.side.arrow.left.and.right.fill") }
 
     /// 􂼛
     /// Single Localization, 2 Layersets
@@ -39,7 +39,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let carSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle = SFSymbol(rawValue: "car.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle")
+    static var carSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle: SFSymbol { .init(rawValue: "car.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle") }
 
     /// 􂼜
     /// Single Localization, 2 Layersets
@@ -47,7 +47,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let carSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill = SFSymbol(rawValue: "car.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill")
+    static var carSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill: SFSymbol { .init(rawValue: "car.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill") }
 
     /// 􂻳
     /// Single Localization, 2 Layersets
@@ -55,7 +55,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndCollisionAndCarSideFrontAndArrowForward = SFSymbol(rawValue: "car.side.rear.and.collision.and.car.side.front.and.arrow.forward")
+    static var carSideRearAndCollisionAndCarSideFrontAndArrowForward: SFSymbol { .init(rawValue: "car.side.rear.and.collision.and.car.side.front.and.arrow.forward") }
 
     /// 􂼚
     /// Single Localization, 2 Layersets
@@ -63,7 +63,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carSideRearAndCollisionAndCarSideFrontAndSteeringwheel = SFSymbol(rawValue: "car.side.rear.and.collision.and.car.side.front.and.steeringwheel")
+    static var carSideRearAndCollisionAndCarSideFrontAndSteeringwheel: SFSymbol { .init(rawValue: "car.side.rear.and.collision.and.car.side.front.and.steeringwheel") }
 
     /// 􂺯
     /// Single Localization, 2 Layersets
@@ -71,7 +71,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedDepartureLeftSlash = SFSymbol(rawValue: "car.top.lane.dashed.departure.left.slash")
+    static var carTopLaneDashedDepartureLeftSlash: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.left.slash") }
 
     /// 􂺱
     /// Single Localization, 2 Layersets
@@ -79,7 +79,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedDepartureLeftSlashFill = SFSymbol(rawValue: "car.top.lane.dashed.departure.left.slash.fill")
+    static var carTopLaneDashedDepartureLeftSlashFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.left.slash.fill") }
 
     /// 􂺳
     /// Single Localization, 2 Layersets
@@ -87,7 +87,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedDepartureRightSlash = SFSymbol(rawValue: "car.top.lane.dashed.departure.right.slash")
+    static var carTopLaneDashedDepartureRightSlash: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.right.slash") }
 
     /// 􂺵
     /// Single Localization, 2 Layersets
@@ -95,7 +95,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carTopLaneDashedDepartureRightSlashFill = SFSymbol(rawValue: "car.top.lane.dashed.departure.right.slash.fill")
+    static var carTopLaneDashedDepartureRightSlashFill: SFSymbol { .init(rawValue: "car.top.lane.dashed.departure.right.slash.fill") }
 
     /// 􂺹
     /// 19 Localizations, 2 Layersets
@@ -124,7 +124,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let characterTextboxBadgeSparkles = SymbolWith18Localizations<Ar, Bn, Gu, He, Hi, Ja, Kn, Ko, Ml, Mni, Mr, Or, Pa, Sat, Si, Ta, Th, Zh>(rawValue: "character.textbox.badge.sparkles")
+    static var characterTextboxBadgeSparkles: SymbolWith18Localizations<Ar, Bn, Gu, He, Hi, Ja, Kn, Ko, Ml, Mni, Mr, Or, Pa, Sat, Si, Ta, Th, Zh> { .init(rawValue: "character.textbox.badge.sparkles") }
 
     /// 􂺀
     /// Single Localization, 2 Layersets
@@ -132,7 +132,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowLeftAndRight = SFSymbol(rawValue: "convertible.side.arrow.left.and.right")
+    static var convertibleSideArrowLeftAndRight: SFSymbol { .init(rawValue: "convertible.side.arrow.left.and.right") }
 
     /// 􂺁
     /// Single Localization, 2 Layersets
@@ -140,7 +140,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let convertibleSideArrowLeftAndRightFill = SFSymbol(rawValue: "convertible.side.arrow.left.and.right.fill")
+    static var convertibleSideArrowLeftAndRightFill: SFSymbol { .init(rawValue: "convertible.side.arrow.left.and.right.fill") }
 
     /// 􂼧
     /// Single Localization, 2 Layersets
@@ -148,7 +148,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let convertibleSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle = SFSymbol(rawValue: "convertible.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle")
+    static var convertibleSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle: SFSymbol { .init(rawValue: "convertible.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle") }
 
     /// 􂼨
     /// Single Localization, 2 Layersets
@@ -156,7 +156,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let convertibleSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill = SFSymbol(rawValue: "convertible.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill")
+    static var convertibleSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill: SFSymbol { .init(rawValue: "convertible.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill") }
 
     /// 􀫌
     /// Single Localization, Single Layerset
@@ -168,14 +168,14 @@ public extension SFSymbol {
     @available(tvOS, introduced: 18.4, deprecated: 26.0, renamed: "pointerArrow")
     @available(watchOS, introduced: 11.4, deprecated: 26.0, renamed: "pointerArrow")
     @available(visionOS, introduced: 2.4, deprecated: 26.0, renamed: "pointerArrow")
-    static let cursorarrowResizeNorthEastSouthEast = SFSymbol(rawValue: "cursorarrow.resize.north.east.south.east")
+    static var cursorarrowResizeNorthEastSouthEast: SFSymbol { .init(rawValue: "cursorarrow.resize.north.east.south.east") }
 
     /// 􂼙
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let electronicTollCollection = SFSymbol(rawValue: "electronic.toll.collection")
+    static var electronicTollCollection: SFSymbol { .init(rawValue: "electronic.toll.collection") }
 
     /// 􂺟
     /// Single Localization, 2 Layersets
@@ -183,7 +183,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let electronicTollCollectionRectangle = SFSymbol(rawValue: "electronic.toll.collection.rectangle")
+    static var electronicTollCollectionRectangle: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle") }
 
     /// 􂺦
     /// Single Localization, 3 Layersets
@@ -192,7 +192,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let electronicTollCollectionRectangleFill = SFSymbol(rawValue: "electronic.toll.collection.rectangle.fill")
+    static var electronicTollCollectionRectangleFill: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle.fill") }
 
     /// 􂺠
     /// Single Localization, 2 Layersets
@@ -200,7 +200,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let electronicTollCollectionRectangleSlash = SFSymbol(rawValue: "electronic.toll.collection.rectangle.slash")
+    static var electronicTollCollectionRectangleSlash: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle.slash") }
 
     /// 􂺧
     /// Single Localization, 2 Layersets
@@ -208,7 +208,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let electronicTollCollectionRectangleSlashFill = SFSymbol(rawValue: "electronic.toll.collection.rectangle.slash.fill")
+    static var electronicTollCollectionRectangleSlashFill: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle.slash.fill") }
 
     /// 􂺢
     /// Single Localization, 3 Layersets
@@ -217,7 +217,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let electronicTollCollectionRectangleTrianglebadgeExclamationmark = SFSymbol(rawValue: "electronic.toll.collection.rectangle.trianglebadge.exclamationmark")
+    static var electronicTollCollectionRectangleTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle.trianglebadge.exclamationmark") }
 
     /// 􂺩
     /// Single Localization, 3 Layersets
@@ -226,7 +226,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let electronicTollCollectionRectangleTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "electronic.toll.collection.rectangle.trianglebadge.exclamationmark.fill")
+    static var electronicTollCollectionRectangleTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "electronic.toll.collection.rectangle.trianglebadge.exclamationmark.fill") }
 
     /// 􂼵
     /// Single Localization, 2 Layersets
@@ -234,7 +234,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let engineEmissionAndDrop2WaterWaveBelow = SFSymbol(rawValue: "engine.emission.and.drop.2.water.wave.below")
+    static var engineEmissionAndDrop2WaterWaveBelow: SFSymbol { .init(rawValue: "engine.emission.and.drop.2.water.wave.below") }
 
     /// 􂻴
     /// Single Localization, 2 Layersets
@@ -242,7 +242,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndArrow3Down = SFSymbol(rawValue: "envelope.and.arrow.3.down")
+    static var envelopeAndArrow3Down: SFSymbol { .init(rawValue: "envelope.and.arrow.3.down") }
 
     /// 􂻵
     /// Single Localization, 2 Layersets
@@ -250,28 +250,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndArrow3DownFill = SFSymbol(rawValue: "envelope.and.arrow.3.down.fill")
+    static var envelopeAndArrow3DownFill: SFSymbol { .init(rawValue: "envelope.and.arrow.3.down.fill") }
 
     /// 􂼊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let flagPatternCheckeredLc = SFSymbol(rawValue: "flag.pattern.checkered.lc")
+    static var flagPatternCheckeredLc: SFSymbol { .init(rawValue: "flag.pattern.checkered.lc") }
 
     /// 􂼋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelFilterWater = SFSymbol(rawValue: "fuel.filter.water")
+    static var fuelFilterWater: SFSymbol { .init(rawValue: "fuel.filter.water") }
 
     /// 􂼅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let hydrogen = SFSymbol(rawValue: "hydrogen")
+    static var hydrogen: SFSymbol { .init(rawValue: "hydrogen") }
 
     /// 􂼆
     /// Single Localization, 2 Layersets
@@ -279,7 +279,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hydrogenCircle = SFSymbol(rawValue: "hydrogen.circle")
+    static var hydrogenCircle: SFSymbol { .init(rawValue: "hydrogen.circle") }
 
     /// 􂼇
     /// Single Localization, 3 Layersets
@@ -288,7 +288,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hydrogenCircleFill = SFSymbol(rawValue: "hydrogen.circle.fill")
+    static var hydrogenCircleFill: SFSymbol { .init(rawValue: "hydrogen.circle.fill") }
 
     /// 􂼈
     /// Single Localization, 2 Layersets
@@ -296,7 +296,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let hydrogenSquare = SFSymbol(rawValue: "hydrogen.square")
+    static var hydrogenSquare: SFSymbol { .init(rawValue: "hydrogen.square") }
 
     /// 􂼉
     /// Single Localization, 3 Layersets
@@ -305,7 +305,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hydrogenSquareFill = SFSymbol(rawValue: "hydrogen.square.fill")
+    static var hydrogenSquareFill: SFSymbol { .init(rawValue: "hydrogen.square.fill") }
 
     /// 􂹚
     /// 2 Localizations, Single Layerset
@@ -316,7 +316,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let infoCircleTextPage = SymbolWith1Localization<Rtl>(rawValue: "info.circle.text.page")
+    static var infoCircleTextPage: SymbolWith1Localization<Rtl> { .init(rawValue: "info.circle.text.page") }
 
     /// 􂹛
     /// 2 Localizations, Single Layerset
@@ -327,7 +327,7 @@ public extension SFSymbol {
     ///
     /// Layersets:
     /// - Monochrome
-    static let infoCircleTextPageFill = SymbolWith1Localization<Rtl>(rawValue: "info.circle.text.page.fill")
+    static var infoCircleTextPageFill: SymbolWith1Localization<Rtl> { .init(rawValue: "info.circle.text.page.fill") }
 
     /// 􂻶
     /// Single Localization, 2 Layersets
@@ -335,7 +335,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyCarSide = SFSymbol(rawValue: "key.car.side")
+    static var keyCarSide: SFSymbol { .init(rawValue: "key.car.side") }
 
     /// 􂻷
     /// Single Localization, 3 Layersets
@@ -344,7 +344,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let keyCarSideFill = SFSymbol(rawValue: "key.car.side.fill")
+    static var keyCarSideFill: SFSymbol { .init(rawValue: "key.car.side.fill") }
 
     /// 􂻺
     /// Single Localization, 2 Layersets
@@ -352,7 +352,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyConvertibleSide = SFSymbol(rawValue: "key.convertible.side")
+    static var keyConvertibleSide: SFSymbol { .init(rawValue: "key.convertible.side") }
 
     /// 􂻻
     /// Single Localization, 3 Layersets
@@ -361,7 +361,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let keyConvertibleSideFill = SFSymbol(rawValue: "key.convertible.side.fill")
+    static var keyConvertibleSideFill: SFSymbol { .init(rawValue: "key.convertible.side.fill") }
 
     /// 􂻸
     /// Single Localization, 2 Layersets
@@ -369,7 +369,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keySuvSide = SFSymbol(rawValue: "key.suv.side")
+    static var keySuvSide: SFSymbol { .init(rawValue: "key.suv.side") }
 
     /// 􂻹
     /// Single Localization, 3 Layersets
@@ -378,7 +378,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let keySuvSideFill = SFSymbol(rawValue: "key.suv.side.fill")
+    static var keySuvSideFill: SFSymbol { .init(rawValue: "key.suv.side.fill") }
 
     /// 􂻼
     /// Single Localization, 2 Layersets
@@ -386,7 +386,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyTruckPickupSide = SFSymbol(rawValue: "key.truck.pickup.side")
+    static var keyTruckPickupSide: SFSymbol { .init(rawValue: "key.truck.pickup.side") }
 
     /// 􂻽
     /// Single Localization, 3 Layersets
@@ -395,7 +395,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let keyTruckPickupSideFill = SFSymbol(rawValue: "key.truck.pickup.side.fill")
+    static var keyTruckPickupSideFill: SFSymbol { .init(rawValue: "key.truck.pickup.side.fill") }
 
     /// 􂽱
     /// Single Localization, 2 Layersets
@@ -403,7 +403,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let longTextPageAndPencil = SFSymbol(rawValue: "long.text.page.and.pencil")
+    static var longTextPageAndPencil: SFSymbol { .init(rawValue: "long.text.page.and.pencil") }
 
     /// 􂽴
     /// Single Localization, 2 Layersets
@@ -411,7 +411,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let longTextPageAndPencilFill = SFSymbol(rawValue: "long.text.page.and.pencil.fill")
+    static var longTextPageAndPencilFill: SFSymbol { .init(rawValue: "long.text.page.and.pencil.fill") }
 
     /// 􂶷
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -420,7 +420,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiGen2 = SFSymbol(rawValue: "macmini.gen2")
+    static var macminiGen2: SFSymbol { .init(rawValue: "macmini.gen2") }
 
     /// 􂶸
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -429,7 +429,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiGen2Fill = SFSymbol(rawValue: "macmini.gen2.fill")
+    static var macminiGen2Fill: SFSymbol { .init(rawValue: "macmini.gen2.fill") }
 
     /// 􂶹
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -438,7 +438,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiGen3 = SFSymbol(rawValue: "macmini.gen3")
+    static var macminiGen3: SFSymbol { .init(rawValue: "macmini.gen3") }
 
     /// 􂶺
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -447,7 +447,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiGen3Fill = SFSymbol(rawValue: "macmini.gen3.fill")
+    static var macminiGen3Fill: SFSymbol { .init(rawValue: "macmini.gen3.fill") }
 
     /// 􂺂
     /// Single Localization, 2 Layersets
@@ -455,7 +455,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let memoriesSlash = SFSymbol(rawValue: "memories.slash")
+    static var memoriesSlash: SFSymbol { .init(rawValue: "memories.slash") }
 
     /// 􂹸
     /// Single Localization, 2 Layersets
@@ -463,7 +463,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusPlusBatteryblockStackArrowtriangleLeft = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.left")
+    static var minusPlusBatteryblockStackArrowtriangleLeft: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.left") }
 
     /// 􂹺
     /// Single Localization, 3 Layersets
@@ -472,7 +472,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let minusPlusBatteryblockStackArrowtriangleLeftFill = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.left.fill")
+    static var minusPlusBatteryblockStackArrowtriangleLeftFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.left.fill") }
 
     /// 􂹴
     /// Single Localization, 2 Layersets
@@ -480,7 +480,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusPlusBatteryblockStackArrowtriangleRight = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right")
+    static var minusPlusBatteryblockStackArrowtriangleRight: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right") }
 
     /// 􂼕
     /// Single Localization, 2 Layersets
@@ -488,7 +488,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusPlusBatteryblockStackArrowtriangleRightAndArrowtriangleLeft = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.and.arrowtriangle.left")
+    static var minusPlusBatteryblockStackArrowtriangleRightAndArrowtriangleLeft: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.and.arrowtriangle.left") }
 
     /// 􂼖
     /// Single Localization, 3 Layersets
@@ -497,7 +497,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let minusPlusBatteryblockStackArrowtriangleRightAndArrowtriangleLeftFill = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.and.arrowtriangle.left.fill")
+    static var minusPlusBatteryblockStackArrowtriangleRightAndArrowtriangleLeftFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.and.arrowtriangle.left.fill") }
 
     /// 􂹶
     /// Single Localization, 3 Layersets
@@ -506,7 +506,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let minusPlusBatteryblockStackArrowtriangleRightFill = SFSymbol(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.fill")
+    static var minusPlusBatteryblockStackArrowtriangleRightFill: SFSymbol { .init(rawValue: "minus.plus.batteryblock.stack.arrowtriangle.right.fill") }
 
     /// 􂼫
     /// Single Localization, 3 Layersets
@@ -515,7 +515,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let nosignBadgeClock = SFSymbol(rawValue: "nosign.badge.clock")
+    static var nosignBadgeClock: SFSymbol { .init(rawValue: "nosign.badge.clock") }
 
     /// 􂻫
     /// 2 Localizations, 2 Layersets
@@ -527,7 +527,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personCheckmarkAndXmark = SymbolWith1Localization<Rtl>(rawValue: "person.checkmark.and.xmark")
+    static var personCheckmarkAndXmark: SymbolWith1Localization<Rtl> { .init(rawValue: "person.checkmark.and.xmark") }
 
     /// 􂻬
     /// 2 Localizations, 2 Layersets
@@ -539,7 +539,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let personFillCheckmarkAndXmark = SymbolWith1Localization<Rtl>(rawValue: "person.fill.checkmark.and.xmark")
+    static var personFillCheckmarkAndXmark: SymbolWith1Localization<Rtl> { .init(rawValue: "person.fill.checkmark.and.xmark") }
 
     /// 􂼭
     /// Single Localization, 3 Layersets
@@ -548,7 +548,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeShieldExclamationmark = SFSymbol(rawValue: "photo.badge.shield.exclamationmark")
+    static var photoBadgeShieldExclamationmark: SFSymbol { .init(rawValue: "photo.badge.shield.exclamationmark") }
 
     /// 􂼷
     /// Single Localization, 3 Layersets
@@ -557,7 +557,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoBadgeShieldExclamationmarkFill = SFSymbol(rawValue: "photo.badge.shield.exclamationmark.fill")
+    static var photoBadgeShieldExclamationmarkFill: SFSymbol { .init(rawValue: "photo.badge.shield.exclamationmark.fill") }
 
     /// 􂼯
     /// Single Localization, 3 Layersets
@@ -566,7 +566,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoTrianglebadgeExclamationmark = SFSymbol(rawValue: "photo.trianglebadge.exclamationmark")
+    static var photoTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "photo.trianglebadge.exclamationmark") }
 
     /// 􂼸
     /// Single Localization, 3 Layersets
@@ -575,14 +575,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let photoTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "photo.trianglebadge.exclamationmark.fill")
+    static var photoTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "photo.trianglebadge.exclamationmark.fill") }
 
     /// 􂹯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pi = SFSymbol(rawValue: "pi")
+    static var pi: SFSymbol { .init(rawValue: "pi") }
 
     /// 􂹰
     /// Single Localization, 2 Layersets
@@ -590,7 +590,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let piCircle = SFSymbol(rawValue: "pi.circle")
+    static var piCircle: SFSymbol { .init(rawValue: "pi.circle") }
 
     /// 􂹱
     /// Single Localization, 3 Layersets
@@ -599,7 +599,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let piCircleFill = SFSymbol(rawValue: "pi.circle.fill")
+    static var piCircleFill: SFSymbol { .init(rawValue: "pi.circle.fill") }
 
     /// 􂹲
     /// Single Localization, 2 Layersets
@@ -607,7 +607,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let piSquare = SFSymbol(rawValue: "pi.square")
+    static var piSquare: SFSymbol { .init(rawValue: "pi.square") }
 
     /// 􂹳
     /// Single Localization, 3 Layersets
@@ -616,7 +616,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let piSquareFill = SFSymbol(rawValue: "pi.square.fill")
+    static var piSquareFill: SFSymbol { .init(rawValue: "pi.square.fill") }
 
     /// 􂻥
     /// Single Localization, 2 Layersets
@@ -624,7 +624,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusMinusCapsule = SFSymbol(rawValue: "plus.minus.capsule")
+    static var plusMinusCapsule: SFSymbol { .init(rawValue: "plus.minus.capsule") }
 
     /// 􂻦
     /// Single Localization, 3 Layersets
@@ -633,7 +633,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let plusMinusCapsuleFill = SFSymbol(rawValue: "plus.minus.capsule.fill")
+    static var plusMinusCapsuleFill: SFSymbol { .init(rawValue: "plus.minus.capsule.fill") }
 
     /// 􂻛
     /// Single Localization, 3 Layersets
@@ -647,7 +647,7 @@ public extension SFSymbol {
     @available(tvOS, introduced: 18.4, deprecated: 26.0, renamed: "repeatBadgeXmark")
     @available(watchOS, introduced: 11.4, deprecated: 26.0, renamed: "repeatBadgeXmark")
     @available(visionOS, introduced: 2.4, deprecated: 26.0, renamed: "repeatBadgeXmark")
-    static let repeatBadgeXmarkCircleFill = SFSymbol(rawValue: "repeat.badge.xmark.circle.fill")
+    static var repeatBadgeXmarkCircleFill: SFSymbol { .init(rawValue: "repeat.badge.xmark.circle.fill") }
 
     /// 􂼀
     /// Single Localization, 2 Layersets
@@ -655,7 +655,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let roadLaneArrowtriangle2Outward = SFSymbol(rawValue: "road.lane.arrowtriangle.2.outward")
+    static var roadLaneArrowtriangle2Outward: SFSymbol { .init(rawValue: "road.lane.arrowtriangle.2.outward") }
 
     /// 􂼳
     /// Single Localization, 2 Layersets
@@ -663,7 +663,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let roboticVacuumAndArrowtriangleUp = SFSymbol(rawValue: "robotic.vacuum.and.arrowtriangle.up")
+    static var roboticVacuumAndArrowtriangleUp: SFSymbol { .init(rawValue: "robotic.vacuum.and.arrowtriangle.up") }
 
     /// 􂼴
     /// Single Localization, 2 Layersets
@@ -671,7 +671,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let roboticVacuumAndArrowtriangleUpFill = SFSymbol(rawValue: "robotic.vacuum.and.arrowtriangle.up.fill")
+    static var roboticVacuumAndArrowtriangleUpFill: SFSymbol { .init(rawValue: "robotic.vacuum.and.arrowtriangle.up.fill") }
 
     /// 􂼱
     /// Single Localization, 2 Layersets
@@ -679,7 +679,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let roboticVacuumAndEllipsis = SFSymbol(rawValue: "robotic.vacuum.and.ellipsis")
+    static var roboticVacuumAndEllipsis: SFSymbol { .init(rawValue: "robotic.vacuum.and.ellipsis") }
 
     /// 􂼲
     /// Single Localization, 2 Layersets
@@ -687,14 +687,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0)
-    static let roboticVacuumAndEllipsisFill = SFSymbol(rawValue: "robotic.vacuum.and.ellipsis.fill")
+    static var roboticVacuumAndEllipsisFill: SFSymbol { .init(rawValue: "robotic.vacuum.and.ellipsis.fill") }
 
     /// 􂻝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let spoonServing = SFSymbol(rawValue: "spoon.serving")
+    static var spoonServing: SFSymbol { .init(rawValue: "spoon.serving") }
 
     /// 􂼽
     /// Single Localization, 3 Layersets
@@ -703,7 +703,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpBadgeCheckmark = SFSymbol(rawValue: "square.and.arrow.up.badge.checkmark")
+    static var squareAndArrowUpBadgeCheckmark: SFSymbol { .init(rawValue: "square.and.arrow.up.badge.checkmark") }
 
     /// 􂼾
     /// Single Localization, 3 Layersets
@@ -712,21 +712,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let squareAndArrowUpBadgeCheckmarkFill = SFSymbol(rawValue: "square.and.arrow.up.badge.checkmark.fill")
+    static var squareAndArrowUpBadgeCheckmarkFill: SFSymbol { .init(rawValue: "square.and.arrow.up.badge.checkmark.fill") }
 
     /// 􀮌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshapeSplit2x2DottedInside = SFSymbol(rawValue: "squareshape.split.2x2.dotted.inside")
+    static var squareshapeSplit2x2DottedInside: SFSymbol { .init(rawValue: "squareshape.split.2x2.dotted.inside") }
 
     /// 􁓓
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let squareshapeSplit2x2DottedInsideAndOutside = SFSymbol(rawValue: "squareshape.split.2x2.dotted.inside.and.outside")
+    static var squareshapeSplit2x2DottedInsideAndOutside: SFSymbol { .init(rawValue: "squareshape.split.2x2.dotted.inside.and.outside") }
 
     /// 􂼼
     /// Single Localization, 2 Layersets
@@ -734,7 +734,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let squareshapeSplit2x2DottedOutside = SFSymbol(rawValue: "squareshape.split.2x2.dotted.outside")
+    static var squareshapeSplit2x2DottedOutside: SFSymbol { .init(rawValue: "squareshape.split.2x2.dotted.outside") }
 
     /// 􂺷
     /// Single Localization, 2 Layersets
@@ -742,7 +742,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let starHexagon = SFSymbol(rawValue: "star.hexagon")
+    static var starHexagon: SFSymbol { .init(rawValue: "star.hexagon") }
 
     /// 􂺸
     /// Single Localization, 3 Layersets
@@ -751,7 +751,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
     /// - Multicolor (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let starHexagonFill = SFSymbol(rawValue: "star.hexagon.fill")
+    static var starHexagonFill: SFSymbol { .init(rawValue: "star.hexagon.fill") }
 
     /// 􂹾
     /// Single Localization, 2 Layersets
@@ -759,7 +759,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowLeftAndRight = SFSymbol(rawValue: "suv.side.arrow.left.and.right")
+    static var suvSideArrowLeftAndRight: SFSymbol { .init(rawValue: "suv.side.arrow.left.and.right") }
 
     /// 􂹿
     /// Single Localization, 2 Layersets
@@ -767,7 +767,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suvSideArrowLeftAndRightFill = SFSymbol(rawValue: "suv.side.arrow.left.and.right.fill")
+    static var suvSideArrowLeftAndRightFill: SFSymbol { .init(rawValue: "suv.side.arrow.left.and.right.fill") }
 
     /// 􂼟
     /// Single Localization, 2 Layersets
@@ -775,7 +775,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let suvSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle = SFSymbol(rawValue: "suv.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle")
+    static var suvSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle: SFSymbol { .init(rawValue: "suv.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle") }
 
     /// 􂼠
     /// Single Localization, 2 Layersets
@@ -783,7 +783,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let suvSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill = SFSymbol(rawValue: "suv.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill")
+    static var suvSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill: SFSymbol { .init(rawValue: "suv.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill") }
 
     /// 􂺫
     /// Single Localization, 2 Layersets
@@ -791,7 +791,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowLeftAndRight = SFSymbol(rawValue: "truck.pickup.side.arrow.left.and.right")
+    static var truckPickupSideArrowLeftAndRight: SFSymbol { .init(rawValue: "truck.pickup.side.arrow.left.and.right") }
 
     /// 􂺬
     /// Single Localization, 2 Layersets
@@ -799,7 +799,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let truckPickupSideArrowLeftAndRightFill = SFSymbol(rawValue: "truck.pickup.side.arrow.left.and.right.fill")
+    static var truckPickupSideArrowLeftAndRightFill: SFSymbol { .init(rawValue: "truck.pickup.side.arrow.left.and.right.fill") }
 
     /// 􂼣
     /// Single Localization, 2 Layersets
@@ -807,7 +807,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let truckPickupSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle = SFSymbol(rawValue: "truck.pickup.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle")
+    static var truckPickupSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangle: SFSymbol { .init(rawValue: "truck.pickup.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle") }
 
     /// 􂼤
     /// Single Localization, 2 Layersets
@@ -815,5 +815,5 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical (iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5)
-    static let truckPickupSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill = SFSymbol(rawValue: "truck.pickup.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill")
+    static var truckPickupSideHillDownAndGaugeOpenWithLinesNeedle25percentAndArrowtriangleFill: SFSymbol { .init(rawValue: "truck.pickup.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+6.4.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+6.4.swift
@@ -12,7 +12,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Intelligence.
-    static let appleIntelligenceBadgeXmark = SFSymbol(rawValue: "apple.intelligence.badge.xmark")
+    static var appleIntelligenceBadgeXmark: SFSymbol { .init(rawValue: "apple.intelligence.badge.xmark") }
 
     /// 􂞞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -22,7 +22,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro 2.
-    static let beatsPowerbeatsPro2 = SFSymbol(rawValue: "beats.powerbeats.pro.2")
+    static var beatsPowerbeatsPro2: SFSymbol { .init(rawValue: "beats.powerbeats.pro.2") }
 
     /// 􂞡
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -31,7 +31,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro 2 case.
-    static let beatsPowerbeatsPro2Chargingcase = SFSymbol(rawValue: "beats.powerbeats.pro.2.chargingcase")
+    static var beatsPowerbeatsPro2Chargingcase: SFSymbol { .init(rawValue: "beats.powerbeats.pro.2.chargingcase") }
 
     /// 􂞢
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -40,7 +40,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro 2 case.
-    static let beatsPowerbeatsPro2ChargingcaseFill = SFSymbol(rawValue: "beats.powerbeats.pro.2.chargingcase.fill")
+    static var beatsPowerbeatsPro2ChargingcaseFill: SFSymbol { .init(rawValue: "beats.powerbeats.pro.2.chargingcase.fill") }
 
     /// 􂞠
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -50,7 +50,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro 2.
-    static let beatsPowerbeatsPro2Left = SFSymbol(rawValue: "beats.powerbeats.pro.2.left")
+    static var beatsPowerbeatsPro2Left: SFSymbol { .init(rawValue: "beats.powerbeats.pro.2.left") }
 
     /// 􂞟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -60,5 +60,5 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Beats Powerbeats Pro 2.
-    static let beatsPowerbeatsPro2Right = SFSymbol(rawValue: "beats.powerbeats.pro.2.right")
+    static var beatsPowerbeatsPro2Right: SFSymbol { .init(rawValue: "beats.powerbeats.pro.2.right") }
 }

--- a/Sources/SFSafeSymbols/Symbols/SFSymbol+7.0.swift
+++ b/Sources/SFSafeSymbols/Symbols/SFSymbol+7.0.swift
@@ -15,7 +15,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _1Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "1.calendar")
+    static var _1Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "1.calendar") }
 
     /// 􃌧
     /// 3 Localizations, 3 Layersets
@@ -29,7 +29,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _2Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "2.calendar")
+    static var _2Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "2.calendar") }
 
     /// 􃌨
     /// 3 Localizations, 3 Layersets
@@ -43,7 +43,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _3Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "3.calendar")
+    static var _3Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "3.calendar") }
 
     /// 􃌩
     /// 3 Localizations, 3 Layersets
@@ -57,7 +57,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _4Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "4.calendar")
+    static var _4Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "4.calendar") }
 
     /// 􃌪
     /// 3 Localizations, 3 Layersets
@@ -71,7 +71,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _5Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "5.calendar")
+    static var _5Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "5.calendar") }
 
     /// 􃌫
     /// 3 Localizations, 3 Layersets
@@ -85,7 +85,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _6Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "6.calendar")
+    static var _6Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "6.calendar") }
 
     /// 􃌬
     /// 3 Localizations, 3 Layersets
@@ -99,7 +99,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _7Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "7.calendar")
+    static var _7Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "7.calendar") }
 
     /// 􃌭
     /// 3 Localizations, 3 Layersets
@@ -113,7 +113,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _8Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "8.calendar")
+    static var _8Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "8.calendar") }
 
     /// 􃌮
     /// 3 Localizations, 3 Layersets
@@ -127,7 +127,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _9Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "9.calendar")
+    static var _9Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "9.calendar") }
 
     /// 􃌯
     /// 3 Localizations, 3 Layersets
@@ -141,7 +141,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _10Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "10.calendar")
+    static var _10Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "10.calendar") }
 
     /// 􃌰
     /// 3 Localizations, 3 Layersets
@@ -155,7 +155,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _11Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "11.calendar")
+    static var _11Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "11.calendar") }
 
     /// 􃌱
     /// 3 Localizations, 3 Layersets
@@ -169,7 +169,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _12Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "12.calendar")
+    static var _12Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "12.calendar") }
 
     /// 􃌲
     /// 3 Localizations, 3 Layersets
@@ -183,7 +183,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _13Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "13.calendar")
+    static var _13Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "13.calendar") }
 
     /// 􃌳
     /// 3 Localizations, 3 Layersets
@@ -197,7 +197,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _14Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "14.calendar")
+    static var _14Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "14.calendar") }
 
     /// 􃌴
     /// 3 Localizations, 3 Layersets
@@ -211,7 +211,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _15Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "15.calendar")
+    static var _15Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "15.calendar") }
 
     /// 􃌵
     /// 3 Localizations, 3 Layersets
@@ -225,7 +225,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _16Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "16.calendar")
+    static var _16Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "16.calendar") }
 
     /// 􃌶
     /// 3 Localizations, 3 Layersets
@@ -239,7 +239,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _17Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "17.calendar")
+    static var _17Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "17.calendar") }
 
     /// 􃌷
     /// 3 Localizations, 3 Layersets
@@ -253,7 +253,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _18Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "18.calendar")
+    static var _18Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "18.calendar") }
 
     /// 􃌸
     /// 3 Localizations, 3 Layersets
@@ -267,7 +267,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _19Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "19.calendar")
+    static var _19Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "19.calendar") }
 
     /// 􃌹
     /// 3 Localizations, 3 Layersets
@@ -281,7 +281,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _20Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "20.calendar")
+    static var _20Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "20.calendar") }
 
     /// 􃌺
     /// 3 Localizations, 3 Layersets
@@ -295,7 +295,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _21Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "21.calendar")
+    static var _21Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "21.calendar") }
 
     /// 􃌻
     /// 3 Localizations, 3 Layersets
@@ -309,7 +309,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _22Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "22.calendar")
+    static var _22Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "22.calendar") }
 
     /// 􃌼
     /// 3 Localizations, 3 Layersets
@@ -323,7 +323,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _23Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "23.calendar")
+    static var _23Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "23.calendar") }
 
     /// 􃌽
     /// 3 Localizations, 3 Layersets
@@ -337,7 +337,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _24Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "24.calendar")
+    static var _24Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "24.calendar") }
 
     /// 􃌾
     /// 3 Localizations, 3 Layersets
@@ -351,7 +351,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _25Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "25.calendar")
+    static var _25Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "25.calendar") }
 
     /// 􃌿
     /// 3 Localizations, 3 Layersets
@@ -365,7 +365,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _26Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "26.calendar")
+    static var _26Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "26.calendar") }
 
     /// 􃍀
     /// 3 Localizations, 3 Layersets
@@ -379,7 +379,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _27Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "27.calendar")
+    static var _27Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "27.calendar") }
 
     /// 􃍁
     /// 3 Localizations, 3 Layersets
@@ -393,7 +393,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _28Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "28.calendar")
+    static var _28Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "28.calendar") }
 
     /// 􃍂
     /// 3 Localizations, 3 Layersets
@@ -407,7 +407,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _29Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "29.calendar")
+    static var _29Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "29.calendar") }
 
     /// 􃍃
     /// 3 Localizations, 3 Layersets
@@ -421,7 +421,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _30Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "30.calendar")
+    static var _30Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "30.calendar") }
 
     /// 􃍄
     /// 3 Localizations, 3 Layersets
@@ -435,14 +435,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let _31Calendar = SymbolWith2Localizations<Ar, Hi>(rawValue: "31.calendar")
+    static var _31Calendar: SymbolWith2Localizations<Ar, Hi> { .init(rawValue: "31.calendar") }
 
     /// 􃕆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ac = SFSymbol(rawValue: "ac")
+    static var ac: SFSymbol { .init(rawValue: "ac") }
 
     /// 􃕇
     /// Single Localization, 2 Layersets
@@ -450,7 +450,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let acSlash = SFSymbol(rawValue: "ac.slash")
+    static var acSlash: SFSymbol { .init(rawValue: "ac.slash") }
 
     /// 􃈜
     /// Single Localization, 2 Layersets
@@ -458,7 +458,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneCloud = SFSymbol(rawValue: "airplane.cloud")
+    static var airplaneCloud: SFSymbol { .init(rawValue: "airplane.cloud") }
 
     /// 􃈛
     /// Single Localization, 2 Layersets
@@ -466,7 +466,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneLanded = SFSymbol(rawValue: "airplane.landed")
+    static var airplaneLanded: SFSymbol { .init(rawValue: "airplane.landed") }
 
     /// 􃋁
     /// Single Localization, 2 Layersets
@@ -474,7 +474,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplanePathDotted = SFSymbol(rawValue: "airplane.path.dotted")
+    static var airplanePathDotted: SFSymbol { .init(rawValue: "airplane.path.dotted") }
 
     /// 􀷱
     /// Single Localization, 2 Layersets
@@ -482,7 +482,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneTicket = SFSymbol(rawValue: "airplane.ticket")
+    static var airplaneTicket: SFSymbol { .init(rawValue: "airplane.ticket") }
 
     /// 􀷲
     /// Single Localization, 2 Layersets
@@ -490,14 +490,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneTicketFill = SFSymbol(rawValue: "airplane.ticket.fill")
+    static var airplaneTicketFill: SFSymbol { .init(rawValue: "airplane.ticket.fill") }
 
     /// 􃎗
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let airplaneUpForward = SFSymbol(rawValue: "airplane.up.forward")
+    static var airplaneUpForward: SFSymbol { .init(rawValue: "airplane.up.forward") }
 
     /// 􃎘
     /// Single Localization, 2 Layersets
@@ -505,7 +505,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneUpForwardApp = SFSymbol(rawValue: "airplane.up.forward.app")
+    static var airplaneUpForwardApp: SFSymbol { .init(rawValue: "airplane.up.forward.app") }
 
     /// 􃎙
     /// Single Localization, 3 Layersets
@@ -514,14 +514,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airplaneUpForwardAppFill = SFSymbol(rawValue: "airplane.up.forward.app.fill")
+    static var airplaneUpForwardAppFill: SFSymbol { .init(rawValue: "airplane.up.forward.app.fill") }
 
     /// 􀸯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let airplaneUpRight = SFSymbol(rawValue: "airplane.up.right")
+    static var airplaneUpRight: SFSymbol { .init(rawValue: "airplane.up.right") }
 
     /// 􃋑
     /// Single Localization, 2 Layersets
@@ -529,7 +529,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let airplaneUpRightApp = SFSymbol(rawValue: "airplane.up.right.app")
+    static var airplaneUpRightApp: SFSymbol { .init(rawValue: "airplane.up.right.app") }
 
     /// 􃋒
     /// Single Localization, 3 Layersets
@@ -538,49 +538,49 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let airplaneUpRightAppFill = SFSymbol(rawValue: "airplane.up.right.app.fill")
+    static var airplaneUpRightAppFill: SFSymbol { .init(rawValue: "airplane.up.right.app.fill") }
 
     /// 􃋰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let airplaneseat = SFSymbol(rawValue: "airplaneseat")
+    static var airplaneseat: SFSymbol { .init(rawValue: "airplaneseat") }
 
     /// 􂷸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appBackgroundDotted = SFSymbol(rawValue: "app.background.dotted")
+    static var appBackgroundDotted: SFSymbol { .init(rawValue: "app.background.dotted") }
 
     /// 􃏞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appGrid = SFSymbol(rawValue: "app.grid")
+    static var appGrid: SFSymbol { .init(rawValue: "app.grid") }
 
     /// 􃎺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appShadow = SFSymbol(rawValue: "app.shadow")
+    static var appShadow: SFSymbol { .init(rawValue: "app.shadow") }
 
     /// 􃏡
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appSpecular = SFSymbol(rawValue: "app.specular")
+    static var appSpecular: SFSymbol { .init(rawValue: "app.specular") }
 
     /// 􃏢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let appTranslucent = SFSymbol(rawValue: "app.translucent")
+    static var appTranslucent: SFSymbol { .init(rawValue: "app.translucent") }
 
     /// 􃁲
     /// Single Localization, 2 Layersets
@@ -588,7 +588,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let appleBooksPages = SFSymbol(rawValue: "apple.books.pages")
+    static var appleBooksPages: SFSymbol { .init(rawValue: "apple.books.pages") }
 
     /// 􃁳
     /// Single Localization, 3 Layersets
@@ -597,7 +597,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appleBooksPagesFill = SFSymbol(rawValue: "apple.books.pages.fill")
+    static var appleBooksPagesFill: SFSymbol { .init(rawValue: "apple.books.pages.fill") }
 
     /// 􃁬
     /// Single Localization, 2 Layersets
@@ -605,7 +605,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let appleClassicalPages = SFSymbol(rawValue: "apple.classical.pages")
+    static var appleClassicalPages: SFSymbol { .init(rawValue: "apple.classical.pages") }
 
     /// 􃁭
     /// Single Localization, 3 Layersets
@@ -614,7 +614,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let appleClassicalPagesFill = SFSymbol(rawValue: "apple.classical.pages.fill")
+    static var appleClassicalPagesFill: SFSymbol { .init(rawValue: "apple.classical.pages.fill") }
 
     /// 􀠀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -625,7 +625,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomeKit.
-    static let appleHomekit = SFSymbol(rawValue: "apple.homekit")
+    static var appleHomekit: SFSymbol { .init(rawValue: "apple.homekit") }
 
     /// 􃁰
     /// Single Localization, 2 Layersets
@@ -633,7 +633,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let applePodcastsPages = SFSymbol(rawValue: "apple.podcasts.pages")
+    static var applePodcastsPages: SFSymbol { .init(rawValue: "apple.podcasts.pages") }
 
     /// 􃁱
     /// Single Localization, 3 Layersets
@@ -642,7 +642,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let applePodcastsPagesFill = SFSymbol(rawValue: "apple.podcasts.pages.fill")
+    static var applePodcastsPagesFill: SFSymbol { .init(rawValue: "apple.podcasts.pages.fill") }
 
     /// 􃊀
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -653,7 +653,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvBadgeCheckmark = SFSymbol(rawValue: "appletv.badge.checkmark")
+    static var appletvBadgeCheckmark: SFSymbol { .init(rawValue: "appletv.badge.checkmark") }
 
     /// 􃊁
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -664,7 +664,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvBadgeCheckmarkFill = SFSymbol(rawValue: "appletv.badge.checkmark.fill")
+    static var appletvBadgeCheckmarkFill: SFSymbol { .init(rawValue: "appletv.badge.checkmark.fill") }
 
     /// 􁰺
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -675,7 +675,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvBadgeExclamationmark = SFSymbol(rawValue: "appletv.badge.exclamationmark")
+    static var appletvBadgeExclamationmark: SFSymbol { .init(rawValue: "appletv.badge.exclamationmark") }
 
     /// 􁰻
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -686,7 +686,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple TV.
-    static let appletvBadgeExclamationmarkFill = SFSymbol(rawValue: "appletv.badge.exclamationmark.fill")
+    static var appletvBadgeExclamationmarkFill: SFSymbol { .init(rawValue: "appletv.badge.exclamationmark.fill") }
 
     /// 􃊄
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -697,7 +697,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchBadgeCheckmark = SFSymbol(rawValue: "applewatch.badge.checkmark")
+    static var applewatchBadgeCheckmark: SFSymbol { .init(rawValue: "applewatch.badge.checkmark") }
 
     /// 􃔣
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -708,7 +708,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Watch.
-    static let applewatchBadgeExclamationmark = SFSymbol(rawValue: "applewatch.badge.exclamationmark")
+    static var applewatchBadgeExclamationmark: SFSymbol { .init(rawValue: "applewatch.badge.exclamationmark") }
 
     /// 􃍤
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -723,7 +723,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let appsIpadBadgeCheckmark = SymbolWith1Localization<Rtl>(rawValue: "apps.ipad.badge.checkmark")
+    static var appsIpadBadgeCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "apps.ipad.badge.checkmark") }
 
     /// 􀯗
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -734,7 +734,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let appsIpadBadgePlus = SFSymbol(rawValue: "apps.ipad.badge.plus")
+    static var appsIpadBadgePlus: SFSymbol { .init(rawValue: "apps.ipad.badge.plus") }
 
     /// 􂿬
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -748,7 +748,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let appsIpadOnRectanglePortraitDashed = SymbolWith1Localization<Rtl>(rawValue: "apps.ipad.on.rectangle.portrait.dashed")
+    static var appsIpadOnRectanglePortraitDashed: SymbolWith1Localization<Rtl> { .init(rawValue: "apps.ipad.on.rectangle.portrait.dashed") }
 
     /// 􃍢
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -763,7 +763,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let appsIphoneBadgeCheckmark = SymbolWith1Localization<Rtl>(rawValue: "apps.iphone.badge.checkmark")
+    static var appsIphoneBadgeCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "apps.iphone.badge.checkmark") }
 
     /// 􃂜
     /// Single Localization, 2 Layersets
@@ -771,7 +771,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let aqiMediumGaugeOpen = SFSymbol(rawValue: "aqi.medium.gauge.open")
+    static var aqiMediumGaugeOpen: SFSymbol { .init(rawValue: "aqi.medium.gauge.open") }
 
     /// 􃇖
     /// Single Localization, 3 Layersets
@@ -780,7 +780,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownCircleBadgePause = SFSymbol(rawValue: "arrow.down.circle.badge.pause")
+    static var arrowDownCircleBadgePause: SFSymbol { .init(rawValue: "arrow.down.circle.badge.pause") }
 
     /// 􃇗
     /// Single Localization, 3 Layersets
@@ -789,7 +789,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownCircleBadgePauseFill = SFSymbol(rawValue: "arrow.down.circle.badge.pause.fill")
+    static var arrowDownCircleBadgePauseFill: SFSymbol { .init(rawValue: "arrow.down.circle.badge.pause.fill") }
 
     /// 􃇚
     /// Single Localization, 3 Layersets
@@ -798,7 +798,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownCircleBadgeXmark = SFSymbol(rawValue: "arrow.down.circle.badge.xmark")
+    static var arrowDownCircleBadgeXmark: SFSymbol { .init(rawValue: "arrow.down.circle.badge.xmark") }
 
     /// 􃇛
     /// Single Localization, 3 Layersets
@@ -807,7 +807,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowDownCircleBadgeXmarkFill = SFSymbol(rawValue: "arrow.down.circle.badge.xmark.fill")
+    static var arrowDownCircleBadgeXmarkFill: SFSymbol { .init(rawValue: "arrow.down.circle.badge.xmark.fill") }
 
     /// 􃀩
     /// 2 Localizations, 2 Layersets
@@ -819,7 +819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowForwardFolder = SymbolWith1Localization<Rtl>(rawValue: "arrow.forward.folder")
+    static var arrowForwardFolder: SymbolWith1Localization<Rtl> { .init(rawValue: "arrow.forward.folder") }
 
     /// 􃀪
     /// 2 Localizations, 3 Layersets
@@ -832,14 +832,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowForwardFolderFill = SymbolWith1Localization<Rtl>(rawValue: "arrow.forward.folder.fill")
+    static var arrowForwardFolderFill: SymbolWith1Localization<Rtl> { .init(rawValue: "arrow.forward.folder.fill") }
 
     /// 􀙝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let arrowTriangleheadTurnUpRight = SFSymbol(rawValue: "arrow.trianglehead.turn.up.right")
+    static var arrowTriangleheadTurnUpRight: SFSymbol { .init(rawValue: "arrow.trianglehead.turn.up.right") }
 
     /// 􃀧
     /// Single Localization, 2 Layersets
@@ -847,7 +847,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let arrowUpFolder = SFSymbol(rawValue: "arrow.up.folder")
+    static var arrowUpFolder: SFSymbol { .init(rawValue: "arrow.up.folder") }
 
     /// 􃀨
     /// Single Localization, 3 Layersets
@@ -856,7 +856,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let arrowUpFolderFill = SFSymbol(rawValue: "arrow.up.folder.fill")
+    static var arrowUpFolderFill: SFSymbol { .init(rawValue: "arrow.up.folder.fill") }
 
     /// 􃀷
     /// Single Localization, 2 Layersets
@@ -864,7 +864,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let backpackSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "backpack.sensor.tag.radiowaves.left.and.right")
+    static var backpackSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "backpack.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀸
     /// Single Localization, 3 Layersets
@@ -873,7 +873,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let backpackSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "backpack.sensor.tag.radiowaves.left.and.right.fill")
+    static var backpackSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "backpack.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃍏
     /// Single Localization, 3 Layersets
@@ -882,7 +882,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bedDoubleBadgeCheckmark = SFSymbol(rawValue: "bed.double.badge.checkmark")
+    static var bedDoubleBadgeCheckmark: SFSymbol { .init(rawValue: "bed.double.badge.checkmark") }
 
     /// 􃍐
     /// Single Localization, 3 Layersets
@@ -891,7 +891,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bedDoubleBadgeCheckmarkFill = SFSymbol(rawValue: "bed.double.badge.checkmark.fill")
+    static var bedDoubleBadgeCheckmarkFill: SFSymbol { .init(rawValue: "bed.double.badge.checkmark.fill") }
 
     /// 􁈍
     /// Single Localization, 2 Layersets
@@ -899,7 +899,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bellBadgeWaveformSlash = SFSymbol(rawValue: "bell.badge.waveform.slash")
+    static var bellBadgeWaveformSlash: SFSymbol { .init(rawValue: "bell.badge.waveform.slash") }
 
     /// 􁈎
     /// Single Localization, 2 Layersets
@@ -907,7 +907,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bellBadgeWaveformSlashFill = SFSymbol(rawValue: "bell.badge.waveform.slash.fill")
+    static var bellBadgeWaveformSlashFill: SFSymbol { .init(rawValue: "bell.badge.waveform.slash.fill") }
 
     /// 􃀹
     /// Single Localization, 2 Layersets
@@ -915,7 +915,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let bicycleSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "bicycle.sensor.tag.radiowaves.left.and.right")
+    static var bicycleSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "bicycle.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀺
     /// Single Localization, 3 Layersets
@@ -924,14 +924,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bicycleSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "bicycle.sensor.tag.radiowaves.left.and.right.fill")
+    static var bicycleSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "bicycle.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃔛
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bloodPressureCuff = SFSymbol(rawValue: "blood.pressure.cuff")
+    static var bloodPressureCuff: SFSymbol { .init(rawValue: "blood.pressure.cuff") }
 
     /// 􃓻
     /// Single Localization, 3 Layersets
@@ -940,7 +940,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bloodPressureCuffBadgeGaugeWithNeedle = SFSymbol(rawValue: "blood.pressure.cuff.badge.gauge.with.needle")
+    static var bloodPressureCuffBadgeGaugeWithNeedle: SFSymbol { .init(rawValue: "blood.pressure.cuff.badge.gauge.with.needle") }
 
     /// 􃓼
     /// Single Localization, 3 Layersets
@@ -949,14 +949,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bloodPressureCuffBadgeGaugeWithNeedleFill = SFSymbol(rawValue: "blood.pressure.cuff.badge.gauge.with.needle.fill")
+    static var bloodPressureCuffBadgeGaugeWithNeedleFill: SFSymbol { .init(rawValue: "blood.pressure.cuff.badge.gauge.with.needle.fill") }
 
     /// 􃔜
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let bloodPressureCuffFill = SFSymbol(rawValue: "blood.pressure.cuff.fill")
+    static var bloodPressureCuffFill: SFSymbol { .init(rawValue: "blood.pressure.cuff.fill") }
 
     /// 􃑏
     /// Single Localization, 3 Layersets
@@ -965,7 +965,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bookBadgePlus = SFSymbol(rawValue: "book.badge.plus")
+    static var bookBadgePlus: SFSymbol { .init(rawValue: "book.badge.plus") }
 
     /// 􃑐
     /// Single Localization, 3 Layersets
@@ -974,7 +974,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let bookBadgePlusFill = SFSymbol(rawValue: "book.badge.plus.fill")
+    static var bookBadgePlusFill: SFSymbol { .init(rawValue: "book.badge.plus.fill") }
 
     /// 􃀱
     /// Single Localization, 2 Layersets
@@ -982,7 +982,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let briefcaseSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "briefcase.sensor.tag.radiowaves.left.and.right")
+    static var briefcaseSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "briefcase.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀲
     /// Single Localization, 3 Layersets
@@ -991,7 +991,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let briefcaseSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "briefcase.sensor.tag.radiowaves.left.and.right.fill")
+    static var briefcaseSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "briefcase.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􂭿
     /// Single Localization, 3 Layersets
@@ -1000,7 +1000,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarBadge = SFSymbol(rawValue: "calendar.badge")
+    static var calendarBadge: SFSymbol { .init(rawValue: "calendar.badge") }
 
     /// 􃂂
     /// Single Localization, 3 Layersets
@@ -1009,7 +1009,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarBadgeLock = SFSymbol(rawValue: "calendar.badge.lock")
+    static var calendarBadgeLock: SFSymbol { .init(rawValue: "calendar.badge.lock") }
 
     /// 􃌄
     /// Single Localization, 2 Layersets
@@ -1017,7 +1017,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let calendarDayTimelineLeadingCircle = SFSymbol(rawValue: "calendar.day.timeline.leading.circle")
+    static var calendarDayTimelineLeadingCircle: SFSymbol { .init(rawValue: "calendar.day.timeline.leading.circle") }
 
     /// 􃌅
     /// Single Localization, 3 Layersets
@@ -1026,7 +1026,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineLeadingCircleFill = SFSymbol(rawValue: "calendar.day.timeline.leading.circle.fill")
+    static var calendarDayTimelineLeadingCircleFill: SFSymbol { .init(rawValue: "calendar.day.timeline.leading.circle.fill") }
 
     /// 􃋶
     /// Single Localization, 2 Layersets
@@ -1034,7 +1034,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let calendarDayTimelineLeftCircle = SFSymbol(rawValue: "calendar.day.timeline.left.circle")
+    static var calendarDayTimelineLeftCircle: SFSymbol { .init(rawValue: "calendar.day.timeline.left.circle") }
 
     /// 􃋷
     /// Single Localization, 3 Layersets
@@ -1043,7 +1043,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineLeftCircleFill = SFSymbol(rawValue: "calendar.day.timeline.left.circle.fill")
+    static var calendarDayTimelineLeftCircleFill: SFSymbol { .init(rawValue: "calendar.day.timeline.left.circle.fill") }
 
     /// 􃋸
     /// Single Localization, 2 Layersets
@@ -1051,7 +1051,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let calendarDayTimelineRightCircle = SFSymbol(rawValue: "calendar.day.timeline.right.circle")
+    static var calendarDayTimelineRightCircle: SFSymbol { .init(rawValue: "calendar.day.timeline.right.circle") }
 
     /// 􃋹
     /// Single Localization, 3 Layersets
@@ -1060,7 +1060,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineRightCircleFill = SFSymbol(rawValue: "calendar.day.timeline.right.circle.fill")
+    static var calendarDayTimelineRightCircleFill: SFSymbol { .init(rawValue: "calendar.day.timeline.right.circle.fill") }
 
     /// 􃌆
     /// Single Localization, 2 Layersets
@@ -1068,7 +1068,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let calendarDayTimelineTrailingCircle = SFSymbol(rawValue: "calendar.day.timeline.trailing.circle")
+    static var calendarDayTimelineTrailingCircle: SFSymbol { .init(rawValue: "calendar.day.timeline.trailing.circle") }
 
     /// 􃌇
     /// Single Localization, 3 Layersets
@@ -1077,7 +1077,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let calendarDayTimelineTrailingCircleFill = SFSymbol(rawValue: "calendar.day.timeline.trailing.circle.fill")
+    static var calendarDayTimelineTrailingCircleFill: SFSymbol { .init(rawValue: "calendar.day.timeline.trailing.circle.fill") }
 
     /// 􃀻
     /// Single Localization, 2 Layersets
@@ -1085,7 +1085,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cameraSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "camera.sensor.tag.radiowaves.left.and.right")
+    static var cameraSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "camera.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀼
     /// Single Localization, 3 Layersets
@@ -1094,7 +1094,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cameraSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "camera.sensor.tag.radiowaves.left.and.right.fill")
+    static var cameraSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "camera.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃕊
     /// Single Localization, 2 Layersets
@@ -1102,7 +1102,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carRearRoadLaneDashedArrowtriangle2Outward = SFSymbol(rawValue: "car.rear.road.lane.dashed.arrowtriangle.2.outward")
+    static var carRearRoadLaneDashedArrowtriangle2Outward: SFSymbol { .init(rawValue: "car.rear.road.lane.dashed.arrowtriangle.2.outward") }
 
     /// 􃖄
     /// Single Localization, 2 Layersets
@@ -1110,7 +1110,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowLeftBadgeLock = SFSymbol(rawValue: "car.window.left.badge.lock")
+    static var carWindowLeftBadgeLock: SFSymbol { .init(rawValue: "car.window.left.badge.lock") }
 
     /// 􃕋
     /// Single Localization, 2 Layersets
@@ -1118,7 +1118,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let carWindowRightBadgeLock = SFSymbol(rawValue: "car.window.right.badge.lock")
+    static var carWindowRightBadgeLock: SFSymbol { .init(rawValue: "car.window.right.badge.lock") }
 
     /// 􃋺
     /// Single Localization, 2 Layersets
@@ -1126,7 +1126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cellularbarsCircle = SFSymbol(rawValue: "cellularbars.circle")
+    static var cellularbarsCircle: SFSymbol { .init(rawValue: "cellularbars.circle") }
 
     /// 􃋻
     /// Single Localization, 3 Layersets
@@ -1135,7 +1135,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cellularbarsCircleFill = SFSymbol(rawValue: "cellularbars.circle.fill")
+    static var cellularbarsCircleFill: SFSymbol { .init(rawValue: "cellularbars.circle.fill") }
 
     /// 􃅗
     /// 19 Localizations, 2 Layersets
@@ -1164,7 +1164,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let characterTextJustify = SymbolWith18Localizations<Ar, Bn, Gu, He, Hi, Ja, Kn, Ko, Ml, Mni, Mr, Or, Pa, Sat, Si, Ta, Th, Zh>(rawValue: "character.text.justify")
+    static var characterTextJustify: SymbolWith18Localizations<Ar, Bn, Gu, He, Hi, Ja, Kn, Ko, Ml, Mni, Mr, Or, Pa, Sat, Si, Ta, Th, Zh> { .init(rawValue: "character.text.justify") }
 
     /// 􃒊
     /// Single Localization, 2 Layersets
@@ -1172,7 +1172,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let chartBarXaxisDescending = SFSymbol(rawValue: "chart.bar.xaxis.descending")
+    static var chartBarXaxisDescending: SFSymbol { .init(rawValue: "chart.bar.xaxis.descending") }
 
     /// 􂿲
     /// Single Localization, 2 Layersets
@@ -1180,7 +1180,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkApp = SFSymbol(rawValue: "checkmark.app")
+    static var checkmarkApp: SFSymbol { .init(rawValue: "checkmark.app") }
 
     /// 􂿳
     /// Single Localization, 3 Layersets
@@ -1189,7 +1189,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkAppFill = SFSymbol(rawValue: "checkmark.app.fill")
+    static var checkmarkAppFill: SFSymbol { .init(rawValue: "checkmark.app.fill") }
 
     /// 􃇽
     /// Single Localization, 2 Layersets
@@ -1197,7 +1197,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkArrowTriangleheadClockwise = SFSymbol(rawValue: "checkmark.arrow.trianglehead.clockwise")
+    static var checkmarkArrowTriangleheadClockwise: SFSymbol { .init(rawValue: "checkmark.arrow.trianglehead.clockwise") }
 
     /// 􃋄
     /// Single Localization, 2 Layersets
@@ -1205,7 +1205,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkCircleBadgeAirplane = SFSymbol(rawValue: "checkmark.circle.badge.airplane")
+    static var checkmarkCircleBadgeAirplane: SFSymbol { .init(rawValue: "checkmark.circle.badge.airplane") }
 
     /// 􃋅
     /// Single Localization, 2 Layersets
@@ -1213,7 +1213,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkCircleBadgeAirplaneFill = SFSymbol(rawValue: "checkmark.circle.badge.airplane.fill")
+    static var checkmarkCircleBadgeAirplaneFill: SFSymbol { .init(rawValue: "checkmark.circle.badge.airplane.fill") }
 
     /// 􃈆
     /// Single Localization, 3 Layersets
@@ -1222,7 +1222,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgePlus = SFSymbol(rawValue: "checkmark.circle.badge.plus")
+    static var checkmarkCircleBadgePlus: SFSymbol { .init(rawValue: "checkmark.circle.badge.plus") }
 
     /// 􃈇
     /// Single Localization, 3 Layersets
@@ -1231,7 +1231,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleBadgePlusFill = SFSymbol(rawValue: "checkmark.circle.badge.plus.fill")
+    static var checkmarkCircleBadgePlusFill: SFSymbol { .init(rawValue: "checkmark.circle.badge.plus.fill") }
 
     /// 􃑹
     /// Single Localization, 2 Layersets
@@ -1239,7 +1239,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let checkmarkCircleDotted = SFSymbol(rawValue: "checkmark.circle.dotted")
+    static var checkmarkCircleDotted: SFSymbol { .init(rawValue: "checkmark.circle.dotted") }
 
     /// 􃋂
     /// Single Localization, 3 Layersets
@@ -1248,7 +1248,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let checkmarkCircleTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "checkmark.circle.trianglebadge.exclamationmark.fill")
+    static var checkmarkCircleTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "checkmark.circle.trianglebadge.exclamationmark.fill") }
 
     /// 􂿪
     /// Single Localization, 3 Layersets
@@ -1257,7 +1257,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let circleGrid2x2TopleftCheckmarkFilled = SFSymbol(rawValue: "circle.grid.2x2.topleft.checkmark.filled")
+    static var circleGrid2x2TopleftCheckmarkFilled: SFSymbol { .init(rawValue: "circle.grid.2x2.topleft.checkmark.filled") }
 
     /// 􃎷
     /// Single Localization, 2 Layersets
@@ -1265,7 +1265,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleOnSquare = SFSymbol(rawValue: "circle.on.square")
+    static var circleOnSquare: SFSymbol { .init(rawValue: "circle.on.square") }
 
     /// 􃏁
     /// Single Localization, 2 Layersets
@@ -1273,14 +1273,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let circleOnSquareIntersectionDotted = SFSymbol(rawValue: "circle.on.square.intersection.dotted")
+    static var circleOnSquareIntersectionDotted: SFSymbol { .init(rawValue: "circle.on.square.intersection.dotted") }
 
     /// 􃎹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let circleOnSquareMerge = SFSymbol(rawValue: "circle.on.square.merge")
+    static var circleOnSquareMerge: SFSymbol { .init(rawValue: "circle.on.square.merge") }
 
     /// 􃋐
     /// Single Localization, 2 Layersets
@@ -1288,7 +1288,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockArrowTriangleheadClockwiseRotate90PathDotted = SFSymbol(rawValue: "clock.arrow.trianglehead.clockwise.rotate.90.path.dotted")
+    static var clockArrowTriangleheadClockwiseRotate90PathDotted: SFSymbol { .init(rawValue: "clock.arrow.trianglehead.clockwise.rotate.90.path.dotted") }
 
     /// 􃋌
     /// Single Localization, 2 Layersets
@@ -1296,7 +1296,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockBadgeAirplane = SFSymbol(rawValue: "clock.badge.airplane")
+    static var clockBadgeAirplane: SFSymbol { .init(rawValue: "clock.badge.airplane") }
 
     /// 􃋍
     /// Single Localization, 2 Layersets
@@ -1304,7 +1304,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let clockBadgeAirplaneFill = SFSymbol(rawValue: "clock.badge.airplane.fill")
+    static var clockBadgeAirplaneFill: SFSymbol { .init(rawValue: "clock.badge.airplane.fill") }
 
     /// 􃁋
     /// Single Localization, 2 Layersets
@@ -1312,7 +1312,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let coatCircle = SFSymbol(rawValue: "coat.circle")
+    static var coatCircle: SFSymbol { .init(rawValue: "coat.circle") }
 
     /// 􃁌
     /// Single Localization, 3 Layersets
@@ -1321,7 +1321,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let coatCircleFill = SFSymbol(rawValue: "coat.circle.fill")
+    static var coatCircleFill: SFSymbol { .init(rawValue: "coat.circle.fill") }
 
     /// 􀭈
     /// Single Localization, 2 Layersets
@@ -1329,7 +1329,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let contextualmenuAndPointerArrow = SFSymbol(rawValue: "contextualmenu.and.pointer.arrow")
+    static var contextualmenuAndPointerArrow: SFSymbol { .init(rawValue: "contextualmenu.and.pointer.arrow") }
 
     /// 􁂨
     /// Single Localization, 2 Layersets
@@ -1337,7 +1337,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let creditcardAndNumbers = SFSymbol(rawValue: "creditcard.and.numbers")
+    static var creditcardAndNumbers: SFSymbol { .init(rawValue: "creditcard.and.numbers") }
 
     /// 􃔩
     /// Single Localization, 2 Layersets
@@ -1345,21 +1345,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let creditcardArrowTrianglehead2ClockwiseRotate90 = SFSymbol(rawValue: "creditcard.arrow.trianglehead.2.clockwise.rotate.90")
+    static var creditcardArrowTrianglehead2ClockwiseRotate90: SFSymbol { .init(rawValue: "creditcard.arrow.trianglehead.2.clockwise.rotate.90") }
 
     /// 􃈕
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let creditcardRewards = SFSymbol(rawValue: "creditcard.rewards")
+    static var creditcardRewards: SFSymbol { .init(rawValue: "creditcard.rewards") }
 
     /// 􃈖
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let creditcardRewardsFill = SFSymbol(rawValue: "creditcard.rewards.fill")
+    static var creditcardRewardsFill: SFSymbol { .init(rawValue: "creditcard.rewards.fill") }
 
     /// 􃅓
     /// Single Localization, 2 Layersets
@@ -1367,7 +1367,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let cubeCircle = SFSymbol(rawValue: "cube.circle")
+    static var cubeCircle: SFSymbol { .init(rawValue: "cube.circle") }
 
     /// 􃅔
     /// Single Localization, 3 Layersets
@@ -1376,7 +1376,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let cubeCircleFill = SFSymbol(rawValue: "cube.circle.fill")
+    static var cubeCircleFill: SFSymbol { .init(rawValue: "cube.circle.fill") }
 
     /// 􃉞
     /// Single Localization, 3 Layersets
@@ -1385,7 +1385,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let desktopcomputerBadgeCheckmark = SFSymbol(rawValue: "desktopcomputer.badge.checkmark")
+    static var desktopcomputerBadgeCheckmark: SFSymbol { .init(rawValue: "desktopcomputer.badge.checkmark") }
 
     /// 􃊆
     /// Single Localization, 3 Layersets
@@ -1394,7 +1394,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let desktopcomputerBadgeShieldCheckmark = SFSymbol(rawValue: "desktopcomputer.badge.shield.checkmark")
+    static var desktopcomputerBadgeShieldCheckmark: SFSymbol { .init(rawValue: "desktopcomputer.badge.shield.checkmark") }
 
     /// 􃒘
     /// Single Localization, 2 Layersets
@@ -1402,7 +1402,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let displayAndScrewdriver = SFSymbol(rawValue: "display.and.screwdriver")
+    static var displayAndScrewdriver: SFSymbol { .init(rawValue: "display.and.screwdriver") }
 
     /// 􁣊
     /// Single Localization, 2 Layersets
@@ -1410,7 +1410,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentOnTrash = SFSymbol(rawValue: "document.on.trash")
+    static var documentOnTrash: SFSymbol { .init(rawValue: "document.on.trash") }
 
     /// 􁣋
     /// Single Localization, 2 Layersets
@@ -1418,7 +1418,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let documentOnTrashFill = SFSymbol(rawValue: "document.on.trash.fill")
+    static var documentOnTrashFill: SFSymbol { .init(rawValue: "document.on.trash.fill") }
 
     /// 􀫍
     /// Single Localization, 2 Layersets
@@ -1426,7 +1426,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCircleAndPointerArrow = SFSymbol(rawValue: "dot.circle.and.pointer.arrow")
+    static var dotCircleAndPointerArrow: SFSymbol { .init(rawValue: "dot.circle.and.pointer.arrow") }
 
     /// 􃆮
     /// Single Localization, 2 Layersets
@@ -1434,7 +1434,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotCrosshair = SFSymbol(rawValue: "dot.crosshair")
+    static var dotCrosshair: SFSymbol { .init(rawValue: "dot.crosshair") }
 
     /// 􁑢
     /// Single Localization, 2 Layersets
@@ -1442,7 +1442,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let dotsAndLineVerticalAndPointerArrowRectangle = SFSymbol(rawValue: "dots.and.line.vertical.and.pointer.arrow.rectangle")
+    static var dotsAndLineVerticalAndPointerArrowRectangle: SFSymbol { .init(rawValue: "dots.and.line.vertical.and.pointer.arrow.rectangle") }
 
     /// 􃀍
     /// Single Localization, 2 Layersets
@@ -1450,7 +1450,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudLeft = SFSymbol(rawValue: "earbud.left")
+    static var earbudLeft: SFSymbol { .init(rawValue: "earbud.left") }
 
     /// 􃀌
     /// Single Localization, 2 Layersets
@@ -1458,28 +1458,28 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudRight = SFSymbol(rawValue: "earbud.right")
+    static var earbudRight: SFSymbol { .init(rawValue: "earbud.right") }
 
     /// 􃍝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let earbudsBoneConduction = SFSymbol(rawValue: "earbuds.bone.conduction")
+    static var earbudsBoneConduction: SFSymbol { .init(rawValue: "earbuds.bone.conduction") }
 
     /// 􃍟
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let earbudsBoneConductionLeft = SFSymbol(rawValue: "earbuds.bone.conduction.left")
+    static var earbudsBoneConductionLeft: SFSymbol { .init(rawValue: "earbuds.bone.conduction.left") }
 
     /// 􃍞
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let earbudsBoneConductionRight = SFSymbol(rawValue: "earbuds.bone.conduction.right")
+    static var earbudsBoneConductionRight: SFSymbol { .init(rawValue: "earbuds.bone.conduction.right") }
 
     /// 􃍓
     /// Single Localization, 2 Layersets
@@ -1487,7 +1487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsInEar = SFSymbol(rawValue: "earbuds.in.ear")
+    static var earbudsInEar: SFSymbol { .init(rawValue: "earbuds.in.ear") }
 
     /// 􃍕
     /// Single Localization, 2 Layersets
@@ -1495,7 +1495,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsInEarLeft = SFSymbol(rawValue: "earbuds.in.ear.left")
+    static var earbudsInEarLeft: SFSymbol { .init(rawValue: "earbuds.in.ear.left") }
 
     /// 􃍔
     /// Single Localization, 2 Layersets
@@ -1503,7 +1503,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsInEarRight = SFSymbol(rawValue: "earbuds.in.ear.right")
+    static var earbudsInEarRight: SFSymbol { .init(rawValue: "earbuds.in.ear.right") }
 
     /// 􃍆
     /// Single Localization, 2 Layersets
@@ -1511,7 +1511,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsStemless = SFSymbol(rawValue: "earbuds.stemless")
+    static var earbudsStemless: SFSymbol { .init(rawValue: "earbuds.stemless") }
 
     /// 􃍈
     /// Single Localization, 2 Layersets
@@ -1519,7 +1519,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsStemlessLeft = SFSymbol(rawValue: "earbuds.stemless.left")
+    static var earbudsStemlessLeft: SFSymbol { .init(rawValue: "earbuds.stemless.left") }
 
     /// 􃍇
     /// Single Localization, 2 Layersets
@@ -1527,7 +1527,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let earbudsStemlessRight = SFSymbol(rawValue: "earbuds.stemless.right")
+    static var earbudsStemlessRight: SFSymbol { .init(rawValue: "earbuds.stemless.right") }
 
     /// 􃏝
     /// Single Localization, 2 Layersets
@@ -1535,7 +1535,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ellipsisCalendar = SFSymbol(rawValue: "ellipsis.calendar")
+    static var ellipsisCalendar: SFSymbol { .init(rawValue: "ellipsis.calendar") }
 
     /// 􃈗
     /// Single Localization, 3 Layersets
@@ -1544,7 +1544,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ellipsisCircleBadge = SFSymbol(rawValue: "ellipsis.circle.badge")
+    static var ellipsisCircleBadge: SFSymbol { .init(rawValue: "ellipsis.circle.badge") }
 
     /// 􃈘
     /// Single Localization, 3 Layersets
@@ -1553,7 +1553,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ellipsisCircleBadgeFill = SFSymbol(rawValue: "ellipsis.circle.badge.fill")
+    static var ellipsisCircleBadgeFill: SFSymbol { .init(rawValue: "ellipsis.circle.badge.fill") }
 
     /// 􃍸
     /// Single Localization, 2 Layersets
@@ -1561,7 +1561,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndHandRaised = SFSymbol(rawValue: "envelope.and.hand.raised")
+    static var envelopeAndHandRaised: SFSymbol { .init(rawValue: "envelope.and.hand.raised") }
 
     /// 􃍹
     /// Single Localization, 2 Layersets
@@ -1569,7 +1569,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let envelopeAndHandRaisedFill = SFSymbol(rawValue: "envelope.and.hand.raised.fill")
+    static var envelopeAndHandRaisedFill: SFSymbol { .init(rawValue: "envelope.and.hand.raised.fill") }
 
     /// 􃈵
     /// Single Localization, 3 Layersets
@@ -1578,7 +1578,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgeMinus = SFSymbol(rawValue: "envelope.badge.minus")
+    static var envelopeBadgeMinus: SFSymbol { .init(rawValue: "envelope.badge.minus") }
 
     /// 􃈶
     /// Single Localization, 3 Layersets
@@ -1587,7 +1587,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgeMinusFill = SFSymbol(rawValue: "envelope.badge.minus.fill")
+    static var envelopeBadgeMinusFill: SFSymbol { .init(rawValue: "envelope.badge.minus.fill") }
 
     /// 􃈳
     /// Single Localization, 3 Layersets
@@ -1596,7 +1596,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgePlus = SFSymbol(rawValue: "envelope.badge.plus")
+    static var envelopeBadgePlus: SFSymbol { .init(rawValue: "envelope.badge.plus") }
 
     /// 􃈴
     /// Single Localization, 3 Layersets
@@ -1605,7 +1605,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeBadgePlusFill = SFSymbol(rawValue: "envelope.badge.plus.fill")
+    static var envelopeBadgePlusFill: SFSymbol { .init(rawValue: "envelope.badge.plus.fill") }
 
     /// 􃑭
     /// Single Localization, 3 Layersets
@@ -1614,7 +1614,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let envelopeOpenBadgeClockFill = SFSymbol(rawValue: "envelope.open.badge.clock.fill")
+    static var envelopeOpenBadgeClockFill: SFSymbol { .init(rawValue: "envelope.open.badge.clock.fill") }
 
     /// 􂀚
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1624,7 +1624,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environments = SFSymbol(rawValue: "environments")
+    static var environments: SFSymbol { .init(rawValue: "environments") }
 
     /// 􂀜
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1634,7 +1634,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsCircle = SFSymbol(rawValue: "environments.circle")
+    static var environmentsCircle: SFSymbol { .init(rawValue: "environments.circle") }
 
     /// 􂀝
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1645,7 +1645,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsCircleFill = SFSymbol(rawValue: "environments.circle.fill")
+    static var environmentsCircleFill: SFSymbol { .init(rawValue: "environments.circle.fill") }
 
     /// 􀬮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1655,7 +1655,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsFill = SFSymbol(rawValue: "environments.fill")
+    static var environmentsFill: SFSymbol { .init(rawValue: "environments.fill") }
 
     /// 􂁚
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1665,7 +1665,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsSlash = SFSymbol(rawValue: "environments.slash")
+    static var environmentsSlash: SFSymbol { .init(rawValue: "environments.slash") }
 
     /// 􂀞
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1675,7 +1675,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsSlashCircle = SFSymbol(rawValue: "environments.slash.circle")
+    static var environmentsSlashCircle: SFSymbol { .init(rawValue: "environments.slash.circle") }
 
     /// 􂀟
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -1686,7 +1686,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsSlashCircleFill = SFSymbol(rawValue: "environments.slash.circle.fill")
+    static var environmentsSlashCircleFill: SFSymbol { .init(rawValue: "environments.slash.circle.fill") }
 
     /// 􁦅
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -1696,7 +1696,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
-    static let environmentsSlashFill = SFSymbol(rawValue: "environments.slash.fill")
+    static var environmentsSlashFill: SFSymbol { .init(rawValue: "environments.slash.fill") }
 
     /// 􃁕
     /// Single Localization, 3 Layersets
@@ -1705,7 +1705,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eraserBadgeXmark = SFSymbol(rawValue: "eraser.badge.xmark")
+    static var eraserBadgeXmark: SFSymbol { .init(rawValue: "eraser.badge.xmark") }
 
     /// 􃁖
     /// Single Localization, 3 Layersets
@@ -1714,7 +1714,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eraserBadgeXmarkFill = SFSymbol(rawValue: "eraser.badge.xmark.fill")
+    static var eraserBadgeXmarkFill: SFSymbol { .init(rawValue: "eraser.badge.xmark.fill") }
 
     /// 􃁙
     /// Single Localization, 2 Layersets
@@ -1722,7 +1722,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eraserSlash = SFSymbol(rawValue: "eraser.slash")
+    static var eraserSlash: SFSymbol { .init(rawValue: "eraser.slash") }
 
     /// 􃁚
     /// Single Localization, 2 Layersets
@@ -1730,7 +1730,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let eraserSlashFill = SFSymbol(rawValue: "eraser.slash.fill")
+    static var eraserSlashFill: SFSymbol { .init(rawValue: "eraser.slash.fill") }
 
     /// 􃁗
     /// Single Localization, 3 Layersets
@@ -1739,7 +1739,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eraserTrianglebadgeExclamationmark = SFSymbol(rawValue: "eraser.trianglebadge.exclamationmark")
+    static var eraserTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "eraser.trianglebadge.exclamationmark") }
 
     /// 􃁘
     /// Single Localization, 3 Layersets
@@ -1748,21 +1748,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let eraserTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "eraser.trianglebadge.exclamationmark.fill")
+    static var eraserTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "eraser.trianglebadge.exclamationmark.fill") }
 
     /// 􂽁
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyeHalfClosed = SFSymbol(rawValue: "eye.half.closed")
+    static var eyeHalfClosed: SFSymbol { .init(rawValue: "eye.half.closed") }
 
     /// 􂽂
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let eyeHalfClosedFill = SFSymbol(rawValue: "eye.half.closed.fill")
+    static var eyeHalfClosedFill: SFSymbol { .init(rawValue: "eye.half.closed.fill") }
 
     /// 􃒌
     /// Single Localization, 2 Layersets
@@ -1770,7 +1770,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fCursiveSlash = SFSymbol(rawValue: "f.cursive.slash")
+    static var fCursiveSlash: SFSymbol { .init(rawValue: "f.cursive.slash") }
 
     /// 􃄻
     /// Single Localization, 2 Layersets
@@ -1778,7 +1778,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanBadgeArrowUpAndDownAndArrowLeftAndRight = SFSymbol(rawValue: "fan.badge.arrow.up.and.down.and.arrow.left.and.right")
+    static var fanBadgeArrowUpAndDownAndArrowLeftAndRight: SFSymbol { .init(rawValue: "fan.badge.arrow.up.and.down.and.arrow.left.and.right") }
 
     /// 􃄼
     /// Single Localization, 2 Layersets
@@ -1786,7 +1786,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanBadgeArrowUpAndDownAndArrowLeftAndRightFill = SFSymbol(rawValue: "fan.badge.arrow.up.and.down.and.arrow.left.and.right.fill")
+    static var fanBadgeArrowUpAndDownAndArrowLeftAndRightFill: SFSymbol { .init(rawValue: "fan.badge.arrow.up.and.down.and.arrow.left.and.right.fill") }
 
     /// 􃂢
     /// Single Localization, 2 Layersets
@@ -1794,7 +1794,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanCircle = SFSymbol(rawValue: "fan.circle")
+    static var fanCircle: SFSymbol { .init(rawValue: "fan.circle") }
 
     /// 􃂣
     /// Single Localization, 3 Layersets
@@ -1803,7 +1803,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let fanCircleFill = SFSymbol(rawValue: "fan.circle.fill")
+    static var fanCircleFill: SFSymbol { .init(rawValue: "fan.circle.fill") }
 
     /// 􃂞
     /// Single Localization, 2 Layersets
@@ -1811,7 +1811,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let fanGaugeOpen = SFSymbol(rawValue: "fan.gauge.open")
+    static var fanGaugeOpen: SFSymbol { .init(rawValue: "fan.gauge.open") }
 
     /// 􃅃
     /// Single Localization, 2 Layersets
@@ -1819,7 +1819,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionIndirect = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.indirect")
+    static var figureSeatedSideLeftAirDistributionIndirect: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.indirect") }
 
     /// 􃄿
     /// Single Localization, 2 Layersets
@@ -1827,7 +1827,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionLowerAngledAndUpperAngled = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.lower.angled.and.upper.angled")
+    static var figureSeatedSideLeftAirDistributionLowerAngledAndUpperAngled: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.lower.angled.and.upper.angled") }
 
     /// 􃅁
     /// Single Localization, 2 Layersets
@@ -1835,7 +1835,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideLeftAirDistributionUpperAngledAndDottedlineAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.dottedline.and.lower.angled")
+    static var figureSeatedSideLeftAirDistributionUpperAngledAndDottedlineAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.left.air.distribution.upper.angled.and.dottedline.and.lower.angled") }
 
     /// 􃅄
     /// Single Localization, 2 Layersets
@@ -1843,7 +1843,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionIndirect = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.indirect")
+    static var figureSeatedSideRightAirDistributionIndirect: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.indirect") }
 
     /// 􃅀
     /// Single Localization, 2 Layersets
@@ -1851,7 +1851,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionLowerAngledAndUpperAngled = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.lower.angled.and.upper.angled")
+    static var figureSeatedSideRightAirDistributionLowerAngledAndUpperAngled: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.lower.angled.and.upper.angled") }
 
     /// 􃅂
     /// Single Localization, 2 Layersets
@@ -1859,21 +1859,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureSeatedSideRightAirDistributionUpperAngledAndDottedlineAndLowerAngled = SFSymbol(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.dottedline.and.lower.angled")
+    static var figureSeatedSideRightAirDistributionUpperAngledAndDottedlineAndLowerAngled: SFSymbol { .init(rawValue: "figure.seated.side.right.air.distribution.upper.angled.and.dottedline.and.lower.angled") }
 
     /// 􃌐
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureSeatedSideRightChildLap = SFSymbol(rawValue: "figure.seated.side.right.child.lap")
+    static var figureSeatedSideRightChildLap: SFSymbol { .init(rawValue: "figure.seated.side.right.child.lap") }
 
     /// 􃋱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let figureWalkSuitcaseRolling = SFSymbol(rawValue: "figure.walk.suitcase.rolling")
+    static var figureWalkSuitcaseRolling: SFSymbol { .init(rawValue: "figure.walk.suitcase.rolling") }
 
     /// 􃋲
     /// Single Localization, 2 Layersets
@@ -1881,7 +1881,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let figureWalkSuitcaseRollingCircle = SFSymbol(rawValue: "figure.walk.suitcase.rolling.circle")
+    static var figureWalkSuitcaseRollingCircle: SFSymbol { .init(rawValue: "figure.walk.suitcase.rolling.circle") }
 
     /// 􃋳
     /// Single Localization, 3 Layersets
@@ -1890,7 +1890,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let figureWalkSuitcaseRollingCircleFill = SFSymbol(rawValue: "figure.walk.suitcase.rolling.circle.fill")
+    static var figureWalkSuitcaseRollingCircleFill: SFSymbol { .init(rawValue: "figure.walk.suitcase.rolling.circle.fill") }
 
     /// 􀯪
     /// 2 Localizations, 2 Layersets
@@ -1902,7 +1902,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let filemenuAndPointerArrow = SymbolWith1Localization<Rtl>(rawValue: "filemenu.and.pointer.arrow")
+    static var filemenuAndPointerArrow: SymbolWith1Localization<Rtl> { .init(rawValue: "filemenu.and.pointer.arrow") }
 
     /// 􀥯
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -1911,7 +1911,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple's Finder app.
-    static let finder = SFSymbol(rawValue: "finder")
+    static var finder: SFSymbol { .init(rawValue: "finder") }
 
     /// 􃂝
     /// Single Localization, 2 Layersets
@@ -1919,42 +1919,42 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let flameGaugeOpen = SFSymbol(rawValue: "flame.gauge.open")
+    static var flameGaugeOpen: SFSymbol { .init(rawValue: "flame.gauge.open") }
 
     /// 􃄹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelpumpThermometer = SFSymbol(rawValue: "fuelpump.thermometer")
+    static var fuelpumpThermometer: SFSymbol { .init(rawValue: "fuelpump.thermometer") }
 
     /// 􃄺
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let fuelpumpThermometerFill = SFSymbol(rawValue: "fuelpump.thermometer.fill")
+    static var fuelpumpThermometerFill: SFSymbol { .init(rawValue: "fuelpump.thermometer.fill") }
 
     /// 􃊊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gaugeChartLefthalfRighthalf = SFSymbol(rawValue: "gauge.chart.lefthalf.righthalf")
+    static var gaugeChartLefthalfRighthalf: SFSymbol { .init(rawValue: "gauge.chart.lefthalf.righthalf") }
 
     /// 􃊋
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gaugeChartLeftthirdTopthirdRightthird = SFSymbol(rawValue: "gauge.chart.leftthird.topthird.rightthird")
+    static var gaugeChartLeftthirdTopthirdRightthird: SFSymbol { .init(rawValue: "gauge.chart.leftthird.topthird.rightthird") }
 
     /// 􃂄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let gaugeOpen = SFSymbol(rawValue: "gauge.open")
+    static var gaugeOpen: SFSymbol { .init(rawValue: "gauge.open") }
 
     /// 􂼑
     /// Single Localization, 2 Layersets
@@ -1962,7 +1962,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let gaugeOpenRighthalfDottedWithNeedleAndArrowTriangleheadBackward = SFSymbol(rawValue: "gauge.open.righthalf.dotted.with.needle.and.arrow.trianglehead.backward")
+    static var gaugeOpenRighthalfDottedWithNeedleAndArrowTriangleheadBackward: SFSymbol { .init(rawValue: "gauge.open.righthalf.dotted.with.needle.and.arrow.trianglehead.backward") }
 
     /// 􃑺
     /// Single Localization, 3 Layersets
@@ -1971,7 +1971,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let globeBadgeClock = SFSymbol(rawValue: "globe.badge.clock")
+    static var globeBadgeClock: SFSymbol { .init(rawValue: "globe.badge.clock") }
 
     /// 􃔇
     /// Single Localization, 3 Layersets
@@ -1980,14 +1980,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let globeBadgeClockFill = SFSymbol(rawValue: "globe.badge.clock.fill")
+    static var globeBadgeClockFill: SFSymbol { .init(rawValue: "globe.badge.clock.fill") }
 
     /// 􃁔
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let globeFill = SFSymbol(rawValue: "globe.fill")
+    static var globeFill: SFSymbol { .init(rawValue: "globe.fill") }
 
     /// 􃈟
     /// Single Localization, 2 Layersets
@@ -1995,7 +1995,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let graph2d = SFSymbol(rawValue: "graph.2d")
+    static var graph2d: SFSymbol { .init(rawValue: "graph.2d") }
 
     /// 􃈠
     /// Single Localization, 2 Layersets
@@ -2003,21 +2003,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let graph3d = SFSymbol(rawValue: "graph.3d")
+    static var graph3d: SFSymbol { .init(rawValue: "graph.3d") }
 
     /// 􃐉
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let guidepointHorizontal = SFSymbol(rawValue: "guidepoint.horizontal")
+    static var guidepointHorizontal: SFSymbol { .init(rawValue: "guidepoint.horizontal") }
 
     /// 􃕵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let guidepointVertical = SFSymbol(rawValue: "guidepoint.vertical")
+    static var guidepointVertical: SFSymbol { .init(rawValue: "guidepoint.vertical") }
 
     /// 􃂲
     /// Single Localization, 2 Layersets
@@ -2025,7 +2025,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guidepointVerticalArrowtriangleForward = SFSymbol(rawValue: "guidepoint.vertical.arrowtriangle.forward")
+    static var guidepointVerticalArrowtriangleForward: SFSymbol { .init(rawValue: "guidepoint.vertical.arrowtriangle.forward") }
 
     /// 􃂳
     /// Single Localization, 2 Layersets
@@ -2033,35 +2033,35 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let guidepointVerticalNumbers = SFSymbol(rawValue: "guidepoint.vertical.numbers")
+    static var guidepointVerticalNumbers: SFSymbol { .init(rawValue: "guidepoint.vertical.numbers") }
 
     /// 􃒆
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdownFilledHandThumbsup = SFSymbol(rawValue: "hand.thumbsdown.filled.hand.thumbsup")
+    static var handThumbsdownFilledHandThumbsup: SFSymbol { .init(rawValue: "hand.thumbsdown.filled.hand.thumbsup") }
 
     /// 􃒄
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdownHandThumbsup = SFSymbol(rawValue: "hand.thumbsdown.hand.thumbsup")
+    static var handThumbsdownHandThumbsup: SFSymbol { .init(rawValue: "hand.thumbsdown.hand.thumbsup") }
 
     /// 􃒅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdownHandThumbsupFill = SFSymbol(rawValue: "hand.thumbsdown.hand.thumbsup.fill")
+    static var handThumbsdownHandThumbsupFill: SFSymbol { .init(rawValue: "hand.thumbsdown.hand.thumbsup.fill") }
 
     /// 􃒇
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let handThumbsdownHandThumbsupFilled = SFSymbol(rawValue: "hand.thumbsdown.hand.thumbsup.filled")
+    static var handThumbsdownHandThumbsupFilled: SFSymbol { .init(rawValue: "hand.thumbsdown.hand.thumbsup.filled") }
 
     /// 􃀽
     /// Single Localization, 2 Layersets
@@ -2069,7 +2069,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let handbagSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "handbag.sensor.tag.radiowaves.left.and.right")
+    static var handbagSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "handbag.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀾
     /// Single Localization, 3 Layersets
@@ -2078,14 +2078,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let handbagSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "handbag.sensor.tag.radiowaves.left.and.right.fill")
+    static var handbagSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "handbag.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃍅
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let headphonesOverEar = SFSymbol(rawValue: "headphones.over.ear")
+    static var headphonesOverEar: SFSymbol { .init(rawValue: "headphones.over.ear") }
 
     /// 􃀿
     /// Single Localization, 2 Layersets
@@ -2093,7 +2093,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let headphonesSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "headphones.sensor.tag.radiowaves.left.and.right")
+    static var headphonesSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "headphones.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃁀
     /// Single Localization, 3 Layersets
@@ -2102,7 +2102,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let headphonesSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "headphones.sensor.tag.radiowaves.left.and.right.fill")
+    static var headphonesSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "headphones.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃓫
     /// Single Localization, 2 Layersets
@@ -2110,7 +2110,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heartBadgeBolt = SFSymbol(rawValue: "heart.badge.bolt")
+    static var heartBadgeBolt: SFSymbol { .init(rawValue: "heart.badge.bolt") }
 
     /// 􃓬
     /// Single Localization, 2 Layersets
@@ -2118,7 +2118,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heartBadgeBoltFill = SFSymbol(rawValue: "heart.badge.bolt.fill")
+    static var heartBadgeBoltFill: SFSymbol { .init(rawValue: "heart.badge.bolt.fill") }
 
     /// 􃓯
     /// Single Localization, 2 Layersets
@@ -2126,7 +2126,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heartBadgeBoltSlash = SFSymbol(rawValue: "heart.badge.bolt.slash")
+    static var heartBadgeBoltSlash: SFSymbol { .init(rawValue: "heart.badge.bolt.slash") }
 
     /// 􃓰
     /// Single Localization, 2 Layersets
@@ -2134,7 +2134,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heartBadgeBoltSlashFill = SFSymbol(rawValue: "heart.badge.bolt.slash.fill")
+    static var heartBadgeBoltSlashFill: SFSymbol { .init(rawValue: "heart.badge.bolt.slash.fill") }
 
     /// 􃂡
     /// Single Localization, 2 Layersets
@@ -2142,7 +2142,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heartGaugeOpen = SFSymbol(rawValue: "heart.gauge.open")
+    static var heartGaugeOpen: SFSymbol { .init(rawValue: "heart.gauge.open") }
 
     /// 􃂤
     /// Single Localization, 2 Layersets
@@ -2150,7 +2150,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heatWavesCircle = SFSymbol(rawValue: "heat.waves.circle")
+    static var heatWavesCircle: SFSymbol { .init(rawValue: "heat.waves.circle") }
 
     /// 􃂥
     /// Single Localization, 3 Layersets
@@ -2159,7 +2159,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let heatWavesCircleFill = SFSymbol(rawValue: "heat.waves.circle.fill")
+    static var heatWavesCircleFill: SFSymbol { .init(rawValue: "heat.waves.circle.fill") }
 
     /// 􃂟
     /// Single Localization, 2 Layersets
@@ -2167,7 +2167,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let heatWavesGaugeOpen = SFSymbol(rawValue: "heat.waves.gauge.open")
+    static var heatWavesGaugeOpen: SFSymbol { .init(rawValue: "heat.waves.gauge.open") }
 
     /// 􃒚
     /// Single Localization, 3 Layersets
@@ -2176,7 +2176,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let highlighterBadgeEllipsis = SFSymbol(rawValue: "highlighter.badge.ellipsis")
+    static var highlighterBadgeEllipsis: SFSymbol { .init(rawValue: "highlighter.badge.ellipsis") }
 
     /// 􃉰
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -2191,7 +2191,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgeCheckmark = SymbolWith1Localization<Rtl>(rawValue: "homepod.badge.checkmark")
+    static var homepodBadgeCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.badge.checkmark") }
 
     /// 􃉱
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -2206,7 +2206,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod.
-    static let homepodBadgeCheckmarkFill = SymbolWith1Localization<Rtl>(rawValue: "homepod.badge.checkmark.fill")
+    static var homepodBadgeCheckmarkFill: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.badge.checkmark.fill") }
 
     /// 􀻹
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -2220,7 +2220,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini and Apple TV.
-    static let homepodMiniAndAppletv = SymbolWith1Localization<Rtl>(rawValue: "homepod.mini.and.appletv")
+    static var homepodMiniAndAppletv: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.mini.and.appletv") }
 
     /// 􀻺
     /// 2 Localizations, 2 Layersets, ⚠️ Restricted
@@ -2234,7 +2234,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini and Apple TV.
-    static let homepodMiniAndAppletvFill = SymbolWith1Localization<Rtl>(rawValue: "homepod.mini.and.appletv.fill")
+    static var homepodMiniAndAppletvFill: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.mini.and.appletv.fill") }
 
     /// 􃉸
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -2249,7 +2249,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgeCheckmark = SymbolWith1Localization<Rtl>(rawValue: "homepod.mini.badge.checkmark")
+    static var homepodMiniBadgeCheckmark: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.mini.badge.checkmark") }
 
     /// 􃉹
     /// 2 Localizations, 3 Layersets, ⚠️ Restricted
@@ -2264,7 +2264,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s HomePod mini.
-    static let homepodMiniBadgeCheckmarkFill = SymbolWith1Localization<Rtl>(rawValue: "homepod.mini.badge.checkmark.fill")
+    static var homepodMiniBadgeCheckmarkFill: SymbolWith1Localization<Rtl> { .init(rawValue: "homepod.mini.badge.checkmark.fill") }
 
     /// 􂇗
     /// Single Localization, 3 Layersets
@@ -2273,7 +2273,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let hourglassBadgeLock = SFSymbol(rawValue: "hourglass.badge.lock")
+    static var hourglassBadgeLock: SFSymbol { .init(rawValue: "hourglass.badge.lock") }
 
     /// 􃒦
     /// Single Localization, 2 Layersets
@@ -2281,7 +2281,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let humidifierAndEllipsis = SFSymbol(rawValue: "humidifier.and.ellipsis")
+    static var humidifierAndEllipsis: SFSymbol { .init(rawValue: "humidifier.and.ellipsis") }
 
     /// 􃒧
     /// Single Localization, 2 Layersets
@@ -2289,7 +2289,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let humidifierAndEllipsisFill = SFSymbol(rawValue: "humidifier.and.ellipsis.fill")
+    static var humidifierAndEllipsisFill: SFSymbol { .init(rawValue: "humidifier.and.ellipsis.fill") }
 
     /// 􀚏
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -2298,7 +2298,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
-    static let icloudDashed = SFSymbol(rawValue: "icloud.dashed")
+    static var icloudDashed: SFSymbol { .init(rawValue: "icloud.dashed") }
 
     /// 􃐸
     /// Single Localization, 2 Layersets
@@ -2306,7 +2306,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleadingBottomtrailingRectangle = SFSymbol(rawValue: "inset.filled.bottomleading.bottomtrailing.rectangle")
+    static var insetFilledBottomleadingBottomtrailingRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomleading.bottomtrailing.rectangle") }
 
     /// 􃐷
     /// Single Localization, 2 Layersets
@@ -2314,7 +2314,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledBottomleftBottomrightRectangle = SFSymbol(rawValue: "inset.filled.bottomleft.bottomright.rectangle")
+    static var insetFilledBottomleftBottomrightRectangle: SFSymbol { .init(rawValue: "inset.filled.bottomleft.bottomright.rectangle") }
 
     /// 􃐥
     /// Single Localization, 2 Layersets
@@ -2322,7 +2322,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledCircleSlash = SFSymbol(rawValue: "inset.filled.circle.slash")
+    static var insetFilledCircleSlash: SFSymbol { .init(rawValue: "inset.filled.circle.slash") }
 
     /// 􃇐
     /// Single Localization, 2 Layersets
@@ -2330,7 +2330,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledLeftthirdMiddlethirdRightthirdRectangle = SFSymbol(rawValue: "inset.filled.leftthird.middlethird.rightthird.rectangle")
+    static var insetFilledLeftthirdMiddlethirdRightthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.leftthird.middlethird.rightthird.rectangle") }
 
     /// 􂖡
     /// Single Localization, 2 Layersets
@@ -2338,7 +2338,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledPano = SFSymbol(rawValue: "inset.filled.pano")
+    static var insetFilledPano: SFSymbol { .init(rawValue: "inset.filled.pano") }
 
     /// 􂇕
     /// Single Localization, 2 Layersets
@@ -2346,7 +2346,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledRectangleAndPointerArrow = SFSymbol(rawValue: "inset.filled.rectangle.and.pointer.arrow")
+    static var insetFilledRectangleAndPointerArrow: SFSymbol { .init(rawValue: "inset.filled.rectangle.and.pointer.arrow") }
 
     /// 􃈃
     /// Single Localization, 2 Layersets
@@ -2354,7 +2354,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let insetFilledTopthirdMiddlethirdBottomthirdRectangle = SFSymbol(rawValue: "inset.filled.topthird.middlethird.bottomthird.rectangle")
+    static var insetFilledTopthirdMiddlethirdBottomthirdRectangle: SFSymbol { .init(rawValue: "inset.filled.topthird.middlethird.bottomthird.rectangle") }
 
     /// 􃉖
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2365,7 +2365,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadBadgeCheckmark = SFSymbol(rawValue: "ipad.badge.checkmark")
+    static var ipadBadgeCheckmark: SFSymbol { .init(rawValue: "ipad.badge.checkmark") }
 
     /// 􃏟
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -2374,7 +2374,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1CropHomebuttonCircle = SFSymbol(rawValue: "ipad.gen1.crop.homebutton.circle")
+    static var ipadGen1CropHomebuttonCircle: SFSymbol { .init(rawValue: "ipad.gen1.crop.homebutton.circle") }
 
     /// 􁣵
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2384,7 +2384,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen1Sizes = SFSymbol(rawValue: "ipad.gen1.sizes")
+    static var ipadGen1Sizes: SFSymbol { .init(rawValue: "ipad.gen1.sizes") }
 
     /// 􃉌
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2394,7 +2394,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad.
-    static let ipadGen2Sizes = SFSymbol(rawValue: "ipad.gen2.sizes")
+    static var ipadGen2Sizes: SFSymbol { .init(rawValue: "ipad.gen2.sizes") }
 
     /// 􃔋
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2404,7 +2404,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad and Apple Watch.
-    static let ipadLandscapeAndApplewatch = SFSymbol(rawValue: "ipad.landscape.and.applewatch")
+    static var ipadLandscapeAndApplewatch: SFSymbol { .init(rawValue: "ipad.landscape.and.applewatch") }
 
     /// 􃔍
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2414,7 +2414,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPad and iPod. 
-    static let ipadLandscapeAndIpod = SFSymbol(rawValue: "ipad.landscape.and.ipod")
+    static var ipadLandscapeAndIpod: SFSymbol { .init(rawValue: "ipad.landscape.and.ipod") }
 
     /// 􃔏
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2424,7 +2424,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone and iPod.
-    static let iphoneAndIpod = SFSymbol(rawValue: "iphone.and.ipod")
+    static var iphoneAndIpod: SFSymbol { .init(rawValue: "iphone.and.ipod") }
 
     /// 􃔕
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2434,7 +2434,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone and Vision Pro.
-    static let iphoneAndVisionPro = SFSymbol(rawValue: "iphone.and.vision.pro")
+    static var iphoneAndVisionPro: SFSymbol { .init(rawValue: "iphone.and.vision.pro") }
 
     /// 􃉔
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2445,7 +2445,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneBadgeCheckmark = SFSymbol(rawValue: "iphone.badge.checkmark")
+    static var iphoneBadgeCheckmark: SFSymbol { .init(rawValue: "iphone.badge.checkmark") }
 
     /// 􃂴
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -2454,7 +2454,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1CropHomebuttonCircle = SFSymbol(rawValue: "iphone.gen1.crop.homebutton.circle")
+    static var iphoneGen1CropHomebuttonCircle: SFSymbol { .init(rawValue: "iphone.gen1.crop.homebutton.circle") }
 
     /// 􃉈
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2464,7 +2464,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen1Sizes = SFSymbol(rawValue: "iphone.gen1.sizes")
+    static var iphoneGen1Sizes: SFSymbol { .init(rawValue: "iphone.gen1.sizes") }
 
     /// 􁣳
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2474,7 +2474,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen2Sizes = SFSymbol(rawValue: "iphone.gen2.sizes")
+    static var iphoneGen2Sizes: SFSymbol { .init(rawValue: "iphone.gen2.sizes") }
 
     /// 􃉊
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2484,7 +2484,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPhone.
-    static let iphoneGen3Sizes = SFSymbol(rawValue: "iphone.gen3.sizes")
+    static var iphoneGen3Sizes: SFSymbol { .init(rawValue: "iphone.gen3.sizes") }
 
     /// 􂤨
     /// Single Localization, 2 Layersets
@@ -2492,7 +2492,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphonePatternDiagonalline = SFSymbol(rawValue: "iphone.pattern.diagonalline")
+    static var iphonePatternDiagonalline: SFSymbol { .init(rawValue: "iphone.pattern.diagonalline") }
 
     /// 􂿥
     /// Single Localization, 2 Layersets
@@ -2500,7 +2500,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let iphonePatternDiagonallineOnRectanglePortraitDashed = SFSymbol(rawValue: "iphone.pattern.diagonalline.on.rectangle.portrait.dashed")
+    static var iphonePatternDiagonallineOnRectanglePortraitDashed: SFSymbol { .init(rawValue: "iphone.pattern.diagonalline.on.rectangle.portrait.dashed") }
 
     /// 􃔓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2510,7 +2510,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod and Apple Watch.
-    static let ipodAndApplewatch = SFSymbol(rawValue: "ipod.and.applewatch")
+    static var ipodAndApplewatch: SFSymbol { .init(rawValue: "ipod.and.applewatch") }
 
     /// 􃔗
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2520,7 +2520,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s iPod and Vision Pro.
-    static let ipodAndVisionPro = SFSymbol(rawValue: "ipod.and.vision.pro")
+    static var ipodAndVisionPro: SFSymbol { .init(rawValue: "ipod.and.vision.pro") }
 
     /// 􃁉
     /// Single Localization, 2 Layersets
@@ -2528,7 +2528,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let jacketCircle = SFSymbol(rawValue: "jacket.circle")
+    static var jacketCircle: SFSymbol { .init(rawValue: "jacket.circle") }
 
     /// 􃁊
     /// Single Localization, 3 Layersets
@@ -2537,7 +2537,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let jacketCircleFill = SFSymbol(rawValue: "jacket.circle.fill")
+    static var jacketCircleFill: SFSymbol { .init(rawValue: "jacket.circle.fill") }
 
     /// 􃁁
     /// Single Localization, 2 Layersets
@@ -2545,7 +2545,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let jacketSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "jacket.sensor.tag.radiowaves.left.and.right")
+    static var jacketSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "jacket.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃁂
     /// Single Localization, 3 Layersets
@@ -2554,7 +2554,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let jacketSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "jacket.sensor.tag.radiowaves.left.and.right.fill")
+    static var jacketSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "jacket.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃁇
     /// Single Localization, 2 Layersets
@@ -2562,7 +2562,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyCircle = SFSymbol(rawValue: "key.circle")
+    static var keyCircle: SFSymbol { .init(rawValue: "key.circle") }
 
     /// 􃁈
     /// Single Localization, 3 Layersets
@@ -2571,7 +2571,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyCircleFill = SFSymbol(rawValue: "key.circle.fill")
+    static var keyCircleFill: SFSymbol { .init(rawValue: "key.circle.fill") }
 
     /// 􃀳
     /// Single Localization, 2 Layersets
@@ -2579,7 +2579,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keySensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "key.sensor.tag.radiowaves.left.and.right")
+    static var keySensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "key.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀴
     /// Single Localization, 3 Layersets
@@ -2588,7 +2588,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keySensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "key.sensor.tag.radiowaves.left.and.right.fill")
+    static var keySensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "key.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃇞
     /// Single Localization, 2 Layersets
@@ -2596,7 +2596,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let keyShield = SFSymbol(rawValue: "key.shield")
+    static var keyShield: SFSymbol { .init(rawValue: "key.shield") }
 
     /// 􃇟
     /// Single Localization, 3 Layersets
@@ -2605,7 +2605,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let keyShieldFill = SFSymbol(rawValue: "key.shield.fill")
+    static var keyShieldFill: SFSymbol { .init(rawValue: "key.shield.fill") }
 
     /// 􃉘
     /// Single Localization, 3 Layersets
@@ -2614,28 +2614,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let laptopcomputerBadgeCheckmark = SFSymbol(rawValue: "laptopcomputer.badge.checkmark")
+    static var laptopcomputerBadgeCheckmark: SFSymbol { .init(rawValue: "laptopcomputer.badge.checkmark") }
 
     /// 􀫱
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lineDiagonalTriangleheadUpRight = SFSymbol(rawValue: "line.diagonal.trianglehead.up.right")
+    static var lineDiagonalTriangleheadUpRight: SFSymbol { .init(rawValue: "line.diagonal.trianglehead.up.right") }
 
     /// 􃏠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let lineDiagonalTriangleheadUpRightLeftDown = SFSymbol(rawValue: "line.diagonal.trianglehead.up.right.left.down")
+    static var lineDiagonalTriangleheadUpRightLeftDown: SFSymbol { .init(rawValue: "line.diagonal.trianglehead.up.right.left.down") }
 
     /// 􃋮
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let linesMeasurementHorizontalAlignedBottom = SFSymbol(rawValue: "lines.measurement.horizontal.aligned.bottom")
+    static var linesMeasurementHorizontalAlignedBottom: SFSymbol { .init(rawValue: "lines.measurement.horizontal.aligned.bottom") }
 
     /// 􃒜
     /// Single Localization, 3 Layersets
@@ -2644,7 +2644,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listBulletBadgeEllipsis = SFSymbol(rawValue: "list.bullet.badge.ellipsis")
+    static var listBulletBadgeEllipsis: SFSymbol { .init(rawValue: "list.bullet.badge.ellipsis") }
 
     /// 􃒞
     /// Single Localization, 3 Layersets
@@ -2653,7 +2653,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listDashBadgeEllipsis = SFSymbol(rawValue: "list.dash.badge.ellipsis")
+    static var listDashBadgeEllipsis: SFSymbol { .init(rawValue: "list.dash.badge.ellipsis") }
 
     /// 􃈩
     /// Single Localization, 3 Layersets
@@ -2662,7 +2662,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listDashHeaderRectangleFill = SFSymbol(rawValue: "list.dash.header.rectangle.fill")
+    static var listDashHeaderRectangleFill: SFSymbol { .init(rawValue: "list.dash.header.rectangle.fill") }
 
     /// 􃒠
     /// 3 Localizations, 3 Layersets
@@ -2676,7 +2676,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let listNumberBadgeEllipsis = SymbolWith2Localizations<Hi, Rtl>(rawValue: "list.number.badge.ellipsis")
+    static var listNumberBadgeEllipsis: SymbolWith2Localizations<Hi, Rtl> { .init(rawValue: "list.number.badge.ellipsis") }
 
     /// 􃍰
     /// Single Localization, 3 Layersets
@@ -2685,7 +2685,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeCheckmark = SFSymbol(rawValue: "lock.badge.checkmark")
+    static var lockBadgeCheckmark: SFSymbol { .init(rawValue: "lock.badge.checkmark") }
 
     /// 􃍱
     /// Single Localization, 3 Layersets
@@ -2694,7 +2694,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeCheckmarkFill = SFSymbol(rawValue: "lock.badge.checkmark.fill")
+    static var lockBadgeCheckmarkFill: SFSymbol { .init(rawValue: "lock.badge.checkmark.fill") }
 
     /// 􃍴
     /// Single Localization, 3 Layersets
@@ -2703,7 +2703,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeXmark = SFSymbol(rawValue: "lock.badge.xmark")
+    static var lockBadgeXmark: SFSymbol { .init(rawValue: "lock.badge.xmark") }
 
     /// 􃍵
     /// Single Localization, 3 Layersets
@@ -2712,7 +2712,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockBadgeXmarkFill = SFSymbol(rawValue: "lock.badge.xmark.fill")
+    static var lockBadgeXmarkFill: SFSymbol { .init(rawValue: "lock.badge.xmark.fill") }
 
     /// 􃊿
     /// Single Localization, 2 Layersets
@@ -2720,7 +2720,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockHeart = SFSymbol(rawValue: "lock.heart")
+    static var lockHeart: SFSymbol { .init(rawValue: "lock.heart") }
 
     /// 􃋀
     /// Single Localization, 3 Layersets
@@ -2729,7 +2729,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let lockHeartFill = SFSymbol(rawValue: "lock.heart.fill")
+    static var lockHeartFill: SFSymbol { .init(rawValue: "lock.heart.fill") }
 
     /// 􃐭
     /// Single Localization, 2 Layersets
@@ -2737,7 +2737,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockRectangleDashed = SFSymbol(rawValue: "lock.rectangle.dashed")
+    static var lockRectangleDashed: SFSymbol { .init(rawValue: "lock.rectangle.dashed") }
 
     /// 􃔟
     /// Single Localization, 2 Layersets
@@ -2745,7 +2745,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let lockSquareDashed = SFSymbol(rawValue: "lock.square.dashed")
+    static var lockSquareDashed: SFSymbol { .init(rawValue: "lock.square.dashed") }
 
     /// 􃔑
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2755,7 +2755,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook and iPod.
-    static let macbookAndIpod = SFSymbol(rawValue: "macbook.and.ipod")
+    static var macbookAndIpod: SFSymbol { .init(rawValue: "macbook.and.ipod") }
 
     /// 􃉚
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2766,7 +2766,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookBadgeCheckmark = SFSymbol(rawValue: "macbook.badge.checkmark")
+    static var macbookBadgeCheckmark: SFSymbol { .init(rawValue: "macbook.badge.checkmark") }
 
     /// 􃔝
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2777,7 +2777,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookBadgeExclamationmark = SFSymbol(rawValue: "macbook.badge.exclamationmark")
+    static var macbookBadgeExclamationmark: SFSymbol { .init(rawValue: "macbook.badge.exclamationmark") }
 
     /// 􃊈
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2788,7 +2788,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookBadgeShieldCheckmark = SFSymbol(rawValue: "macbook.badge.shield.checkmark")
+    static var macbookBadgeShieldCheckmark: SFSymbol { .init(rawValue: "macbook.badge.shield.checkmark") }
 
     /// 􃉏
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2798,7 +2798,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookGen1Sizes = SFSymbol(rawValue: "macbook.gen1.sizes")
+    static var macbookGen1Sizes: SFSymbol { .init(rawValue: "macbook.gen1.sizes") }
 
     /// 􃉐
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2808,7 +2808,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookGen2Sizes = SFSymbol(rawValue: "macbook.gen2.sizes")
+    static var macbookGen2Sizes: SFSymbol { .init(rawValue: "macbook.gen2.sizes") }
 
     /// 􃉎
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -2818,7 +2818,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookSizes = SFSymbol(rawValue: "macbook.sizes")
+    static var macbookSizes: SFSymbol { .init(rawValue: "macbook.sizes") }
 
     /// 􃉛
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2829,7 +2829,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s MacBook.
-    static let macbookTrianglebadgeExclamationmark = SFSymbol(rawValue: "macbook.trianglebadge.exclamationmark")
+    static var macbookTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "macbook.trianglebadge.exclamationmark") }
 
     /// 􃉨
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2840,7 +2840,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiBadgeCheckmark = SFSymbol(rawValue: "macmini.badge.checkmark")
+    static var macminiBadgeCheckmark: SFSymbol { .init(rawValue: "macmini.badge.checkmark") }
 
     /// 􃉩
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2851,7 +2851,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac mini.
-    static let macminiBadgeCheckmarkFill = SFSymbol(rawValue: "macmini.badge.checkmark.fill")
+    static var macminiBadgeCheckmarkFill: SFSymbol { .init(rawValue: "macmini.badge.checkmark.fill") }
 
     /// 􃉠
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2862,7 +2862,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen3BadgeCkeckmark = SFSymbol(rawValue: "macpro.gen3.badge.ckeckmark")
+    static var macproGen3BadgeCkeckmark: SFSymbol { .init(rawValue: "macpro.gen3.badge.ckeckmark") }
 
     /// 􃉡
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2873,7 +2873,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Pro.
-    static let macproGen3BadgeCkeckmarkFill = SFSymbol(rawValue: "macpro.gen3.badge.ckeckmark.fill")
+    static var macproGen3BadgeCkeckmarkFill: SFSymbol { .init(rawValue: "macpro.gen3.badge.ckeckmark.fill") }
 
     /// 􃉤
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2884,7 +2884,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Studio.
-    static let macstudioBadgeCheckmark = SFSymbol(rawValue: "macstudio.badge.checkmark")
+    static var macstudioBadgeCheckmark: SFSymbol { .init(rawValue: "macstudio.badge.checkmark") }
 
     /// 􃉥
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -2895,7 +2895,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Mac Studio.
-    static let macstudioBadgeCheckmarkFill = SFSymbol(rawValue: "macstudio.badge.checkmark.fill")
+    static var macstudioBadgeCheckmarkFill: SFSymbol { .init(rawValue: "macstudio.badge.checkmark.fill") }
 
     /// 􁝸
     /// 2 Localizations, 2 Layersets
@@ -2907,14 +2907,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let macwindowAndPointerArrow = SymbolWith1Localization<Rtl>(rawValue: "macwindow.and.pointer.arrow")
+    static var macwindowAndPointerArrow: SymbolWith1Localization<Rtl> { .init(rawValue: "macwindow.and.pointer.arrow") }
 
     /// 􃑷
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let macwindowStack = SFSymbol(rawValue: "macwindow.stack")
+    static var macwindowStack: SFSymbol { .init(rawValue: "macwindow.stack") }
 
     /// 􃇼
     /// Single Localization, 2 Layersets
@@ -2922,7 +2922,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusArrowTriangleheadClockwise = SFSymbol(rawValue: "minus.arrow.trianglehead.clockwise")
+    static var minusArrowTriangleheadClockwise: SFSymbol { .init(rawValue: "minus.arrow.trianglehead.clockwise") }
 
     /// 􃋯
     /// Single Localization, 2 Layersets
@@ -2930,7 +2930,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let minusPlusLinesMeasurementHorizontalAlignedBottom = SFSymbol(rawValue: "minus.plus.lines.measurement.horizontal.aligned.bottom")
+    static var minusPlusLinesMeasurementHorizontalAlignedBottom: SFSymbol { .init(rawValue: "minus.plus.lines.measurement.horizontal.aligned.bottom") }
 
     /// 􃃂
     /// Single Localization, 2 Layersets
@@ -2938,7 +2938,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicNoteArrowTriangleheadClockwise = SFSymbol(rawValue: "music.note.arrow.trianglehead.clockwise")
+    static var musicNoteArrowTriangleheadClockwise: SFSymbol { .init(rawValue: "music.note.arrow.trianglehead.clockwise") }
 
     /// 􃑓
     /// Single Localization, 2 Layersets
@@ -2946,7 +2946,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicNoteSlash = SFSymbol(rawValue: "music.note.slash")
+    static var musicNoteSlash: SFSymbol { .init(rawValue: "music.note.slash") }
 
     /// 􃐹
     /// Single Localization, 2 Layersets
@@ -2954,7 +2954,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicNoteSquareStack = SFSymbol(rawValue: "music.note.square.stack")
+    static var musicNoteSquareStack: SFSymbol { .init(rawValue: "music.note.square.stack") }
 
     /// 􃐺
     /// Single Localization, 3 Layersets
@@ -2963,7 +2963,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let musicNoteSquareStackFill = SFSymbol(rawValue: "music.note.square.stack.fill")
+    static var musicNoteSquareStackFill: SFSymbol { .init(rawValue: "music.note.square.stack.fill") }
 
     /// 􃁮
     /// Single Localization, 2 Layersets
@@ -2971,7 +2971,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let musicPages = SFSymbol(rawValue: "music.pages")
+    static var musicPages: SFSymbol { .init(rawValue: "music.pages") }
 
     /// 􃁯
     /// Single Localization, 3 Layersets
@@ -2980,21 +2980,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let musicPagesFill = SFSymbol(rawValue: "music.pages.fill")
+    static var musicPagesFill: SFSymbol { .init(rawValue: "music.pages.fill") }
 
     /// 􀧵
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let padHeader = SFSymbol(rawValue: "pad.header")
+    static var padHeader: SFSymbol { .init(rawValue: "pad.header") }
 
     /// 􀠣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let paintBucketClassic = SFSymbol(rawValue: "paint.bucket.classic")
+    static var paintBucketClassic: SFSymbol { .init(rawValue: "paint.bucket.classic") }
 
     /// 􃕑
     /// Single Localization, 3 Layersets
@@ -3003,7 +3003,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pedestrianGateClosedTrianglebadgeExclamationmark = SFSymbol(rawValue: "pedestrian.gate.closed.trianglebadge.exclamationmark")
+    static var pedestrianGateClosedTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "pedestrian.gate.closed.trianglebadge.exclamationmark") }
 
     /// 􃕐
     /// Single Localization, 3 Layersets
@@ -3012,7 +3012,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pedestrianGateOpenTrianglebadgeExclamationmark = SFSymbol(rawValue: "pedestrian.gate.open.trianglebadge.exclamationmark")
+    static var pedestrianGateOpenTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "pedestrian.gate.open.trianglebadge.exclamationmark") }
 
     /// 􂣑
     /// Single Localization, 3 Layersets
@@ -3021,7 +3021,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2Badge = SFSymbol(rawValue: "person.2.badge")
+    static var person2Badge: SFSymbol { .init(rawValue: "person.2.badge") }
 
     /// 􂣒
     /// Single Localization, 3 Layersets
@@ -3030,7 +3030,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2BadgeFill = SFSymbol(rawValue: "person.2.badge.fill")
+    static var person2BadgeFill: SFSymbol { .init(rawValue: "person.2.badge.fill") }
 
     /// 􃒈
     /// Single Localization, 2 Layersets
@@ -3038,7 +3038,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let person2Shield = SFSymbol(rawValue: "person.2.shield")
+    static var person2Shield: SFSymbol { .init(rawValue: "person.2.shield") }
 
     /// 􃒉
     /// Single Localization, 3 Layersets
@@ -3047,7 +3047,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let person2ShieldFill = SFSymbol(rawValue: "person.2.shield.fill")
+    static var person2ShieldFill: SFSymbol { .init(rawValue: "person.2.shield.fill") }
 
     /// 􃂇
     /// Single Localization, 3 Layersets
@@ -3056,7 +3056,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropCircleBadgeEllipsis = SFSymbol(rawValue: "person.crop.circle.badge.ellipsis")
+    static var personCropCircleBadgeEllipsis: SFSymbol { .init(rawValue: "person.crop.circle.badge.ellipsis") }
 
     /// 􃂈
     /// Single Localization, 3 Layersets
@@ -3065,7 +3065,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personCropCircleBadgeEllipsisFill = SFSymbol(rawValue: "person.crop.circle.badge.ellipsis.fill")
+    static var personCropCircleBadgeEllipsisFill: SFSymbol { .init(rawValue: "person.crop.circle.badge.ellipsis.fill") }
 
     /// 􃈮
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3075,7 +3075,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Audio.
-    static let personSpatialaudio3dFill = SFSymbol(rawValue: "person.spatialaudio.3d.fill")
+    static var personSpatialaudio3dFill: SFSymbol { .init(rawValue: "person.spatialaudio.3d.fill") }
 
     /// 􁀨
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3085,7 +3085,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Audio.
-    static let personSpatialaudioFill = SFSymbol(rawValue: "person.spatialaudio.fill")
+    static var personSpatialaudioFill: SFSymbol { .init(rawValue: "person.spatialaudio.fill") }
 
     /// 􃈭
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3095,7 +3095,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Audio.
-    static let personSpatialaudioStereo3dFill = SFSymbol(rawValue: "person.spatialaudio.stereo.3d.fill")
+    static var personSpatialaudioStereo3dFill: SFSymbol { .init(rawValue: "person.spatialaudio.stereo.3d.fill") }
 
     /// 􁀧
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3105,7 +3105,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Audio.
-    static let personSpatialaudioStereoFill = SFSymbol(rawValue: "person.spatialaudio.stereo.fill")
+    static var personSpatialaudioStereoFill: SFSymbol { .init(rawValue: "person.spatialaudio.stereo.fill") }
 
     /// 􃒀
     /// Single Localization, 3 Layersets
@@ -3114,7 +3114,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personTextRectangleTrianglebadgeExclamationmark = SFSymbol(rawValue: "person.text.rectangle.trianglebadge.exclamationmark")
+    static var personTextRectangleTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "person.text.rectangle.trianglebadge.exclamationmark") }
 
     /// 􃒁
     /// Single Localization, 3 Layersets
@@ -3123,7 +3123,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let personTextRectangleTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "person.text.rectangle.trianglebadge.exclamationmark.fill")
+    static var personTextRectangleTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "person.text.rectangle.trianglebadge.exclamationmark.fill") }
 
     /// 􃌑
     /// Single Localization, 2 Layersets
@@ -3131,7 +3131,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let petCarrier = SFSymbol(rawValue: "pet.carrier")
+    static var petCarrier: SFSymbol { .init(rawValue: "pet.carrier") }
 
     /// 􃎤
     /// Single Localization, 2 Layersets
@@ -3139,7 +3139,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let petCarrierCircle = SFSymbol(rawValue: "pet.carrier.circle")
+    static var petCarrierCircle: SFSymbol { .init(rawValue: "pet.carrier.circle") }
 
     /// 􃎥
     /// Single Localization, 3 Layersets
@@ -3148,7 +3148,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let petCarrierCircleFill = SFSymbol(rawValue: "pet.carrier.circle.fill")
+    static var petCarrierCircleFill: SFSymbol { .init(rawValue: "pet.carrier.circle.fill") }
 
     /// 􃌒
     /// Single Localization, 3 Layersets
@@ -3157,7 +3157,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let petCarrierFill = SFSymbol(rawValue: "pet.carrier.fill")
+    static var petCarrierFill: SFSymbol { .init(rawValue: "pet.carrier.fill") }
 
     /// 􃂓
     /// Single Localization, 2 Layersets
@@ -3165,7 +3165,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phonePause = SFSymbol(rawValue: "phone.pause")
+    static var phonePause: SFSymbol { .init(rawValue: "phone.pause") }
 
     /// 􃂕
     /// Single Localization, 2 Layersets
@@ -3173,7 +3173,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phonePauseCircle = SFSymbol(rawValue: "phone.pause.circle")
+    static var phonePauseCircle: SFSymbol { .init(rawValue: "phone.pause.circle") }
 
     /// 􃂖
     /// Single Localization, 3 Layersets
@@ -3182,7 +3182,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let phonePauseCircleFill = SFSymbol(rawValue: "phone.pause.circle.fill")
+    static var phonePauseCircleFill: SFSymbol { .init(rawValue: "phone.pause.circle.fill") }
 
     /// 􃂔
     /// Single Localization, 2 Layersets
@@ -3190,7 +3190,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let phonePauseFill = SFSymbol(rawValue: "phone.pause.fill")
+    static var phonePauseFill: SFSymbol { .init(rawValue: "phone.pause.fill") }
 
     /// 􃄤
     /// Single Localization, 2 Layersets
@@ -3198,7 +3198,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let playDiamond = SFSymbol(rawValue: "play.diamond")
+    static var playDiamond: SFSymbol { .init(rawValue: "play.diamond") }
 
     /// 􃄥
     /// Single Localization, 3 Layersets
@@ -3207,7 +3207,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let playDiamondFill = SFSymbol(rawValue: "play.diamond.fill")
+    static var playDiamondFill: SFSymbol { .init(rawValue: "play.diamond.fill") }
 
     /// 􃇿
     /// Single Localization, 2 Layersets
@@ -3215,7 +3215,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusArrowTriangleheadCounterclockwise = SFSymbol(rawValue: "plus.arrow.trianglehead.counterclockwise")
+    static var plusArrowTriangleheadCounterclockwise: SFSymbol { .init(rawValue: "plus.arrow.trianglehead.counterclockwise") }
 
     /// 􃁴
     /// Single Localization, 2 Layersets
@@ -3223,7 +3223,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let plusCapsule = SFSymbol(rawValue: "plus.capsule")
+    static var plusCapsule: SFSymbol { .init(rawValue: "plus.capsule") }
 
     /// 􃁵
     /// Single Localization, 3 Layersets
@@ -3232,14 +3232,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let plusCapsuleFill = SFSymbol(rawValue: "plus.capsule.fill")
+    static var plusCapsuleFill: SFSymbol { .init(rawValue: "plus.capsule.fill") }
 
     /// 􀫌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pointerArrow = SFSymbol(rawValue: "pointer.arrow")
+    static var pointerArrow: SFSymbol { .init(rawValue: "pointer.arrow") }
 
     /// 􀮐
     /// Single Localization, 2 Layersets
@@ -3247,7 +3247,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowAndSquareOnSquareDashed = SFSymbol(rawValue: "pointer.arrow.and.square.on.square.dashed")
+    static var pointerArrowAndSquareOnSquareDashed: SFSymbol { .init(rawValue: "pointer.arrow.and.square.on.square.dashed") }
 
     /// 􀭆
     /// Single Localization, 2 Layersets
@@ -3255,7 +3255,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowClick = SFSymbol(rawValue: "pointer.arrow.click")
+    static var pointerArrowClick: SFSymbol { .init(rawValue: "pointer.arrow.click") }
 
     /// 􀭇
     /// Single Localization, 3 Layersets
@@ -3264,7 +3264,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowClick2 = SFSymbol(rawValue: "pointer.arrow.click.2")
+    static var pointerArrowClick2: SFSymbol { .init(rawValue: "pointer.arrow.click.2") }
 
     /// 􀮴
     /// Single Localization, 3 Layersets
@@ -3273,14 +3273,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowClickBadgeClock = SFSymbol(rawValue: "pointer.arrow.click.badge.clock")
+    static var pointerArrowClickBadgeClock: SFSymbol { .init(rawValue: "pointer.arrow.click.badge.clock") }
 
     /// 􃕝
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pointerArrowIpad = SFSymbol(rawValue: "pointer.arrow.ipad")
+    static var pointerArrowIpad: SFSymbol { .init(rawValue: "pointer.arrow.ipad") }
 
     /// 􃕥
     /// Single Localization, 2 Layersets
@@ -3288,7 +3288,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowIpadAndSquareOnSquareDashed = SFSymbol(rawValue: "pointer.arrow.ipad.and.square.on.square.dashed")
+    static var pointerArrowIpadAndSquareOnSquareDashed: SFSymbol { .init(rawValue: "pointer.arrow.ipad.and.square.on.square.dashed") }
 
     /// 􃕤
     /// Single Localization, 2 Layersets
@@ -3296,7 +3296,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowIpadRays = SFSymbol(rawValue: "pointer.arrow.ipad.rays")
+    static var pointerArrowIpadRays: SFSymbol { .init(rawValue: "pointer.arrow.ipad.rays") }
 
     /// 􃕠
     /// Single Localization, 2 Layersets
@@ -3304,7 +3304,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowIpadSlash = SFSymbol(rawValue: "pointer.arrow.ipad.slash")
+    static var pointerArrowIpadSlash: SFSymbol { .init(rawValue: "pointer.arrow.ipad.slash") }
 
     /// 􃕢
     /// Single Localization, 2 Layersets
@@ -3312,7 +3312,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowIpadSlashSquare = SFSymbol(rawValue: "pointer.arrow.ipad.slash.square")
+    static var pointerArrowIpadSlashSquare: SFSymbol { .init(rawValue: "pointer.arrow.ipad.slash.square") }
 
     /// 􃕣
     /// Single Localization, 3 Layersets
@@ -3321,7 +3321,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowIpadSlashSquareFill = SFSymbol(rawValue: "pointer.arrow.ipad.slash.square.fill")
+    static var pointerArrowIpadSlashSquareFill: SFSymbol { .init(rawValue: "pointer.arrow.ipad.slash.square.fill") }
 
     /// 􃕞
     /// Single Localization, 2 Layersets
@@ -3329,7 +3329,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowIpadSquare = SFSymbol(rawValue: "pointer.arrow.ipad.square")
+    static var pointerArrowIpadSquare: SFSymbol { .init(rawValue: "pointer.arrow.ipad.square") }
 
     /// 􃕟
     /// Single Localization, 3 Layersets
@@ -3338,14 +3338,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowIpadSquareFill = SFSymbol(rawValue: "pointer.arrow.ipad.square.fill")
+    static var pointerArrowIpadSquareFill: SFSymbol { .init(rawValue: "pointer.arrow.ipad.square.fill") }
 
     /// 􀣠
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let pointerArrowMotionlines = SFSymbol(rawValue: "pointer.arrow.motionlines")
+    static var pointerArrowMotionlines: SFSymbol { .init(rawValue: "pointer.arrow.motionlines") }
 
     /// 􀣡
     /// Single Localization, 2 Layersets
@@ -3353,7 +3353,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowMotionlinesClick = SFSymbol(rawValue: "pointer.arrow.motionlines.click")
+    static var pointerArrowMotionlinesClick: SFSymbol { .init(rawValue: "pointer.arrow.motionlines.click") }
 
     /// 􀇰
     /// Single Localization, 2 Layersets
@@ -3361,7 +3361,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowRays = SFSymbol(rawValue: "pointer.arrow.rays")
+    static var pointerArrowRays: SFSymbol { .init(rawValue: "pointer.arrow.rays") }
 
     /// 􁷁
     /// Single Localization, 2 Layersets
@@ -3369,7 +3369,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowSlash = SFSymbol(rawValue: "pointer.arrow.slash")
+    static var pointerArrowSlash: SFSymbol { .init(rawValue: "pointer.arrow.slash") }
 
     /// 􁷂
     /// Single Localization, 2 Layersets
@@ -3377,7 +3377,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowSlashSquare = SFSymbol(rawValue: "pointer.arrow.slash.square")
+    static var pointerArrowSlashSquare: SFSymbol { .init(rawValue: "pointer.arrow.slash.square") }
 
     /// 􁷃
     /// Single Localization, 3 Layersets
@@ -3386,7 +3386,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowSlashSquareFill = SFSymbol(rawValue: "pointer.arrow.slash.square.fill")
+    static var pointerArrowSlashSquareFill: SFSymbol { .init(rawValue: "pointer.arrow.slash.square.fill") }
 
     /// 􀭅
     /// Single Localization, 2 Layersets
@@ -3394,7 +3394,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let pointerArrowSquare = SFSymbol(rawValue: "pointer.arrow.square")
+    static var pointerArrowSquare: SFSymbol { .init(rawValue: "pointer.arrow.square") }
 
     /// 􁚀
     /// Single Localization, 3 Layersets
@@ -3403,28 +3403,28 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let pointerArrowSquareFill = SFSymbol(rawValue: "pointer.arrow.square.fill")
+    static var pointerArrowSquareFill: SFSymbol { .init(rawValue: "pointer.arrow.square.fill") }
 
     /// 􃑊
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangle3GroupDashed = SFSymbol(rawValue: "rectangle.3.group.dashed")
+    static var rectangle3GroupDashed: SFSymbol { .init(rawValue: "rectangle.3.group.dashed") }
 
     /// 􃑼
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid1x3 = SFSymbol(rawValue: "rectangle.grid.1x3")
+    static var rectangleGrid1x3: SFSymbol { .init(rawValue: "rectangle.grid.1x3") }
 
     /// 􃑽
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let rectangleGrid1x3Fill = SFSymbol(rawValue: "rectangle.grid.1x3.fill")
+    static var rectangleGrid1x3Fill: SFSymbol { .init(rawValue: "rectangle.grid.1x3.fill") }
 
     /// 􃔲
     /// Single Localization, 2 Layersets
@@ -3432,7 +3432,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleLandscapeRotateSlash = SFSymbol(rawValue: "rectangle.landscape.rotate.slash")
+    static var rectangleLandscapeRotateSlash: SFSymbol { .init(rawValue: "rectangle.landscape.rotate.slash") }
 
     /// 􃔵
     /// Single Localization, 2 Layersets
@@ -3440,7 +3440,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectanglePortraitRotateSlash = SFSymbol(rawValue: "rectangle.portrait.rotate.slash")
+    static var rectanglePortraitRotateSlash: SFSymbol { .init(rawValue: "rectangle.portrait.rotate.slash") }
 
     /// 􃈑
     /// Single Localization, 2 Layersets
@@ -3448,7 +3448,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleStackSlash = SFSymbol(rawValue: "rectangle.stack.slash")
+    static var rectangleStackSlash: SFSymbol { .init(rawValue: "rectangle.stack.slash") }
 
     /// 􃈒
     /// Single Localization, 2 Layersets
@@ -3456,7 +3456,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let rectangleStackSlashFill = SFSymbol(rawValue: "rectangle.stack.slash.fill")
+    static var rectangleStackSlashFill: SFSymbol { .init(rawValue: "rectangle.stack.slash.fill") }
 
     /// 􂻛
     /// Single Localization, 3 Layersets
@@ -3465,21 +3465,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let repeatBadgeXmark = SFSymbol(rawValue: "repeat.badge.xmark")
+    static var repeatBadgeXmark: SFSymbol { .init(rawValue: "repeat.badge.xmark") }
 
     /// 􃊍
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ring = SFSymbol(rawValue: "ring")
+    static var ring: SFSymbol { .init(rawValue: "ring") }
 
     /// 􃊌
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let ringDashed = SFSymbol(rawValue: "ring.dashed")
+    static var ringDashed: SFSymbol { .init(rawValue: "ring.dashed") }
 
     /// 􃆲
     /// Single Localization, 2 Layersets
@@ -3487,7 +3487,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sensorRadiowavesLeftAndRight = SFSymbol(rawValue: "sensor.radiowaves.left.and.right")
+    static var sensorRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "sensor.radiowaves.left.and.right") }
 
     /// 􃆳
     /// Single Localization, 2 Layersets
@@ -3495,21 +3495,21 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sensorRadiowavesLeftAndRightFill = SFSymbol(rawValue: "sensor.radiowaves.left.and.right.fill")
+    static var sensorRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "sensor.radiowaves.left.and.right.fill") }
 
     /// 􃎢
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let serviceDog = SFSymbol(rawValue: "service.dog")
+    static var serviceDog: SFSymbol { .init(rawValue: "service.dog") }
 
     /// 􃎣
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let serviceDogFill = SFSymbol(rawValue: "service.dog.fill")
+    static var serviceDogFill: SFSymbol { .init(rawValue: "service.dog.fill") }
 
     /// 􃕉
     /// Single Localization, 2 Layersets
@@ -3517,7 +3517,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeArrowTriangleheadUpAndDown = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.and.down")
+    static var shoeArrowTriangleheadUpAndDown: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.and.down") }
 
     /// 􃕔
     /// Single Localization, 2 Layersets
@@ -3525,7 +3525,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeArrowTriangleheadUpAndDownFill = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.and.down.fill")
+    static var shoeArrowTriangleheadUpAndDownFill: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.and.down.fill") }
 
     /// 􁣫
     /// Single Localization, 2 Layersets
@@ -3533,7 +3533,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeArrowTriangleheadUpRight = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.right")
+    static var shoeArrowTriangleheadUpRight: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.right") }
 
     /// 􁣬
     /// Single Localization, 2 Layersets
@@ -3541,7 +3541,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeArrowTriangleheadUpRightCircle = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.right.circle")
+    static var shoeArrowTriangleheadUpRightCircle: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.right.circle") }
 
     /// 􁣭
     /// Single Localization, 3 Layersets
@@ -3550,7 +3550,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let shoeArrowTriangleheadUpRightCircleFill = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.right.circle.fill")
+    static var shoeArrowTriangleheadUpRightCircleFill: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.right.circle.fill") }
 
     /// 􁣮
     /// Single Localization, 2 Layersets
@@ -3558,7 +3558,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let shoeArrowTriangleheadUpRightFill = SFSymbol(rawValue: "shoe.arrow.trianglehead.up.right.fill")
+    static var shoeArrowTriangleheadUpRightFill: SFSymbol { .init(rawValue: "shoe.arrow.trianglehead.up.right.fill") }
 
     /// 􀫛
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3568,7 +3568,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Siri.
-    static let siri = SFSymbol(rawValue: "siri")
+    static var siri: SFSymbol { .init(rawValue: "siri") }
 
     /// 􃁣
     /// Single Localization, 2 Layersets
@@ -3576,7 +3576,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowCircleLefthalfFilled = SFSymbol(rawValue: "slider.horizontal.below.circle.lefthalf.filled")
+    static var sliderHorizontalBelowCircleLefthalfFilled: SFSymbol { .init(rawValue: "slider.horizontal.below.circle.lefthalf.filled") }
 
     /// 􃁤
     /// Single Localization, 2 Layersets
@@ -3584,7 +3584,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowCircleLefthalfFilledInverse = SFSymbol(rawValue: "slider.horizontal.below.circle.lefthalf.filled.inverse")
+    static var sliderHorizontalBelowCircleLefthalfFilledInverse: SFSymbol { .init(rawValue: "slider.horizontal.below.circle.lefthalf.filled.inverse") }
 
     /// 􃁥
     /// Single Localization, 2 Layersets
@@ -3592,7 +3592,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowCircleRighthalfFilled = SFSymbol(rawValue: "slider.horizontal.below.circle.righthalf.filled")
+    static var sliderHorizontalBelowCircleRighthalfFilled: SFSymbol { .init(rawValue: "slider.horizontal.below.circle.righthalf.filled") }
 
     /// 􃁦
     /// Single Localization, 2 Layersets
@@ -3600,7 +3600,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sliderHorizontalBelowCircleRighthalfFilledInverse = SFSymbol(rawValue: "slider.horizontal.below.circle.righthalf.filled.inverse")
+    static var sliderHorizontalBelowCircleRighthalfFilledInverse: SFSymbol { .init(rawValue: "slider.horizontal.below.circle.righthalf.filled.inverse") }
 
     /// 􃓿
     /// Single Localization, 2 Layersets
@@ -3608,7 +3608,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let sparkleTextClipboard = SFSymbol(rawValue: "sparkle.text.clipboard")
+    static var sparkleTextClipboard: SFSymbol { .init(rawValue: "sparkle.text.clipboard") }
 
     /// 􃔀
     /// Single Localization, 3 Layersets
@@ -3617,14 +3617,14 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let sparkleTextClipboardFill = SFSymbol(rawValue: "sparkle.text.clipboard.fill")
+    static var sparkleTextClipboardFill: SFSymbol { .init(rawValue: "sparkle.text.clipboard.fill") }
 
     /// 􃈰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let sparkles2 = SFSymbol(rawValue: "sparkles.2")
+    static var sparkles2: SFSymbol { .init(rawValue: "sparkles.2") }
 
     /// 􂊑
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3633,7 +3633,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCapture = SFSymbol(rawValue: "spatial.capture")
+    static var spatialCapture: SFSymbol { .init(rawValue: "spatial.capture") }
 
     /// 􂊒
     /// Single Localization, Single Layerset, ⚠️ Restricted
@@ -3642,7 +3642,7 @@ public extension SFSymbol {
     /// - Monochrome
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCaptureFill = SFSymbol(rawValue: "spatial.capture.fill")
+    static var spatialCaptureFill: SFSymbol { .init(rawValue: "spatial.capture.fill") }
 
     /// 􂊓
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3652,7 +3652,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCaptureOnHexagon = SFSymbol(rawValue: "spatial.capture.on.hexagon")
+    static var spatialCaptureOnHexagon: SFSymbol { .init(rawValue: "spatial.capture.on.hexagon") }
 
     /// 􂊔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3662,7 +3662,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCaptureOnHexagonFill = SFSymbol(rawValue: "spatial.capture.on.hexagon.fill")
+    static var spatialCaptureOnHexagonFill: SFSymbol { .init(rawValue: "spatial.capture.on.hexagon.fill") }
 
     /// 􂪙
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3672,7 +3672,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCaptureSlash = SFSymbol(rawValue: "spatial.capture.slash")
+    static var spatialCaptureSlash: SFSymbol { .init(rawValue: "spatial.capture.slash") }
 
     /// 􂪚
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3682,7 +3682,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
-    static let spatialCaptureSlashFill = SFSymbol(rawValue: "spatial.capture.slash.fill")
+    static var spatialCaptureSlashFill: SFSymbol { .init(rawValue: "spatial.capture.slash.fill") }
 
     /// 􃊺
     /// Single Localization, 3 Layersets
@@ -3691,7 +3691,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerTrianglebadgeExclamationmark = SFSymbol(rawValue: "speaker.trianglebadge.exclamationmark")
+    static var speakerTrianglebadgeExclamationmark: SFSymbol { .init(rawValue: "speaker.trianglebadge.exclamationmark") }
 
     /// 􃊻
     /// Single Localization, 3 Layersets
@@ -3700,7 +3700,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let speakerTrianglebadgeExclamationmarkFill = SFSymbol(rawValue: "speaker.trianglebadge.exclamationmark.fill")
+    static var speakerTrianglebadgeExclamationmarkFill: SFSymbol { .init(rawValue: "speaker.trianglebadge.exclamationmark.fill") }
 
     /// 􁟀
     /// Single Localization, 2 Layersets
@@ -3708,7 +3708,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let steeringwheelBadgeLock = SFSymbol(rawValue: "steeringwheel.badge.lock")
+    static var steeringwheelBadgeLock: SFSymbol { .init(rawValue: "steeringwheel.badge.lock") }
 
     /// 􃐋
     /// Single Localization, 2 Layersets
@@ -3716,14 +3716,14 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let strikethroughDouble = SFSymbol(rawValue: "strikethrough.double")
+    static var strikethroughDouble: SFSymbol { .init(rawValue: "strikethrough.double") }
 
     /// 􃑪
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let strokeLineDiagonal = SFSymbol(rawValue: "stroke.line.diagonal")
+    static var strokeLineDiagonal: SFSymbol { .init(rawValue: "stroke.line.diagonal") }
 
     /// 􃑫
     /// Single Localization, 2 Layersets
@@ -3731,7 +3731,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let strokeLineDiagonalSlash = SFSymbol(rawValue: "stroke.line.diagonal.slash")
+    static var strokeLineDiagonalSlash: SFSymbol { .init(rawValue: "stroke.line.diagonal.slash") }
 
     /// 􃁅
     /// Single Localization, 2 Layersets
@@ -3739,7 +3739,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseCircle = SFSymbol(rawValue: "suitcase.circle")
+    static var suitcaseCircle: SFSymbol { .init(rawValue: "suitcase.circle") }
 
     /// 􃁆
     /// Single Localization, 3 Layersets
@@ -3748,7 +3748,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suitcaseCircleFill = SFSymbol(rawValue: "suitcase.circle.fill")
+    static var suitcaseCircleFill: SFSymbol { .init(rawValue: "suitcase.circle.fill") }
 
     /// 􃌈
     /// Single Localization, 2 Layersets
@@ -3756,7 +3756,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndFilm = SFSymbol(rawValue: "suitcase.rolling.and.film")
+    static var suitcaseRollingAndFilm: SFSymbol { .init(rawValue: "suitcase.rolling.and.film") }
 
     /// 􃌌
     /// Single Localization, 2 Layersets
@@ -3764,7 +3764,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndFilmCircle = SFSymbol(rawValue: "suitcase.rolling.and.film.circle")
+    static var suitcaseRollingAndFilmCircle: SFSymbol { .init(rawValue: "suitcase.rolling.and.film.circle") }
 
     /// 􃌍
     /// Single Localization, 3 Layersets
@@ -3773,7 +3773,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suitcaseRollingAndFilmCircleFill = SFSymbol(rawValue: "suitcase.rolling.and.film.circle.fill")
+    static var suitcaseRollingAndFilmCircleFill: SFSymbol { .init(rawValue: "suitcase.rolling.and.film.circle.fill") }
 
     /// 􃌉
     /// Single Localization, 2 Layersets
@@ -3781,7 +3781,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndFilmFill = SFSymbol(rawValue: "suitcase.rolling.and.film.fill")
+    static var suitcaseRollingAndFilmFill: SFSymbol { .init(rawValue: "suitcase.rolling.and.film.fill") }
 
     /// 􃋕
     /// Single Localization, 2 Layersets
@@ -3789,7 +3789,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndSuitcase = SFSymbol(rawValue: "suitcase.rolling.and.suitcase")
+    static var suitcaseRollingAndSuitcase: SFSymbol { .init(rawValue: "suitcase.rolling.and.suitcase") }
 
     /// 􃋗
     /// Single Localization, 2 Layersets
@@ -3797,7 +3797,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndSuitcaseCircle = SFSymbol(rawValue: "suitcase.rolling.and.suitcase.circle")
+    static var suitcaseRollingAndSuitcaseCircle: SFSymbol { .init(rawValue: "suitcase.rolling.and.suitcase.circle") }
 
     /// 􃋘
     /// Single Localization, 3 Layersets
@@ -3806,7 +3806,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suitcaseRollingAndSuitcaseCircleFill = SFSymbol(rawValue: "suitcase.rolling.and.suitcase.circle.fill")
+    static var suitcaseRollingAndSuitcaseCircleFill: SFSymbol { .init(rawValue: "suitcase.rolling.and.suitcase.circle.fill") }
 
     /// 􃋖
     /// Single Localization, 2 Layersets
@@ -3814,7 +3814,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingAndSuitcaseFill = SFSymbol(rawValue: "suitcase.rolling.and.suitcase.fill")
+    static var suitcaseRollingAndSuitcaseFill: SFSymbol { .init(rawValue: "suitcase.rolling.and.suitcase.fill") }
 
     /// 􃋓
     /// Single Localization, 2 Layersets
@@ -3822,7 +3822,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let suitcaseRollingCircle = SFSymbol(rawValue: "suitcase.rolling.circle")
+    static var suitcaseRollingCircle: SFSymbol { .init(rawValue: "suitcase.rolling.circle") }
 
     /// 􃋔
     /// Single Localization, 3 Layersets
@@ -3831,21 +3831,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let suitcaseRollingCircleFill = SFSymbol(rawValue: "suitcase.rolling.circle.fill")
+    static var suitcaseRollingCircleFill: SFSymbol { .init(rawValue: "suitcase.rolling.circle.fill") }
 
     /// 􃐯
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textBelowFolder = SFSymbol(rawValue: "text.below.folder")
+    static var textBelowFolder: SFSymbol { .init(rawValue: "text.below.folder") }
 
     /// 􃐰
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let textBelowFolderFill = SFSymbol(rawValue: "text.below.folder.fill")
+    static var textBelowFolderFill: SFSymbol { .init(rawValue: "text.below.folder.fill") }
 
     /// 􂦔
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3855,7 +3855,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to the Apple Intelligence summary feature.
-    static let textLine2Summary = SFSymbol(rawValue: "text.line.2.summary")
+    static var textLine2Summary: SFSymbol { .init(rawValue: "text.line.2.summary") }
 
     /// 􃀭
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -3866,7 +3866,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to the Apple Intelligence summary feature.
-    static let textLine2SummaryBadgeXmark = SFSymbol(rawValue: "text.line.2.summary.badge.xmark")
+    static var textLine2SummaryBadgeXmark: SFSymbol { .init(rawValue: "text.line.2.summary.badge.xmark") }
 
     /// 􂤟
     /// Single Localization, 2 Layersets, ⚠️ Restricted
@@ -3876,7 +3876,7 @@ public extension SFSymbol {
     /// - Hierarchical
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to the Apple Intelligence summary feature.
-    static let textLine3Summary = SFSymbol(rawValue: "text.line.3.summary")
+    static var textLine3Summary: SFSymbol { .init(rawValue: "text.line.3.summary") }
 
     /// 􀓕
     /// Single Localization, 2 Layersets
@@ -3884,7 +3884,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textPadHeader = SFSymbol(rawValue: "text.pad.header")
+    static var textPadHeader: SFSymbol { .init(rawValue: "text.pad.header") }
 
     /// 􃀑
     /// 2 Localizations, 3 Layersets
@@ -3897,7 +3897,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let textPadHeaderBadgeClock = SymbolWith1Localization<Rtl>(rawValue: "text.pad.header.badge.clock")
+    static var textPadHeaderBadgeClock: SymbolWith1Localization<Rtl> { .init(rawValue: "text.pad.header.badge.clock") }
 
     /// 􀣙
     /// Single Localization, 3 Layersets
@@ -3906,7 +3906,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Multicolor
     /// - Hierarchical
-    static let textPadHeaderBadgePlus = SFSymbol(rawValue: "text.pad.header.badge.plus")
+    static var textPadHeaderBadgePlus: SFSymbol { .init(rawValue: "text.pad.header.badge.plus") }
 
     /// 􃐵
     /// Single Localization, 2 Layersets
@@ -3914,7 +3914,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textRectangle = SFSymbol(rawValue: "text.rectangle")
+    static var textRectangle: SFSymbol { .init(rawValue: "text.rectangle") }
 
     /// 􃐶
     /// Single Localization, 3 Layersets
@@ -3923,7 +3923,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let textRectangleFill = SFSymbol(rawValue: "text.rectangle.fill")
+    static var textRectangleFill: SFSymbol { .init(rawValue: "text.rectangle.fill") }
 
     /// 􃆭
     /// Single Localization, 2 Layersets
@@ -3931,7 +3931,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let textSquareFilled = SFSymbol(rawValue: "text.square.filled")
+    static var textSquareFilled: SFSymbol { .init(rawValue: "text.square.filled") }
 
     /// 􃒨
     /// Single Localization, 2 Layersets
@@ -3939,7 +3939,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerAndEllipsis = SFSymbol(rawValue: "thermometer.and.ellipsis")
+    static var thermometerAndEllipsis: SFSymbol { .init(rawValue: "thermometer.and.ellipsis") }
 
     /// 􃂠
     /// Single Localization, 2 Layersets
@@ -3947,7 +3947,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerGaugeOpen = SFSymbol(rawValue: "thermometer.gauge.open")
+    static var thermometerGaugeOpen: SFSymbol { .init(rawValue: "thermometer.gauge.open") }
 
     /// 􂿩
     /// Single Localization, 2 Layersets
@@ -3955,7 +3955,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let thermometerTirepressure = SFSymbol(rawValue: "thermometer.tirepressure")
+    static var thermometerTirepressure: SFSymbol { .init(rawValue: "thermometer.tirepressure") }
 
     /// 􃐍
     /// Single Localization, 3 Layersets
@@ -3964,7 +3964,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerVariableBadgeClock = SFSymbol(rawValue: "thermometer.variable.badge.clock")
+    static var thermometerVariableBadgeClock: SFSymbol { .init(rawValue: "thermometer.variable.badge.clock") }
 
     /// 􃐎
     /// Single Localization, 3 Layersets
@@ -3973,7 +3973,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let thermometerVariableBadgePlay = SFSymbol(rawValue: "thermometer.variable.badge.play")
+    static var thermometerVariableBadgePlay: SFSymbol { .init(rawValue: "thermometer.variable.badge.play") }
 
     /// 􃕙
     /// Single Localization, 2 Layersets
@@ -3981,7 +3981,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ticketCircle = SFSymbol(rawValue: "ticket.circle")
+    static var ticketCircle: SFSymbol { .init(rawValue: "ticket.circle") }
 
     /// 􃕚
     /// Single Localization, 3 Layersets
@@ -3990,7 +3990,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let ticketCircleFill = SFSymbol(rawValue: "ticket.circle.fill")
+    static var ticketCircleFill: SFSymbol { .init(rawValue: "ticket.circle.fill") }
 
     /// 􃀜
     /// Single Localization, 2 Layersets
@@ -3998,7 +3998,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let tramCard = SFSymbol(rawValue: "tram.card")
+    static var tramCard: SFSymbol { .init(rawValue: "tram.card") }
 
     /// 􃀝
     /// Single Localization, 3 Layersets
@@ -4007,7 +4007,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let tramCardFill = SFSymbol(rawValue: "tram.card.fill")
+    static var tramCardFill: SFSymbol { .init(rawValue: "tram.card.fill") }
 
     /// 􃃬
     /// Single Localization, 3 Layersets
@@ -4016,7 +4016,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trayBadge = SFSymbol(rawValue: "tray.badge")
+    static var trayBadge: SFSymbol { .init(rawValue: "tray.badge") }
 
     /// 􃃭
     /// Single Localization, 3 Layersets
@@ -4025,7 +4025,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let trayBadgeFill = SFSymbol(rawValue: "tray.badge.fill")
+    static var trayBadgeFill: SFSymbol { .init(rawValue: "tray.badge.fill") }
 
     /// 􃁍
     /// Single Localization, 2 Layersets
@@ -4033,7 +4033,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let umbrellaCircle = SFSymbol(rawValue: "umbrella.circle")
+    static var umbrellaCircle: SFSymbol { .init(rawValue: "umbrella.circle") }
 
     /// 􃁎
     /// Single Localization, 3 Layersets
@@ -4042,7 +4042,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let umbrellaCircleFill = SFSymbol(rawValue: "umbrella.circle.fill")
+    static var umbrellaCircleFill: SFSymbol { .init(rawValue: "umbrella.circle.fill") }
 
     /// 􃂛
     /// Single Localization, 2 Layersets
@@ -4050,7 +4050,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let umbrellaGaugeOpen = SFSymbol(rawValue: "umbrella.gauge.open")
+    static var umbrellaGaugeOpen: SFSymbol { .init(rawValue: "umbrella.gauge.open") }
 
     /// 􃁃
     /// Single Localization, 2 Layersets
@@ -4058,7 +4058,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let umbrellaSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "umbrella.sensor.tag.radiowaves.left.and.right")
+    static var umbrellaSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "umbrella.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃁄
     /// Single Localization, 3 Layersets
@@ -4067,7 +4067,7 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let umbrellaSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "umbrella.sensor.tag.radiowaves.left.and.right.fill")
+    static var umbrellaSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "umbrella.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃐊
     /// Single Localization, 2 Layersets
@@ -4075,7 +4075,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let underlineDouble = SFSymbol(rawValue: "underline.double")
+    static var underlineDouble: SFSymbol { .init(rawValue: "underline.double") }
 
     /// 􃅅
     /// Single Localization, 2 Layersets
@@ -4083,7 +4083,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let ventHeatWavesUpward = SFSymbol(rawValue: "vent.heat.waves.upward")
+    static var ventHeatWavesUpward: SFSymbol { .init(rawValue: "vent.heat.waves.upward") }
 
     /// 􃉬
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4094,7 +4094,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgeCheckmark = SFSymbol(rawValue: "vision.pro.badge.checkmark")
+    static var visionProBadgeCheckmark: SFSymbol { .init(rawValue: "vision.pro.badge.checkmark") }
 
     /// 􃉭
     /// Single Localization, 3 Layersets, ⚠️ Restricted
@@ -4105,7 +4105,7 @@ public extension SFSymbol {
     /// - Multicolor
     ///
     /// - Warning: ⚠️ This symbol may not be modified and may only be used to refer to Apple Vision Pro.
-    static let visionProBadgeCheckmarkFill = SFSymbol(rawValue: "vision.pro.badge.checkmark.fill")
+    static var visionProBadgeCheckmarkFill: SFSymbol { .init(rawValue: "vision.pro.badge.checkmark.fill") }
 
     /// 􃀵
     /// Single Localization, 2 Layersets
@@ -4113,7 +4113,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let walletSensorTagRadiowavesLeftAndRight = SFSymbol(rawValue: "wallet.sensor.tag.radiowaves.left.and.right")
+    static var walletSensorTagRadiowavesLeftAndRight: SFSymbol { .init(rawValue: "wallet.sensor.tag.radiowaves.left.and.right") }
 
     /// 􃀶
     /// Single Localization, 3 Layersets
@@ -4122,21 +4122,21 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let walletSensorTagRadiowavesLeftAndRightFill = SFSymbol(rawValue: "wallet.sensor.tag.radiowaves.left.and.right.fill")
+    static var walletSensorTagRadiowavesLeftAndRightFill: SFSymbol { .init(rawValue: "wallet.sensor.tag.radiowaves.left.and.right.fill") }
 
     /// 􃊸
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformLow = SFSymbol(rawValue: "waveform.low")
+    static var waveformLow: SFSymbol { .init(rawValue: "waveform.low") }
 
     /// 􃊹
     /// Single Localization, Single Layerset
     ///
     /// Layersets:
     /// - Monochrome
-    static let waveformMid = SFSymbol(rawValue: "waveform.mid")
+    static var waveformMid: SFSymbol { .init(rawValue: "waveform.mid") }
 
     /// 􃔷
     /// Single Localization, 2 Layersets
@@ -4144,7 +4144,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let wifiBadgeLock = SFSymbol(rawValue: "wifi.badge.lock")
+    static var wifiBadgeLock: SFSymbol { .init(rawValue: "wifi.badge.lock") }
 
     /// 􃋈
     /// Single Localization, 2 Layersets
@@ -4152,7 +4152,7 @@ public extension SFSymbol {
     /// Layersets:
     /// - Monochrome
     /// - Hierarchical
-    static let xmarkCircleBadgeAirplane = SFSymbol(rawValue: "xmark.circle.badge.airplane")
+    static var xmarkCircleBadgeAirplane: SFSymbol { .init(rawValue: "xmark.circle.badge.airplane") }
 
     /// 􃋉
     /// Single Localization, 3 Layersets
@@ -4161,5 +4161,5 @@ public extension SFSymbol {
     /// - Monochrome
     /// - Hierarchical
     /// - Multicolor
-    static let xmarkCircleBadgeAirplaneFill = SFSymbol(rawValue: "xmark.circle.badge.airplane.fill")
+    static var xmarkCircleBadgeAirplaneFill: SFSymbol { .init(rawValue: "xmark.circle.badge.airplane.fill") }
 }

--- a/SymbolsGenerator/Sources/SymbolsGenerator/main.swift
+++ b/SymbolsGenerator/Sources/SymbolsGenerator/main.swift
@@ -259,7 +259,7 @@ let symbolToCode: (Symbol) -> String = { symbol in
     }
     let variadics = structNames.isNotEmpty ? "<\(structNames.joined(separator: ", "))>" : ""
 
-    outputString += "\tstatic let \(symbol.propertyName) = \(nonVariadicClassName(localizationCount-1))\(variadics)(rawValue: \"\(symbol.name)\")"
+    outputString += "\tstatic var \(symbol.propertyName): \(nonVariadicClassName(localizationCount-1))\(variadics) { .init(rawValue: \"\(symbol.name)\") }"
 
     return outputString
 }


### PR DESCRIPTION
Switching the symbols to be `static var` computed properties instead of `static let`. Resulting in reducing the binary size by up to 50% (tested by archiving an empty mac app)

Discussion [here](https://forums.swift.org/t/static-let-vs-computed-properties-and-binary-size/83706)