### PR TITLE
Add Label initializer for LocalizedStringResource titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - Add symbol preview in Xcode Quick Help (By [Phineas Guo](https://github.com/guoPhineas))
+- Add `Label` initializer for `LocalizedStringResource` titles (By [Martin Wahlmüller](https://github.com/wallichinz))
 
 ### Changed
 

--- a/Sources/SFSafeSymbols/Initializers/SwiftUI/Label+SFSymbol.swift
+++ b/Sources/SFSafeSymbols/Initializers/SwiftUI/Label+SFSymbol.swift
@@ -21,6 +21,18 @@ public extension Label where Title == Text, Icon == Image {
     nonisolated init(_ title: some StringProtocol, systemSymbol: SFSymbol?) {
         self.init(title, systemImage: systemSymbol?.rawValue ?? "")
     }
+
+    /// Creates a label with a system symbol image and a title generated from a
+    /// localized string resource.
+    ///
+    /// - Parameter systemSymbol: The `SFSymbol` describing this image. No image is shown if nil is passed.
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
+    nonisolated init(_ title: LocalizedStringResource, systemSymbol: SFSymbol?) {
+        self.init(
+            title: { Text(title) },
+            icon: { Image(systemName: systemSymbol?.rawValue ?? "") }
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
## Add `Label` initializer for `LocalizedStringResource` + `SFSymbol`

Adds a new `Label` init overload that accepts a `LocalizedStringResource` title alongside an `SFSymbol`, complementing the existing `LocalizedStringKey` and `StringProtocol` overloads.

## Motivation

`LocalizedStringResource` is the modern Swift localization type introduced in iOS 16 / macOS 13 and is increasingly the preferred way to pass localized strings — especially when working with string catalogs (`.xcstrings`). Without this overload, callers had to wrap manually:

**Before - cumbersome**
```swift
Label(String(localized: .continueButtonTitle), systemSymbol: .checkmark)
```

**After - clean**
```swift
Label(.continueButtonTitle, systemSymbol: .checkmark)
```

## Changes

- Added `init(_ title: LocalizedStringResource, systemSymbol: SFSymbol?)` to `Label+SFSymbol.swift`
- Updated `CHANGELOG.md`

## Availability

`iOS 16.0+` · `macOS 13.0+` · `tvOS 16.0+` · `watchOS 9.0+` · `visionOS 1.0+`

## Implementation

```swift
/// Creates a label with a system symbol image and a title generated from a
/// localized string resource.
///
/// - Parameter systemSymbol: The `SFSymbol` describing this image.
///   No image is shown if nil is passed.
@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
nonisolated init(_ title: LocalizedStringResource, systemSymbol: SFSymbol?) {
    self.init(
        title: { Text(title) },
        icon: { Image(systemName: systemSymbol?.rawValue ?? "") }
    )
}
```
